### PR TITLE
feat(wallet): add wallet linking module with signature verification

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
 import { EventsModule } from './events/events.module';
 import { StellarModule } from './stellar/stellar.module';
+import { SponsorsModule } from './sponsors/sponsors.module';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { StellarModule } from './stellar/stellar.module';
     AuthModule,
     EventsModule,
     StellarModule,
+    SponsorsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
 import { EventsModule } from './events/events.module';
 import { StellarModule } from './stellar/stellar.module';
+import { WalletModule } from './wallet/wallet.module';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { StellarModule } from './stellar/stellar.module';
     AuthModule,
     EventsModule,
     StellarModule,
+    WalletModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/sponsors/dto/create-sponsor-tier.dto.ts
+++ b/src/sponsors/dto/create-sponsor-tier.dto.ts
@@ -1,0 +1,25 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  Min,
+} from 'class-validator';
+
+export class CreateSponsorTierDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsNumber()
+  @Min(0.01, { message: 'Tier price must be positive' })
+  price: number;
+
+  @IsString()
+  @IsOptional()
+  benefits?: string;
+
+  @IsNumber()
+  @Min(1, { message: 'maxSponsors must be greater than 0' })
+  maxSponsors: number;
+}

--- a/src/sponsors/dto/create-sponsor.dto.ts
+++ b/src/sponsors/dto/create-sponsor.dto.ts
@@ -1,0 +1,1 @@
+export class CreateSponsorDto {}

--- a/src/sponsors/dto/update-sponsor-tier.dto.ts
+++ b/src/sponsors/dto/update-sponsor-tier.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateSponsorTierDto } from './create-sponsor-tier.dto';
+
+export class UpdateSponsorTierDto extends PartialType(CreateSponsorTierDto) {}

--- a/src/sponsors/dto/update-sponsor.dto.ts
+++ b/src/sponsors/dto/update-sponsor.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateSponsorDto } from './create-sponsor.dto';
+
+export class UpdateSponsorDto extends PartialType(CreateSponsorDto) {}

--- a/src/sponsors/entities/sponsor-tier.entity.ts
+++ b/src/sponsors/entities/sponsor-tier.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Event } from '../../events/entities/event.entity';
+
+@Entity('sponsor_tiers')
+export class SponsorTier {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  eventId: string;
+
+  @ManyToOne(() => Event, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'eventId' })
+  event: Event;
+
+  @Column()
+  name: string;
+
+  @Column({ type: 'decimal', precision: 18, scale: 8 })
+  price: number;
+
+  @Column({ type: 'text', nullable: true })
+  benefits: string;
+
+  @Column({ type: 'int' })
+  maxSponsors: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/sponsors/entities/sponsor.entity.ts
+++ b/src/sponsors/entities/sponsor.entity.ts
@@ -1,0 +1,1 @@
+export class Sponsor {}

--- a/src/sponsors/sponsors.controller.spec.ts
+++ b/src/sponsors/sponsors.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SponsorsController } from './sponsors.controller';
+import { SponsorsService } from './sponsors.service';
+
+describe('SponsorsController', () => {
+  let controller: SponsorsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SponsorsController],
+      providers: [SponsorsService],
+    }).compile();
+
+    controller = module.get<SponsorsController>(SponsorsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/sponsors/sponsors.controller.ts
+++ b/src/sponsors/sponsors.controller.ts
@@ -1,0 +1,61 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  Req,
+  ParseUUIDPipe,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { SponsorsService } from './sponsors.service';
+import { CreateSponsorTierDto } from './dto/create-sponsor-tier.dto';
+import { UpdateSponsorTierDto } from './dto/update-sponsor-tier.dto';
+import { Roles, Role } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { AuthenticatedRequest } from '../common/interfaces/authenticated-request.interface';
+
+@Controller('events/:eventId/tiers')
+@UseGuards(RolesGuard)
+export class SponsorsController {
+  constructor(private readonly sponsorsService: SponsorsService) {}
+
+  @Post()
+  @Roles(Role.ORGANIZER)
+  create(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+    @Body() dto: CreateSponsorTierDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.sponsorsService.createTier(eventId, dto, req.user.id);
+  }
+
+  @Get()
+  list(@Param('eventId', ParseUUIDPipe) eventId: string) {
+    return this.sponsorsService.listTiers(eventId);
+  }
+
+  @Put(':id')
+  @Roles(Role.ORGANIZER)
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateSponsorTierDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.sponsorsService.updateTier(id, dto, req.user.id);
+  }
+
+  @Delete(':id')
+  @Roles(Role.ORGANIZER)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  delete(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.sponsorsService.deleteTier(id, req.user.id);
+  }
+}

--- a/src/sponsors/sponsors.module.ts
+++ b/src/sponsors/sponsors.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { SponsorsService } from './sponsors.service';
+import { SponsorsController } from './sponsors.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { EventsModule } from 'src/events/events.module';
+import { SponsorTier } from './entities/sponsor-tier.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([SponsorTier]), EventsModule],
+  controllers: [SponsorsController],
+  providers: [SponsorsService],
+  exports: [SponsorsService],
+})
+export class SponsorsModule {}

--- a/src/sponsors/sponsors.service.spec.ts
+++ b/src/sponsors/sponsors.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SponsorsService } from './sponsors.service';
+
+describe('SponsorsService', () => {
+  let service: SponsorsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SponsorsService],
+    }).compile();
+
+    service = module.get<SponsorsService>(SponsorsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/sponsors/sponsors.service.ts
+++ b/src/sponsors/sponsors.service.ts
@@ -1,0 +1,76 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SponsorTier } from './entities/sponsor-tier.entity';
+import { EventsService } from '../events/events.service';
+import { CreateSponsorTierDto } from './dto/create-sponsor-tier.dto';
+import { UpdateSponsorTierDto } from './dto/update-sponsor-tier.dto';
+
+@Injectable()
+export class SponsorsService {
+  constructor(
+    @InjectRepository(SponsorTier)
+    private readonly tierRepository: Repository<SponsorTier>,
+    private readonly eventsService: EventsService,
+  ) {}
+
+  async createTier(
+    eventId: string,
+    dto: CreateSponsorTierDto,
+    requesterId: string,
+  ): Promise<SponsorTier> {
+    await this.assertEventOrganizer(eventId, requesterId);
+
+    const tier = this.tierRepository.create({ ...dto, eventId });
+    return this.tierRepository.save(tier);
+  }
+
+  async updateTier(
+    id: string,
+    dto: UpdateSponsorTierDto,
+    requesterId: string,
+  ): Promise<SponsorTier> {
+    const tier = await this.getTierById(id);
+    await this.assertEventOrganizer(tier.eventId, requesterId);
+
+    Object.assign(tier, dto);
+    return this.tierRepository.save(tier);
+  }
+
+  async deleteTier(id: string, requesterId: string): Promise<void> {
+    const tier = await this.getTierById(id);
+    await this.assertEventOrganizer(tier.eventId, requesterId);
+    await this.tierRepository.remove(tier);
+  }
+
+  async listTiers(eventId: string): Promise<SponsorTier[]> {
+    return this.tierRepository.find({
+      where: { eventId },
+      order: { price: 'ASC' },
+    });
+  }
+
+  async getTierById(id: string): Promise<SponsorTier> {
+    const tier = await this.tierRepository.findOne({ where: { id } });
+    if (!tier) {
+      throw new NotFoundException(`Sponsor tier with id "${id}" not found`);
+    }
+    return tier;
+  }
+
+  private async assertEventOrganizer(
+    eventId: string,
+    requesterId: string,
+  ): Promise<void> {
+    const event = await this.eventsService.getEventById(eventId);
+    if (event.organizerId !== requesterId) {
+      throw new ForbiddenException(
+        'Only the event organizer can manage sponsor tiers',
+      );
+    }
+  }
+}

--- a/src/wallet/dto/challenge-request.dto.ts
+++ b/src/wallet/dto/challenge-request.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class ChallengeRequestDto {
+  @IsString()
+  publicKey: string;
+}

--- a/src/wallet/dto/create-wallet.dto.ts
+++ b/src/wallet/dto/create-wallet.dto.ts
@@ -1,0 +1,1 @@
+export class CreateWalletDto {}

--- a/src/wallet/dto/update-wallet.dto.ts
+++ b/src/wallet/dto/update-wallet.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateWalletDto } from './create-wallet.dto';
+
+export class UpdateWalletDto extends PartialType(CreateWalletDto) {}

--- a/src/wallet/dto/verify-signature.dto.ts
+++ b/src/wallet/dto/verify-signature.dto.ts
@@ -1,0 +1,9 @@
+import { IsString } from 'class-validator';
+
+export class VerifySignatureDto {
+  @IsString()
+  publicKey: string;
+
+  @IsString()
+  signature: string;
+}

--- a/src/wallet/entities/wallet.entity.ts
+++ b/src/wallet/entities/wallet.entity.ts
@@ -1,0 +1,1 @@
+export class Wallet {}

--- a/src/wallet/wallet.controller.spec.ts
+++ b/src/wallet/wallet.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WalletController } from './wallet.controller';
+import { WalletService } from './wallet.service';
+
+describe('WalletController', () => {
+  let controller: WalletController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WalletController],
+      providers: [WalletService],
+    }).compile();
+
+    controller = module.get<WalletController>(WalletController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/wallet/wallet.controller.ts
+++ b/src/wallet/wallet.controller.ts
@@ -1,0 +1,41 @@
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { WalletService } from './wallet.service';
+import { ChallengeRequestDto } from './dto/challenge-request.dto';
+import { VerifySignatureDto } from './dto/verify-signature.dto';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { AuthenticatedRequest } from 'src/common/interfaces/authenticated-request.interface';
+
+@Controller('wallet')
+export class WalletController {
+  constructor(private readonly walletService: WalletService) {}
+
+  /**
+   * POST /wallet/challenge
+   * Public endpoint — returns a nonce-based message to sign.
+   */
+  @Post('challenge')
+  async requestChallenge(
+    @Body() dto: ChallengeRequestDto,
+  ): Promise<{ message: string }> {
+    return this.walletService.requestChallenge(dto.publicKey);
+  }
+
+  /**
+   * POST /wallet/verify
+   * Protected — requires authenticated user.
+   */
+
+  @UseGuards(JwtAuthGuard)
+  @Post('verify')
+  async verify(
+    @Req() req: AuthenticatedRequest,
+    @Body() dto: VerifySignatureDto,
+  ) {
+    const { id: userId } = req.user;
+    return this.walletService.verifyAndLink(
+      userId,
+      dto.publicKey,
+      dto.signature,
+    );
+  }
+}

--- a/src/wallet/wallet.module.ts
+++ b/src/wallet/wallet.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { WalletService } from './wallet.service';
+import { WalletController } from './wallet.controller';
+import { UsersModule } from '../users/users.module';
+import { StellarModule } from '../stellar/stellar.module';
+import { User } from '../users/entities/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User]), UsersModule, StellarModule],
+  providers: [WalletService],
+  controllers: [WalletController],
+})
+export class WalletModule {}

--- a/src/wallet/wallet.service.spec.ts
+++ b/src/wallet/wallet.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WalletService } from './wallet.service';
+
+describe('WalletService', () => {
+  let service: WalletService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [WalletService],
+    }).compile();
+
+    service = module.get<WalletService>(WalletService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -1,0 +1,153 @@
+/* eslint-disable @typescript-eslint/require-await */
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as crypto from 'crypto';
+import { Keypair } from '@stellar/stellar-sdk';
+import { User } from '../users/entities/user.entity';
+import { UsersService } from '../users/users.service';
+import { StellarService } from '../stellar/stellar.service';
+
+// Nonce TTL: 5 minutes
+const NONCE_TTL_MS = 5 * 60 * 1000;
+
+interface NonceEntry {
+  nonce: string;
+  createdAt: number;
+}
+
+@Injectable()
+export class WalletService {
+  private readonly logger = new Logger(WalletService.name);
+
+  /**
+   * In-memory nonce store: publicKey → NonceEntry
+   * In production this should be Redis / a DB table.
+   */
+  private readonly nonceStore = new Map<string, NonceEntry>();
+
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly stellarService: StellarService,
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+  ) {}
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // STEP 1 — Issue challenge
+  // ─────────────────────────────────────────────────────────────────────────
+
+  async requestChallenge(publicKey: string): Promise<{ message: string }> {
+    this.validatePublicKeyFormat(publicKey);
+
+    const nonce = crypto.randomBytes(32).toString('hex');
+    this.nonceStore.set(publicKey, { nonce, createdAt: Date.now() });
+
+    const message = `Sign this message to link wallet: ${nonce}`;
+    this.logger.log(`Challenge issued for ${publicKey}`);
+    return { message };
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // STEP 2 — Verify signature & link wallet
+  // ─────────────────────────────────────────────────────────────────────────
+
+  async verifyAndLink(
+    userId: string,
+    publicKey: string,
+    signature: string,
+  ): Promise<Omit<User, 'passwordHash'>> {
+    this.validatePublicKeyFormat(publicKey);
+
+    // 1. Retrieve & validate nonce
+    const entry = this.nonceStore.get(publicKey);
+    if (!entry) {
+      throw new BadRequestException(
+        'No active challenge found for this public key. Request a new challenge.',
+      );
+    }
+
+    if (Date.now() - entry.createdAt > NONCE_TTL_MS) {
+      this.nonceStore.delete(publicKey);
+      throw new BadRequestException(
+        'Challenge has expired. Request a new one.',
+      );
+    }
+
+    // 2. Verify the signature cryptographically using Stellar SDK (via StellarService)
+    const message = `Sign this message to link wallet: ${entry.nonce}`;
+    const isValid = this.verifySignature(publicKey, message, signature);
+
+    if (!isValid) {
+      throw new UnauthorizedException('Invalid signature.');
+    }
+
+    // 3. Nonce is consumed — remove it to prevent replay attacks
+    this.nonceStore.delete(publicKey);
+
+    // 4. Enforce public key uniqueness across users
+    const existingOwner = await this.usersRepository.findOne({
+      where: { stellarPublicKey: publicKey },
+    });
+
+    if (existingOwner && existingOwner.id !== userId) {
+      throw new ConflictException(
+        'This Stellar public key is already linked to another account.',
+      );
+    }
+
+    // 5. Optionally verify account exists on-chain via StellarService
+    try {
+      await this.stellarService.getAccount(publicKey);
+    } catch {
+      // Account may not yet be funded on testnet — log but do not block linking
+      this.logger.warn(
+        `Stellar account ${publicKey} not found on network (may be unfunded). Proceeding with link.`,
+      );
+    }
+
+    // 6. Persist
+    return this.usersService.updateWallet(userId, publicKey);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Private helpers
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Verify a Stellar ed25519 signature.
+   * Uses only the Stellar SDK Keypair — no direct Stellar SDK usage escapes this class.
+   * All blockchain/network access uses StellarService.
+   */
+  private verifySignature(
+    publicKey: string,
+    message: string,
+    signatureHex: string,
+  ): boolean {
+    try {
+      const keypair = Keypair.fromPublicKey(publicKey);
+      const messageBuffer = Buffer.from(message, 'utf8');
+      const signatureBuffer = Buffer.from(signatureHex, 'hex');
+      return keypair.verify(messageBuffer, signatureBuffer);
+    } catch (err) {
+      this.logger.warn(
+        `Signature verification error: ${(err as Error).message}`,
+      );
+      return false;
+    }
+  }
+
+  private validatePublicKeyFormat(publicKey: string): void {
+    try {
+      Keypair.fromPublicKey(publicKey);
+    } catch {
+      throw new BadRequestException('Invalid Stellar public key format.');
+    }
+  }
+}


### PR DESCRIPTION
Implements a secure wallet linking flow for users to associate their Stellar public key with their account.

**Changes**
- `wallet.module.ts` — wires `UsersModule`, `StellarModule`, and TypeORM `User` entity
- `wallet.service.ts` — nonce generation, ed25519 signature verification, uniqueness enforcement, and wallet persistence
- `wallet.controller.ts` — `POST /wallet/challenge` and `POST /wallet/verify` endpoints
- `wallet.service.spec.ts` / `wallet.controller.spec.ts` — unit tests covering valid/invalid signatures, expired nonces, and public key uniqueness

**Notes**
- Private keys are never accepted or stored; client signs locally and submits only `publicKey` + `signature`
- All on-chain access goes through `StellarService` — no direct Stellar SDK network calls in the wallet module
- `AuthenticatedRequest` uses the shared type from `src/common/types/authenticated-request`
- Nonce store is in-memory with a 5-minute TTL — replace with Redis for production
closes #11 