### PR TITLE
events module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
+import { EventsModule } from './events/events.module';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { AuthModule } from './auth/auth.module';
     }),
     UsersModule,
     AuthModule,
+    EventsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/common/decorators/roles.decorator.ts
+++ b/src/common/decorators/roles.decorator.ts
@@ -1,0 +1,10 @@
+import { SetMetadata } from '@nestjs/common';
+
+export enum Role {
+  ORGANIZER = 'organizer',
+  ATTENDEE = 'attendee',
+  ADMIN = 'admin',
+}
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/common/guards/roles.guard.ts
+++ b/src/common/guards/roles.guard.ts
@@ -1,0 +1,27 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY, Role } from '../decorators/roles.decorator';
+import { AuthenticatedRequest } from '../interfaces/authenticated-request.interface';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!requiredRoles) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const { user } = request;
+
+    if (!user) return false;
+
+    return requiredRoles.some((role) => user.role === role);
+  }
+}

--- a/src/common/interfaces/authenticated-request.interface.ts
+++ b/src/common/interfaces/authenticated-request.interface.ts
@@ -1,0 +1,12 @@
+import { Request } from 'express';
+import { Role } from 'src/common/decorators/roles.decorator';
+
+export interface AuthenticatedUser {
+  id: string;
+  role: Role;
+  email?: string;
+}
+
+export interface AuthenticatedRequest extends Request {
+  user: AuthenticatedUser;
+}

--- a/src/events/dto/create-event.dto.ts
+++ b/src/events/dto/create-event.dto.ts
@@ -1,0 +1,43 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsDateString,
+  IsNumber,
+  IsEnum,
+  Min,
+} from 'class-validator';
+import { EventStatus } from '../entities/event.entity';
+
+export class CreateEventDto {
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsString()
+  @IsOptional()
+  location?: string;
+
+  @IsDateString()
+  startDate: string;
+
+  @IsDateString()
+  endDate: string;
+
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  ticketPrice?: number;
+
+  @IsString()
+  @IsOptional()
+  currency?: string;
+
+  @IsEnum(EventStatus)
+  @IsOptional()
+  status?: EventStatus;
+}

--- a/src/events/dto/list-events.dto.ts
+++ b/src/events/dto/list-events.dto.ts
@@ -1,0 +1,29 @@
+import { IsOptional, IsEnum, IsString, IsInt, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { EventStatus } from '../entities/event.entity';
+
+export class ListEventsDto {
+  @IsOptional()
+  @IsEnum(EventStatus)
+  status?: EventStatus;
+
+  @IsOptional()
+  @IsString()
+  organizerId?: string;
+
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number = 10;
+}

--- a/src/events/dto/update-event.dto.ts
+++ b/src/events/dto/update-event.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateEventDto } from './create-event.dto';
+
+export class UpdateEventDto extends PartialType(CreateEventDto) {}

--- a/src/events/entities/event.entity.ts
+++ b/src/events/entities/event.entity.ts
@@ -1,0 +1,57 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export enum EventStatus {
+  DRAFT = 'draft',
+  PUBLISHED = 'published',
+  COMPLETED = 'completed',
+  CANCELLED = 'cancelled',
+}
+
+@Entity('events')
+export class Event {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  title: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @Column({ nullable: true })
+  location: string;
+
+  @Column({ type: 'timestamp' })
+  startDate: Date;
+
+  @Column({ type: 'timestamp' })
+  endDate: Date;
+
+  @Column({ type: 'decimal', precision: 18, scale: 8, default: 0 })
+  ticketPrice: number;
+
+  @Column({ default: 'USD' })
+  currency: string;
+
+  @Column()
+  organizerId: string;
+
+  @Column({
+    type: 'enum',
+    enum: EventStatus,
+    default: EventStatus.DRAFT,
+  })
+  status: EventStatus;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/events/events.controller.spec.ts
+++ b/src/events/events.controller.spec.ts
@@ -1,0 +1,149 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { EventsController } from './events.controller';
+import { EventsService } from './events.service';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Event, EventStatus } from './entities/event.entity';
+import { Role } from '../common/decorators/roles.decorator';
+import { AuthenticatedRequest } from 'src/common/interfaces/authenticated-request.interface';
+
+const mockEvent: Event = {
+  id: 'uuid-1',
+  title: 'Test Event',
+  description: 'desc',
+  location: 'Lagos',
+  startDate: new Date('2025-06-01'),
+  endDate: new Date('2025-06-02'),
+  ticketPrice: 10,
+  currency: 'USD',
+  organizerId: 'organizer-1',
+  status: EventStatus.DRAFT,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const mockEventsService = {
+  createEvent: jest.fn(),
+  updateEvent: jest.fn(),
+  deleteEvent: jest.fn(),
+  getEventById: jest.fn(),
+  listEvents: jest.fn(),
+};
+
+function createMockExecutionContext(
+  userRole: string,
+  userId: string,
+): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () =>
+        ({
+          user: { id: userId, role: userRole as Role },
+        }) as Partial<AuthenticatedRequest>,
+      getResponse: jest.fn(),
+      getNext: jest.fn(),
+    }),
+    getHandler: () => EventsController.prototype.create,
+    getClass: () => EventsController,
+    getArgs: jest.fn(),
+    getArgByIndex: jest.fn(),
+    switchToRpc: jest.fn(),
+    switchToWs: jest.fn(),
+    getType: jest.fn(),
+  } as unknown as ExecutionContext;
+}
+
+describe('EventsController', () => {
+  let controller: EventsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [EventsController],
+      providers: [
+        { provide: EventsService, useValue: mockEventsService },
+        RolesGuard,
+        Reflector,
+      ],
+    }).compile();
+
+    controller = module.get<EventsController>(EventsController);
+    jest.clearAllMocks();
+  });
+
+  it('organizer can create event', async () => {
+    mockEventsService.createEvent.mockResolvedValue(mockEvent);
+
+    const req = {
+      user: { id: 'organizer-1', role: Role.ORGANIZER },
+    } as AuthenticatedRequest;
+
+    const result = await controller.create(
+      { title: 'Test Event', startDate: '2025-06-01', endDate: '2025-06-02' },
+      req,
+    );
+
+    expect(mockEventsService.createEvent).toHaveBeenCalledWith(
+      expect.any(Object),
+      'organizer-1',
+    );
+    expect(result).toEqual(mockEvent);
+  });
+
+  it('should get event by id', async () => {
+    mockEventsService.getEventById.mockResolvedValue(mockEvent);
+    const result = await controller.getById('uuid-1');
+    expect(result).toEqual(mockEvent);
+  });
+
+  it('should list events with pagination', async () => {
+    const paginated = {
+      data: [mockEvent],
+      total: 1,
+      page: 1,
+      limit: 10,
+      totalPages: 1,
+    };
+    mockEventsService.listEvents.mockResolvedValue(paginated);
+
+    const result = await controller.list({ page: 1, limit: 10 });
+    expect(result.data).toHaveLength(1);
+    expect(result.total).toBe(1);
+  });
+
+  it('should update event', async () => {
+    const updated = { ...mockEvent, title: 'Updated' };
+    mockEventsService.updateEvent.mockResolvedValue(updated);
+
+    const result = await controller.update('uuid-1', { title: 'Updated' });
+    expect(result.title).toBe('Updated');
+  });
+});
+
+describe('RolesGuard', () => {
+  it('should deny non-organizer role', () => {
+    const reflector = new Reflector();
+    const guard = new RolesGuard(reflector);
+
+    const mockContext = createMockExecutionContext('attendee', 'user-1');
+
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([Role.ORGANIZER]);
+
+    expect(guard.canActivate(mockContext)).toBe(false);
+  });
+
+  it('should allow organizer role', () => {
+    const reflector = new Reflector();
+    const guard = new RolesGuard(reflector);
+
+    const mockContext = createMockExecutionContext(Role.ORGANIZER, 'org-1');
+
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([Role.ORGANIZER]);
+
+    expect(guard.canActivate(mockContext)).toBe(true);
+  });
+});

--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -1,0 +1,57 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  Req,
+  ParseUUIDPipe,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { EventsService } from './events.service';
+import { CreateEventDto } from './dto/create-event.dto';
+import { UpdateEventDto } from './dto/update-event.dto';
+import { ListEventsDto } from './dto/list-events.dto';
+import { Roles, Role } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { AuthenticatedRequest } from '../common/interfaces/authenticated-request.interface';
+
+@Controller('events')
+@UseGuards(RolesGuard)
+export class EventsController {
+  constructor(private readonly eventsService: EventsService) {}
+
+  @Post()
+  @Roles(Role.ORGANIZER)
+  create(@Body() dto: CreateEventDto, @Req() req: AuthenticatedRequest) {
+    return this.eventsService.createEvent(dto, req.user.id);
+  }
+
+  @Get()
+  list(@Query() filterDto: ListEventsDto) {
+    return this.eventsService.listEvents(filterDto);
+  }
+
+  @Get(':id')
+  getById(@Param('id', ParseUUIDPipe) id: string) {
+    return this.eventsService.getEventById(id);
+  }
+
+  @Put(':id')
+  @Roles(Role.ORGANIZER)
+  update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: UpdateEventDto) {
+    return this.eventsService.updateEvent(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles(Role.ORGANIZER)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  delete(@Param('id', ParseUUIDPipe) id: string) {
+    return this.eventsService.deleteEvent(id);
+  }
+}

--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Event } from './entities/event.entity';
+import { EventsService } from './events.service';
+import { EventsController } from './events.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Event])],
+  controllers: [EventsController],
+  providers: [EventsService],
+  exports: [EventsService],
+})
+export class EventsModule {}

--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -1,0 +1,152 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { FindOptionsWhere, Repository } from 'typeorm';
+import { EventsService } from './events.service';
+import { Event, EventStatus } from './entities/event.entity';
+import { CreateEventDto } from './dto/create-event.dto';
+import { ListEventsDto } from './dto/list-events.dto';
+
+const mockEvent: Event = {
+  id: 'uuid-1',
+  title: 'Test Event',
+  description: 'A test event',
+  location: 'Lagos',
+  startDate: new Date('2025-06-01'),
+  endDate: new Date('2025-06-02'),
+  ticketPrice: 10,
+  currency: 'USD',
+  organizerId: 'organizer-1',
+  status: EventStatus.DRAFT,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const mockRepo = {
+  create: jest.fn(),
+  save: jest.fn(),
+  findOne: jest.fn(),
+  findAndCount: jest.fn(),
+  remove: jest.fn(),
+};
+
+describe('EventsService', () => {
+  let service: EventsService;
+  let repo: Repository<Event>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EventsService,
+        { provide: getRepositoryToken(Event), useValue: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get<EventsService>(EventsService);
+    repo = module.get<Repository<Event>>(getRepositoryToken(Event));
+    jest.clearAllMocks();
+  });
+
+  describe('createEvent', () => {
+    it('should create and return an event for an organizer', async () => {
+      const dto: CreateEventDto = {
+        title: 'Test Event',
+        startDate: '2025-06-01',
+        endDate: '2025-06-02',
+        ticketPrice: 10,
+      };
+      mockRepo.create.mockReturnValue(mockEvent);
+      mockRepo.save.mockResolvedValue(mockEvent);
+
+      const result = await service.createEvent(dto, 'organizer-1');
+
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ organizerId: 'organizer-1' }),
+      );
+      expect(result).toEqual(mockEvent);
+    });
+  });
+
+  describe('updateEvent', () => {
+    it('should update and persist changes', async () => {
+      mockRepo.findOne.mockResolvedValue({ ...mockEvent });
+      const updated = { ...mockEvent, title: 'Updated Title' };
+      mockRepo.save.mockResolvedValue(updated);
+
+      const result = await service.updateEvent('uuid-1', {
+        title: 'Updated Title',
+      });
+
+      expect(result.title).toBe('Updated Title');
+      expect(mockRepo.save).toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException if event does not exist', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.updateEvent('non-existent', { title: 'New' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('deleteEvent', () => {
+    it('should delete the event', async () => {
+      mockRepo.findOne.mockResolvedValue(mockEvent);
+      mockRepo.remove.mockResolvedValue(mockEvent);
+
+      await service.deleteEvent('uuid-1');
+
+      expect(mockRepo.remove).toHaveBeenCalledWith(mockEvent);
+    });
+  });
+
+  describe('getEventById', () => {
+    it('should return an event by id', async () => {
+      mockRepo.findOne.mockResolvedValue(mockEvent);
+      const result = await service.getEventById('uuid-1');
+      expect(result).toEqual(mockEvent);
+    });
+
+    it('should throw NotFoundException if not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      await expect(service.getEventById('bad-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('listEvents', () => {
+    it('should return paginated results', async () => {
+      mockRepo.findAndCount.mockResolvedValue([[mockEvent], 1]);
+
+      const dto: ListEventsDto = { page: 1, limit: 10 };
+      const result = await service.listEvents(dto);
+
+      expect(result.data).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(result.page).toBe(1);
+      expect(result.totalPages).toBe(1);
+    });
+
+    it('should filter by status', async () => {
+      mockRepo.findAndCount.mockResolvedValue([[], 0]);
+
+      const dto: ListEventsDto = {
+        status: EventStatus.PUBLISHED,
+        page: 1,
+        limit: 10,
+      };
+      await service.listEvents(dto);
+
+      expect(mockRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining<Parameters<typeof mockRepo.findAndCount>[0]>({
+          where: expect.objectContaining({
+            status: EventStatus.PUBLISHED,
+          }) as FindOptionsWhere<Event>,
+        }),
+      );
+    });
+  });
+});

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -1,0 +1,91 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Like, FindOptionsWhere } from 'typeorm';
+import { Event } from './entities/event.entity';
+import { CreateEventDto } from './dto/create-event.dto';
+import { UpdateEventDto } from './dto/update-event.dto';
+import { ListEventsDto } from './dto/list-events.dto';
+
+export interface PaginatedResult<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+@Injectable()
+export class EventsService {
+  constructor(
+    @InjectRepository(Event)
+    private readonly eventRepository: Repository<Event>,
+  ) {}
+
+  async createEvent(dto: CreateEventDto, organizerId: string): Promise<Event> {
+    const event = this.eventRepository.create({
+      ...dto,
+      startDate: new Date(dto.startDate),
+      endDate: new Date(dto.endDate),
+      organizerId,
+    });
+    return this.eventRepository.save(event);
+  }
+
+  async updateEvent(id: string, dto: UpdateEventDto): Promise<Event> {
+    const event = await this.getEventById(id);
+
+    const updates: Partial<Event> = {
+      ...(dto.title !== undefined && { title: dto.title }),
+      ...(dto.description !== undefined && { description: dto.description }),
+      ...(dto.location !== undefined && { location: dto.location }),
+      ...(dto.ticketPrice !== undefined && { ticketPrice: dto.ticketPrice }),
+      ...(dto.currency !== undefined && { currency: dto.currency }),
+      ...(dto.status !== undefined && { status: dto.status }),
+      ...(dto.startDate !== undefined && {
+        startDate: new Date(dto.startDate),
+      }),
+      ...(dto.endDate !== undefined && { endDate: new Date(dto.endDate) }),
+    };
+
+    Object.assign(event, updates);
+    return this.eventRepository.save(event);
+  }
+
+  async deleteEvent(id: string): Promise<void> {
+    const event = await this.getEventById(id);
+    await this.eventRepository.remove(event);
+  }
+
+  async getEventById(id: string): Promise<Event> {
+    const event = await this.eventRepository.findOne({ where: { id } });
+    if (!event) {
+      throw new NotFoundException(`Event with id "${id}" not found`);
+    }
+    return event;
+  }
+
+  async listEvents(filterDto: ListEventsDto): Promise<PaginatedResult<Event>> {
+    const { status, organizerId, search, page = 1, limit = 10 } = filterDto;
+
+    const where: FindOptionsWhere<Event> = {
+      ...(status && { status }),
+      ...(organizerId && { organizerId }),
+      ...(search && { title: Like(`%${search}%`) }),
+    };
+
+    const [data, total] = await this.eventRepository.findAndCount({
+      where,
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
Implements the core Event Management module (`src/events/`) — database-only CRUD with role-based access control. No blockchain logic.

## Changes
- `Event` entity with uuid, status enum (`draft | published | completed | cancelled`), and timestamps
- Service methods: `createEvent`, `updateEvent`, `deleteEvent`, `getEventById`, `listEvents` (paginated)
- REST controller with `RolesGuard` — only `ORGANIZER` role can create, update, or delete
- Typed `AuthenticatedRequest` interface — eliminates all `any` typings across guard, controller, and specs

## Type Safety
All `any` usages replaced with proper types:
- `getRequest<AuthenticatedRequest>()` in `RolesGuard`
- `FindOptionsWhere<Event>` for TypeORM query filters
- Explicit `Partial<Event>` spread in `updateEvent`

## Tests
- [x] Organizer can create event
- [x] Non-organizer is rejected
- [x] Update persists changes
- [x] List returns paginated result

closes #3 