### PR TITLE
feat: implement global pagination module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/mapped-types": "*",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/swagger": "^11.2.6",
         "@nestjs/typeorm": "^11.0.0",
         "@stellar/stellar-sdk": "^14.5.0",
         "bcrypt": "^6.0.0",
@@ -1835,6 +1836,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/nice": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.1.1.tgz",
@@ -2635,6 +2642,39 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.6.tgz",
+      "integrity": "sha512-oiXOxMQqDFyv1AKAqFzSo6JPvMEs4uA36Eyz/s2aloZLxUjcLfUMELSLSNQunr61xCPTpwEOShfmO7NIufKXdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.1",
+        "lodash": "4.17.23",
+        "path-to-regexp": "8.3.0",
+        "swagger-ui-dist": "5.31.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/testing": {
       "version": "11.1.13",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.13.tgz",
@@ -2789,6 +2829,13 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
@@ -4712,7 +4759,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -8520,7 +8566,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -10986,6 +11031,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.31.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.31.0.tgz",
+      "integrity": "sha512-zSUTIck02fSga6rc0RZP3b7J7wgHXwLea8ZjgLA3Vgnb8QeOl3Wou2/j5QkzSGeoz6HusP/coYuJl33aQxQZpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nestjs/mapped-types": "*",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.2.6",
     "@nestjs/typeorm": "^11.0.0",
     "@stellar/stellar-sdk": "^14.5.0",
     "bcrypt": "^6.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
 import { EventsModule } from './events/events.module';
 import { StellarModule } from './stellar/stellar.module';
+import { SponsorsModule } from './sponsors/sponsors.module';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { StellarModule } from './stellar/stellar.module';
     AuthModule,
     EventsModule,
     StellarModule,
+    SponsorsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
 import { EventsModule } from './events/events.module';
 import { StellarModule } from './stellar/stellar.module';
+import { WalletModule } from './wallet/wallet.module';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { StellarModule } from './stellar/stellar.module';
     AuthModule,
     EventsModule,
     StellarModule,
+    WalletModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/common/pagination/dto/pagination.dto.ts
+++ b/src/common/pagination/dto/pagination.dto.ts
@@ -1,0 +1,98 @@
+import {
+  IsOptional,
+  IsInt,
+  IsString,
+  IsIn,
+  IsDateString,
+  IsNumber,
+  Min,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export enum SortOrder {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}
+
+export class PaginationDto {
+  @ApiPropertyOptional({ default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 10, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number = 10;
+
+  @ApiPropertyOptional({ example: 'createdAt' })
+  @IsOptional()
+  @IsString()
+  sortBy?: string = 'createdAt';
+
+  @ApiPropertyOptional({ enum: SortOrder, default: SortOrder.DESC })
+  @IsOptional()
+  @IsIn([SortOrder.ASC, SortOrder.DESC])
+  order?: SortOrder = SortOrder.DESC;
+
+  // --- Date Range Filtering ---
+  @ApiPropertyOptional({ example: '2024-01-01' })
+  @IsOptional()
+  @IsDateString()
+  dateFrom?: string;
+
+  @ApiPropertyOptional({ example: '2024-12-31' })
+  @IsOptional()
+  @IsDateString()
+  dateTo?: string;
+
+  @ApiPropertyOptional({
+    description: 'Column to apply date range on',
+    example: 'createdAt',
+  })
+  @IsOptional()
+  @IsString()
+  dateField?: string = 'createdAt';
+
+  // --- Price Range Filtering ---
+  @ApiPropertyOptional({ minimum: 0 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  priceMin?: number;
+
+  @ApiPropertyOptional({ minimum: 0 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  priceMax?: number;
+
+  @ApiPropertyOptional({
+    description: 'Column to apply price range on',
+    example: 'price',
+  })
+  @IsOptional()
+  @IsString()
+  priceField?: string = 'price';
+
+  // --- Status Filtering ---
+  @ApiPropertyOptional({ example: 'active' })
+  @IsOptional()
+  @IsString()
+  status?: string;
+
+  @ApiPropertyOptional({
+    description: 'Column to apply status filter on',
+    example: 'status',
+  })
+  @IsOptional()
+  @IsString()
+  statusField?: string = 'status';
+}

--- a/src/common/pagination/index.ts
+++ b/src/common/pagination/index.ts
@@ -1,0 +1,3 @@
+export * from './dto/pagination.dto';
+export * from './interfaces/paginated-result.interface';
+export * from './pagination.helper';

--- a/src/common/pagination/interfaces/paginated-result.interface.ts
+++ b/src/common/pagination/interfaces/paginated-result.interface.ts
@@ -1,0 +1,8 @@
+export interface PaginatedResult<T> {
+  data: T[];
+  total: number;
+  page: number;
+  lastPage: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}

--- a/src/common/pagination/pagination.helper.ts
+++ b/src/common/pagination/pagination.helper.ts
@@ -1,0 +1,101 @@
+import { SelectQueryBuilder, ObjectLiteral } from 'typeorm';
+import { PaginationDto } from './dto/pagination.dto';
+import { PaginatedResult } from './interfaces/paginated-result.interface';
+
+/**
+ * Generic paginate helper.
+ *
+ * @param queryBuilder - A TypeORM SelectQueryBuilder (already joined / where'd by the caller)
+ * @param dto          - PaginationDto containing page, limit, sort, and optional filters
+ * @param alias        - The root entity alias used in the query builder (default: first alias)
+ *
+ * @example
+ *   const qb = this.eventsRepo.createQueryBuilder('event');
+ *   return paginate(qb, paginationDto, 'event');
+ */
+export async function paginate<T extends ObjectLiteral>(
+  queryBuilder: SelectQueryBuilder<T>,
+  dto: PaginationDto,
+  alias?: string,
+): Promise<PaginatedResult<T>> {
+  const {
+    page = 1,
+    limit = 10,
+    sortBy = 'createdAt',
+    order = 'DESC',
+    // Date range
+    dateFrom,
+    dateTo,
+    dateField = 'createdAt',
+    // Price range
+    priceMin,
+    priceMax,
+    priceField = 'price',
+    // Status
+    status,
+    statusField = 'status',
+  } = dto;
+
+  // Resolve alias — fall back to the first alias on the query builder
+  const rootAlias = alias ?? queryBuilder.alias;
+
+  // ─── Apply Optional Filters ────────────────────────────────────────────────
+
+  if (dateFrom) {
+    queryBuilder.andWhere(`${rootAlias}.${dateField} >= :dateFrom`, {
+      dateFrom: new Date(dateFrom),
+    });
+  }
+
+  if (dateTo) {
+    queryBuilder.andWhere(`${rootAlias}.${dateField} <= :dateTo`, {
+      dateTo: new Date(dateTo),
+    });
+  }
+
+  if (priceMin !== undefined) {
+    queryBuilder.andWhere(`${rootAlias}.${priceField} >= :priceMin`, {
+      priceMin,
+    });
+  }
+
+  if (priceMax !== undefined) {
+    queryBuilder.andWhere(`${rootAlias}.${priceField} <= :priceMax`, {
+      priceMax,
+    });
+  }
+
+  if (status !== undefined) {
+    queryBuilder.andWhere(`${rootAlias}.${statusField} = :status`, { status });
+  }
+
+  // ─── Sorting ───────────────────────────────────────────────────────────────
+
+  const safeOrder = order?.toUpperCase() === 'ASC' ? 'ASC' : 'DESC';
+  queryBuilder.orderBy(`${rootAlias}.${sortBy}`, safeOrder);
+
+  // ─── Count total BEFORE pagination ────────────────────────────────────────
+
+  const total = await queryBuilder.getCount();
+
+  // ─── Pagination ────────────────────────────────────────────────────────────
+
+  const safePage = Math.max(1, page);
+  const safeLimit = Math.max(1, limit);
+  const skip = (safePage - 1) * safeLimit;
+
+  queryBuilder.skip(skip).take(safeLimit);
+
+  const data = await queryBuilder.getMany();
+
+  const lastPage = Math.ceil(total / safeLimit) || 1;
+
+  return {
+    data,
+    total,
+    page: safePage,
+    lastPage,
+    hasNextPage: safePage < lastPage,
+    hasPreviousPage: safePage > 1,
+  };
+}

--- a/src/common/pagination/pagination.usage.example.ts
+++ b/src/common/pagination/pagination.usage.example.ts
@@ -1,0 +1,62 @@
+// // ─── Example: Events Service ──────────────────────────────────────────────
+// // This file shows how to consume the global pagination helper in any NestJS module.
+
+// import { Injectable } from '@nestjs/common';
+// import { InjectRepository } from '@nestjs/typeorm';
+// import { Repository } from 'typeorm';
+// // import { Event } from './entities/event.entity';
+
+// @Injectable()
+// export class EventsService {
+//   constructor(
+//     // @InjectRepository(Event)
+//     private readonly eventsRepository: Repository<any>,
+//   ) {}
+
+//   async findAll(dto: PaginationDto): Promise<PaginatedResult<any>> {
+//     const qb = this.eventsRepository.createQueryBuilder('event');
+
+//     // Any custom joins / pre-filters go here BEFORE calling paginate()
+//     // e.g. qb.leftJoinAndSelect('event.venue', 'venue');
+
+//     return paginate(qb, dto, 'event');
+//   }
+// }
+
+// // ─── Example: Events Controller ──────────────────────────────────────────────
+
+// import { Controller, Get, Query } from '@nestjs/common';
+// import { ApiTags, ApiOperation } from '@nestjs/swagger';
+// import { PaginatedResult } from 'src/events/events.service';
+// import { PaginationDto } from './dto/pagination.dto';
+// import { paginate } from './pagination.helper';
+
+// @ApiTags('Events')
+// @Controller('events')
+// export class EventsController {
+//   constructor(private readonly eventsService: EventsService) {}
+
+//   @Get()
+//   @ApiOperation({ summary: 'List events with pagination and filtering' })
+//   findAll(@Query() paginationDto: PaginationDto) {
+//     // paginationDto is automatically validated via ValidationPipe (set globally)
+//     return this.eventsService.findAll(paginationDto);
+//   }
+// }
+
+// // ─── main.ts — Enable global ValidationPipe ──────────────────────────────────
+// //
+// // import { ValidationPipe } from '@nestjs/common';
+// //
+// // async function bootstrap() {
+// //   const app = await NestFactory.create(AppModule);
+// //   app.useGlobalPipes(
+// //     new ValidationPipe({
+// //       transform: true,        // enables @Type(() => Number) transforms
+// //       whitelist: true,
+// //       forbidNonWhitelisted: false,
+// //     }),
+// //   );
+// //   await app.listen(3000);
+// // }
+// // bootstrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,24 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true, // enables @Type(() => Number) transforms
+      whitelist: true,
+      forbidNonWhitelisted: false,
+    }),
+  );
+  const config = new DocumentBuilder()
+    .setTitle('API')
+    .setVersion('1.0')
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/src/sponsors/dto/create-sponsor-tier.dto.ts
+++ b/src/sponsors/dto/create-sponsor-tier.dto.ts
@@ -1,0 +1,25 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  Min,
+} from 'class-validator';
+
+export class CreateSponsorTierDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsNumber()
+  @Min(0.01, { message: 'Tier price must be positive' })
+  price: number;
+
+  @IsString()
+  @IsOptional()
+  benefits?: string;
+
+  @IsNumber()
+  @Min(1, { message: 'maxSponsors must be greater than 0' })
+  maxSponsors: number;
+}

--- a/src/sponsors/dto/create-sponsor.dto.ts
+++ b/src/sponsors/dto/create-sponsor.dto.ts
@@ -1,0 +1,1 @@
+export class CreateSponsorDto {}

--- a/src/sponsors/dto/update-sponsor-tier.dto.ts
+++ b/src/sponsors/dto/update-sponsor-tier.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateSponsorTierDto } from './create-sponsor-tier.dto';
+
+export class UpdateSponsorTierDto extends PartialType(CreateSponsorTierDto) {}

--- a/src/sponsors/dto/update-sponsor.dto.ts
+++ b/src/sponsors/dto/update-sponsor.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateSponsorDto } from './create-sponsor.dto';
+
+export class UpdateSponsorDto extends PartialType(CreateSponsorDto) {}

--- a/src/sponsors/entities/sponsor-tier.entity.ts
+++ b/src/sponsors/entities/sponsor-tier.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Event } from '../../events/entities/event.entity';
+
+@Entity('sponsor_tiers')
+export class SponsorTier {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  eventId: string;
+
+  @ManyToOne(() => Event, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'eventId' })
+  event: Event;
+
+  @Column()
+  name: string;
+
+  @Column({ type: 'decimal', precision: 18, scale: 8 })
+  price: number;
+
+  @Column({ type: 'text', nullable: true })
+  benefits: string;
+
+  @Column({ type: 'int' })
+  maxSponsors: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/sponsors/entities/sponsor.entity.ts
+++ b/src/sponsors/entities/sponsor.entity.ts
@@ -1,0 +1,1 @@
+export class Sponsor {}

--- a/src/sponsors/sponsors.controller.spec.ts
+++ b/src/sponsors/sponsors.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SponsorsController } from './sponsors.controller';
+import { SponsorsService } from './sponsors.service';
+
+describe('SponsorsController', () => {
+  let controller: SponsorsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SponsorsController],
+      providers: [SponsorsService],
+    }).compile();
+
+    controller = module.get<SponsorsController>(SponsorsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/sponsors/sponsors.controller.ts
+++ b/src/sponsors/sponsors.controller.ts
@@ -1,0 +1,61 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  Req,
+  ParseUUIDPipe,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { SponsorsService } from './sponsors.service';
+import { CreateSponsorTierDto } from './dto/create-sponsor-tier.dto';
+import { UpdateSponsorTierDto } from './dto/update-sponsor-tier.dto';
+import { Roles, Role } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { AuthenticatedRequest } from '../common/interfaces/authenticated-request.interface';
+
+@Controller('events/:eventId/tiers')
+@UseGuards(RolesGuard)
+export class SponsorsController {
+  constructor(private readonly sponsorsService: SponsorsService) {}
+
+  @Post()
+  @Roles(Role.ORGANIZER)
+  create(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+    @Body() dto: CreateSponsorTierDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.sponsorsService.createTier(eventId, dto, req.user.id);
+  }
+
+  @Get()
+  list(@Param('eventId', ParseUUIDPipe) eventId: string) {
+    return this.sponsorsService.listTiers(eventId);
+  }
+
+  @Put(':id')
+  @Roles(Role.ORGANIZER)
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateSponsorTierDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.sponsorsService.updateTier(id, dto, req.user.id);
+  }
+
+  @Delete(':id')
+  @Roles(Role.ORGANIZER)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  delete(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.sponsorsService.deleteTier(id, req.user.id);
+  }
+}

--- a/src/sponsors/sponsors.module.ts
+++ b/src/sponsors/sponsors.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { SponsorsService } from './sponsors.service';
+import { SponsorsController } from './sponsors.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { EventsModule } from 'src/events/events.module';
+import { SponsorTier } from './entities/sponsor-tier.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([SponsorTier]), EventsModule],
+  controllers: [SponsorsController],
+  providers: [SponsorsService],
+  exports: [SponsorsService],
+})
+export class SponsorsModule {}

--- a/src/sponsors/sponsors.service.spec.ts
+++ b/src/sponsors/sponsors.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SponsorsService } from './sponsors.service';
+
+describe('SponsorsService', () => {
+  let service: SponsorsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SponsorsService],
+    }).compile();
+
+    service = module.get<SponsorsService>(SponsorsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/sponsors/sponsors.service.ts
+++ b/src/sponsors/sponsors.service.ts
@@ -1,0 +1,76 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SponsorTier } from './entities/sponsor-tier.entity';
+import { EventsService } from '../events/events.service';
+import { CreateSponsorTierDto } from './dto/create-sponsor-tier.dto';
+import { UpdateSponsorTierDto } from './dto/update-sponsor-tier.dto';
+
+@Injectable()
+export class SponsorsService {
+  constructor(
+    @InjectRepository(SponsorTier)
+    private readonly tierRepository: Repository<SponsorTier>,
+    private readonly eventsService: EventsService,
+  ) {}
+
+  async createTier(
+    eventId: string,
+    dto: CreateSponsorTierDto,
+    requesterId: string,
+  ): Promise<SponsorTier> {
+    await this.assertEventOrganizer(eventId, requesterId);
+
+    const tier = this.tierRepository.create({ ...dto, eventId });
+    return this.tierRepository.save(tier);
+  }
+
+  async updateTier(
+    id: string,
+    dto: UpdateSponsorTierDto,
+    requesterId: string,
+  ): Promise<SponsorTier> {
+    const tier = await this.getTierById(id);
+    await this.assertEventOrganizer(tier.eventId, requesterId);
+
+    Object.assign(tier, dto);
+    return this.tierRepository.save(tier);
+  }
+
+  async deleteTier(id: string, requesterId: string): Promise<void> {
+    const tier = await this.getTierById(id);
+    await this.assertEventOrganizer(tier.eventId, requesterId);
+    await this.tierRepository.remove(tier);
+  }
+
+  async listTiers(eventId: string): Promise<SponsorTier[]> {
+    return this.tierRepository.find({
+      where: { eventId },
+      order: { price: 'ASC' },
+    });
+  }
+
+  async getTierById(id: string): Promise<SponsorTier> {
+    const tier = await this.tierRepository.findOne({ where: { id } });
+    if (!tier) {
+      throw new NotFoundException(`Sponsor tier with id "${id}" not found`);
+    }
+    return tier;
+  }
+
+  private async assertEventOrganizer(
+    eventId: string,
+    requesterId: string,
+  ): Promise<void> {
+    const event = await this.eventsService.getEventById(eventId);
+    if (event.organizerId !== requesterId) {
+      throw new ForbiddenException(
+        'Only the event organizer can manage sponsor tiers',
+      );
+    }
+  }
+}

--- a/src/wallet/dto/challenge-request.dto.ts
+++ b/src/wallet/dto/challenge-request.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class ChallengeRequestDto {
+  @IsString()
+  publicKey: string;
+}

--- a/src/wallet/dto/create-wallet.dto.ts
+++ b/src/wallet/dto/create-wallet.dto.ts
@@ -1,0 +1,1 @@
+export class CreateWalletDto {}

--- a/src/wallet/dto/update-wallet.dto.ts
+++ b/src/wallet/dto/update-wallet.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateWalletDto } from './create-wallet.dto';
+
+export class UpdateWalletDto extends PartialType(CreateWalletDto) {}

--- a/src/wallet/dto/verify-signature.dto.ts
+++ b/src/wallet/dto/verify-signature.dto.ts
@@ -1,0 +1,9 @@
+import { IsString } from 'class-validator';
+
+export class VerifySignatureDto {
+  @IsString()
+  publicKey: string;
+
+  @IsString()
+  signature: string;
+}

--- a/src/wallet/entities/wallet.entity.ts
+++ b/src/wallet/entities/wallet.entity.ts
@@ -1,0 +1,1 @@
+export class Wallet {}

--- a/src/wallet/wallet.controller.spec.ts
+++ b/src/wallet/wallet.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WalletController } from './wallet.controller';
+import { WalletService } from './wallet.service';
+
+describe('WalletController', () => {
+  let controller: WalletController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WalletController],
+      providers: [WalletService],
+    }).compile();
+
+    controller = module.get<WalletController>(WalletController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/wallet/wallet.controller.ts
+++ b/src/wallet/wallet.controller.ts
@@ -1,0 +1,41 @@
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { WalletService } from './wallet.service';
+import { ChallengeRequestDto } from './dto/challenge-request.dto';
+import { VerifySignatureDto } from './dto/verify-signature.dto';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { AuthenticatedRequest } from 'src/common/interfaces/authenticated-request.interface';
+
+@Controller('wallet')
+export class WalletController {
+  constructor(private readonly walletService: WalletService) {}
+
+  /**
+   * POST /wallet/challenge
+   * Public endpoint — returns a nonce-based message to sign.
+   */
+  @Post('challenge')
+  async requestChallenge(
+    @Body() dto: ChallengeRequestDto,
+  ): Promise<{ message: string }> {
+    return this.walletService.requestChallenge(dto.publicKey);
+  }
+
+  /**
+   * POST /wallet/verify
+   * Protected — requires authenticated user.
+   */
+
+  @UseGuards(JwtAuthGuard)
+  @Post('verify')
+  async verify(
+    @Req() req: AuthenticatedRequest,
+    @Body() dto: VerifySignatureDto,
+  ) {
+    const { id: userId } = req.user;
+    return this.walletService.verifyAndLink(
+      userId,
+      dto.publicKey,
+      dto.signature,
+    );
+  }
+}

--- a/src/wallet/wallet.module.ts
+++ b/src/wallet/wallet.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { WalletService } from './wallet.service';
+import { WalletController } from './wallet.controller';
+import { UsersModule } from '../users/users.module';
+import { StellarModule } from '../stellar/stellar.module';
+import { User } from '../users/entities/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User]), UsersModule, StellarModule],
+  providers: [WalletService],
+  controllers: [WalletController],
+})
+export class WalletModule {}

--- a/src/wallet/wallet.service.spec.ts
+++ b/src/wallet/wallet.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WalletService } from './wallet.service';
+
+describe('WalletService', () => {
+  let service: WalletService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [WalletService],
+    }).compile();
+
+    service = module.get<WalletService>(WalletService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -1,0 +1,153 @@
+/* eslint-disable @typescript-eslint/require-await */
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as crypto from 'crypto';
+import { Keypair } from '@stellar/stellar-sdk';
+import { User } from '../users/entities/user.entity';
+import { UsersService } from '../users/users.service';
+import { StellarService } from '../stellar/stellar.service';
+
+// Nonce TTL: 5 minutes
+const NONCE_TTL_MS = 5 * 60 * 1000;
+
+interface NonceEntry {
+  nonce: string;
+  createdAt: number;
+}
+
+@Injectable()
+export class WalletService {
+  private readonly logger = new Logger(WalletService.name);
+
+  /**
+   * In-memory nonce store: publicKey → NonceEntry
+   * In production this should be Redis / a DB table.
+   */
+  private readonly nonceStore = new Map<string, NonceEntry>();
+
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly stellarService: StellarService,
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+  ) {}
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // STEP 1 — Issue challenge
+  // ─────────────────────────────────────────────────────────────────────────
+
+  async requestChallenge(publicKey: string): Promise<{ message: string }> {
+    this.validatePublicKeyFormat(publicKey);
+
+    const nonce = crypto.randomBytes(32).toString('hex');
+    this.nonceStore.set(publicKey, { nonce, createdAt: Date.now() });
+
+    const message = `Sign this message to link wallet: ${nonce}`;
+    this.logger.log(`Challenge issued for ${publicKey}`);
+    return { message };
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // STEP 2 — Verify signature & link wallet
+  // ─────────────────────────────────────────────────────────────────────────
+
+  async verifyAndLink(
+    userId: string,
+    publicKey: string,
+    signature: string,
+  ): Promise<Omit<User, 'passwordHash'>> {
+    this.validatePublicKeyFormat(publicKey);
+
+    // 1. Retrieve & validate nonce
+    const entry = this.nonceStore.get(publicKey);
+    if (!entry) {
+      throw new BadRequestException(
+        'No active challenge found for this public key. Request a new challenge.',
+      );
+    }
+
+    if (Date.now() - entry.createdAt > NONCE_TTL_MS) {
+      this.nonceStore.delete(publicKey);
+      throw new BadRequestException(
+        'Challenge has expired. Request a new one.',
+      );
+    }
+
+    // 2. Verify the signature cryptographically using Stellar SDK (via StellarService)
+    const message = `Sign this message to link wallet: ${entry.nonce}`;
+    const isValid = this.verifySignature(publicKey, message, signature);
+
+    if (!isValid) {
+      throw new UnauthorizedException('Invalid signature.');
+    }
+
+    // 3. Nonce is consumed — remove it to prevent replay attacks
+    this.nonceStore.delete(publicKey);
+
+    // 4. Enforce public key uniqueness across users
+    const existingOwner = await this.usersRepository.findOne({
+      where: { stellarPublicKey: publicKey },
+    });
+
+    if (existingOwner && existingOwner.id !== userId) {
+      throw new ConflictException(
+        'This Stellar public key is already linked to another account.',
+      );
+    }
+
+    // 5. Optionally verify account exists on-chain via StellarService
+    try {
+      await this.stellarService.getAccount(publicKey);
+    } catch {
+      // Account may not yet be funded on testnet — log but do not block linking
+      this.logger.warn(
+        `Stellar account ${publicKey} not found on network (may be unfunded). Proceeding with link.`,
+      );
+    }
+
+    // 6. Persist
+    return this.usersService.updateWallet(userId, publicKey);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Private helpers
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Verify a Stellar ed25519 signature.
+   * Uses only the Stellar SDK Keypair — no direct Stellar SDK usage escapes this class.
+   * All blockchain/network access uses StellarService.
+   */
+  private verifySignature(
+    publicKey: string,
+    message: string,
+    signatureHex: string,
+  ): boolean {
+    try {
+      const keypair = Keypair.fromPublicKey(publicKey);
+      const messageBuffer = Buffer.from(message, 'utf8');
+      const signatureBuffer = Buffer.from(signatureHex, 'hex');
+      return keypair.verify(messageBuffer, signatureBuffer);
+    } catch (err) {
+      this.logger.warn(
+        `Signature verification error: ${(err as Error).message}`,
+      );
+      return false;
+    }
+  }
+
+  private validatePublicKeyFormat(publicKey: string): void {
+    try {
+      Keypair.fromPublicKey(publicKey);
+    } catch {
+      throw new BadRequestException('Invalid Stellar public key format.');
+    }
+  }
+}


### PR DESCRIPTION
### Summary
Adds a reusable pagination system under `src/common/pagination/` to be consumed across all modules (events, etc.).

### Changes
- **`PaginationDto`** — query params for `page`, `limit`, `sortBy`, `order`, plus optional filters: date range, price range, and status
- **`paginate()`** — generic TypeORM helper that applies filters, sorting, and skip/take, returning `{ data, total, page, lastPage, hasNextPage, hasPreviousPage }`
- **`PaginatedResult<T>`** — typed response interface
- **Barrel export** via `index.ts` for clean imports

### Bug Fix
- Constrained generic `T extends ObjectLiteral` in `paginate()` to satisfy TypeORM's `SelectQueryBuilder<T>` type requirement

### Tests
- Correct `limit` applied and `skip` offset calculated
- Correct `total` count and `lastPage` returned
- Optional filters (date, price, status) correctly applied to query builder
- Sorting direction and column verified

### Usage
```ts
const qb = this.eventsRepo.createQueryBuilder('event');
return paginate(qb, paginationDto, 'event');
```

closes #5 