### PR TITLE
feat(escrow): add per-event escrow account management with encrypted key storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,8 @@ JWT_EXPIRES_IN = 7d
 
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+
+# Using an existing funded account's public key
+# Generating a new keypair on Stellar Laboratory for testnet, or via the Stellar SDK: Keypair.random().publicKey()
+# Stellar escrow wallet public key — receives ticket payments
+ESCROW_WALLET_PUBLIC_KEY=GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,5 @@ STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 # Generating a new keypair on Stellar Laboratory for testnet, or via the Stellar SDK: Keypair.random().publicKey()
 # Stellar escrow wallet public key — receives ticket payments
 ESCROW_WALLET_PUBLIC_KEY=GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+ESCROW_ENCRYPTION_SECRET=a-random-32-char-secret-string!!
+ESCROW_FUNDER_SECRET=SFUNDER_STELLAR_SECRET_KEY_HERE

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { StellarModule } from './stellar/stellar.module';
 import { SponsorsModule } from './sponsors/sponsors.module';
 import { WalletModule } from './wallet/wallet.module';
 import { PaymentsModule } from './payments/payments.module';
+import { AuditModule } from './audit/audit.module';
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { PaymentsModule } from './payments/payments.module';
     SponsorsModule,
     WalletModule,
     PaymentsModule,
+    AuditModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { EventsModule } from './events/events.module';
 import { StellarModule } from './stellar/stellar.module';
 import { SponsorsModule } from './sponsors/sponsors.module';
 import { WalletModule } from './wallet/wallet.module';
+import { PaymentsModule } from './payments/payments.module';
 
 @Module({
   imports: [
@@ -37,6 +38,7 @@ import { WalletModule } from './wallet/wallet.module';
     StellarModule,
     SponsorsModule,
     WalletModule,
+    PaymentsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/audit/audit.controller.spec.ts
+++ b/src/audit/audit.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuditController } from './audit.controller';
+import { AuditService } from './audit.service';
+
+describe('AuditController', () => {
+  let controller: AuditController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuditController],
+      providers: [AuditService],
+    }).compile();
+
+    controller = module.get<AuditController>(AuditController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/audit/audit.controller.ts
+++ b/src/audit/audit.controller.ts
@@ -1,0 +1,34 @@
+// import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+// import { AuditService } from './audit.service';
+// import { CreateAuditDto } from './dto/create-audit.dto';
+// import { UpdateAuditDto } from './dto/update-audit.dto';
+
+// @Controller('audit')
+// export class AuditController {
+//   constructor(private readonly auditService: AuditService) {}
+
+//   @Post()
+//   create(@Body() createAuditDto: CreateAuditDto) {
+//     return this.auditService.create(createAuditDto);
+//   }
+
+//   @Get()
+//   findAll() {
+//     return this.auditService.findAll();
+//   }
+
+//   @Get(':id')
+//   findOne(@Param('id') id: string) {
+//     return this.auditService.findOne(+id);
+//   }
+
+//   @Patch(':id')
+//   update(@Param('id') id: string, @Body() updateAuditDto: UpdateAuditDto) {
+//     return this.auditService.update(+id, updateAuditDto);
+//   }
+
+//   @Delete(':id')
+//   remove(@Param('id') id: string) {
+//     return this.auditService.remove(+id);
+//   }
+// }

--- a/src/audit/audit.module.ts
+++ b/src/audit/audit.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuditLog } from './entities/audit-log.entity';
+import { AuditService } from './audit.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([AuditLog])],
+  providers: [AuditService],
+  exports: [AuditService],
+})
+export class AuditModule {}

--- a/src/audit/audit.service.spec.ts
+++ b/src/audit/audit.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuditService } from './audit.service';
+
+describe('AuditService', () => {
+  let service: AuditService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AuditService],
+    }).compile();
+
+    service = module.get<AuditService>(AuditService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/audit/audit.service.ts
+++ b/src/audit/audit.service.ts
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/require-await */
+import { Injectable, Logger } from '@nestjs/common';
+
+export interface AuditLogEntry {
+  action: string;
+  userId: string;
+  resourceId: string;
+  meta?: Record<string, unknown>;
+}
+
+/**
+ * AuditService — persist audit trail entries.
+ * Replace the logger-only implementation with your real persistence layer
+ * (e.g. a TypeORM AuditLog entity) when ready.
+ */
+@Injectable()
+export class AuditService {
+  private readonly logger = new Logger(AuditService.name);
+
+  async log(entry: AuditLogEntry): Promise<void> {
+    this.logger.log(
+      `[AUDIT] action=${entry.action} userId=${entry.userId} resourceId=${entry.resourceId} meta=${JSON.stringify(entry.meta ?? {})}`,
+    );
+  }
+}

--- a/src/audit/dto/create-audit.dto.ts
+++ b/src/audit/dto/create-audit.dto.ts
@@ -1,0 +1,1 @@
+export class CreateAuditDto {}

--- a/src/audit/dto/update-audit.dto.ts
+++ b/src/audit/dto/update-audit.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateAuditDto } from './create-audit.dto';
+
+export class UpdateAuditDto extends PartialType(CreateAuditDto) {}

--- a/src/audit/entities/audit-log.entity.ts
+++ b/src/audit/entities/audit-log.entity.ts
@@ -1,0 +1,50 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum AuditAction {
+  // Payments
+  PAYMENT_INTENT_CREATED = 'PAYMENT_INTENT_CREATED',
+  PAYMENT_CONFIRMED = 'PAYMENT_CONFIRMED',
+  PAYMENT_FAILED = 'PAYMENT_FAILED',
+
+  // Refunds
+  REFUND_REQUESTED = 'REFUND_REQUESTED',
+  REFUND_APPROVED = 'REFUND_APPROVED',
+  REFUND_REJECTED = 'REFUND_REJECTED',
+
+  // Escrow
+  ESCROW_RELEASED = 'ESCROW_RELEASED',
+
+  // Events
+  EVENT_PUBLISHED = 'EVENT_PUBLISHED',
+  EVENT_CANCELLED = 'EVENT_CANCELLED',
+  EVENT_COMPLETED = 'EVENT_COMPLETED',
+}
+
+@Entity('audit_logs')
+export class AuditLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index()
+  @Column()
+  action: string;
+
+  @Index()
+  @Column()
+  userId: string;
+
+  @Column({ nullable: true, type: 'varchar' })
+  resourceId: string | null;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata: Record<string, unknown> | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/audit/entities/audit.entity.ts
+++ b/src/audit/entities/audit.entity.ts
@@ -1,0 +1,1 @@
+export class Audit {}

--- a/src/events/entities/event.entity.ts
+++ b/src/events/entities/event.entity.ts
@@ -49,6 +49,21 @@ export class Event {
   })
   status: EventStatus;
 
+  /**
+   * Stellar public key of this event's dedicated escrow account.
+   * Populated when the event is published.
+   */
+  @Column({ nullable: true, type: 'varchar' })
+  escrowPublicKey: string | null;
+
+  /**
+   * AES-256-GCM encrypted escrow secret key.
+   * Format: "<iv_hex>:<authTag_hex>:<ciphertext_hex>"
+   * NEVER expose this field in API responses.
+   */
+  @Column({ nullable: true, type: 'text', select: false })
+  escrowSecretEncrypted: string | null;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/payments/dto/confirm-payment.dto.ts
+++ b/src/payments/dto/confirm-payment.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class ConfirmPaymentDto {
+  @IsString()
+  @IsNotEmpty()
+  transactionHash: string;
+}

--- a/src/payments/dto/create-payment-intent.dto.ts
+++ b/src/payments/dto/create-payment-intent.dto.ts
@@ -1,0 +1,6 @@
+import { IsUUID } from 'class-validator';
+
+export class CreatePaymentIntentDto {
+  @IsUUID()
+  eventId: string;
+}

--- a/src/payments/dto/create-payment.dto.ts
+++ b/src/payments/dto/create-payment.dto.ts
@@ -1,0 +1,1 @@
+export class CreatePaymentDto {}

--- a/src/payments/dto/update-payment.dto.ts
+++ b/src/payments/dto/update-payment.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreatePaymentDto } from './create-payment.dto';
+
+export class UpdatePaymentDto extends PartialType(CreatePaymentDto) {}

--- a/src/payments/entities/payment.entity.ts
+++ b/src/payments/entities/payment.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+} from 'typeorm';
+
+export enum PaymentStatus {
+  PENDING = 'pending',
+  CONFIRMED = 'confirmed',
+  FAILED = 'failed',
+}
+
+@Entity('payments')
+export class Payment {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  eventId: string;
+
+  @Column()
+  userId: string;
+
+  @Column({ type: 'decimal', precision: 18, scale: 7 })
+  amount: number;
+
+  @Column({ default: 'XLM' })
+  currency: string;
+
+  @Column({ nullable: true, type: 'varchar' })
+  transactionHash: string | null;
+
+  @Column({
+    type: 'enum',
+    enum: PaymentStatus,
+    default: PaymentStatus.PENDING,
+  })
+  status: PaymentStatus;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/payments/escrow.module.ts
+++ b/src/payments/escrow.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuditModule } from 'src/audit/audit.module';
+import { Event } from 'src/events/entities/event.entity';
+import { StellarModule } from 'src/stellar';
+import { EscrowService } from './services/escrow.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Event]), StellarModule, AuditModule],
+  providers: [EscrowService],
+  exports: [EscrowService],
+})
+export class EscrowModule {}

--- a/src/payments/payments.controller.spec.ts
+++ b/src/payments/payments.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PaymentsController } from './payments.controller';
+import { PaymentsService } from './payments.service';
+
+describe('PaymentsController', () => {
+  let controller: PaymentsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PaymentsController],
+      providers: [PaymentsService],
+    }).compile();
+
+    controller = module.get<PaymentsController>(PaymentsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/payments/payments.controller.ts
+++ b/src/payments/payments.controller.ts
@@ -1,0 +1,35 @@
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { PaymentsService } from './payments.service';
+import { CreatePaymentIntentDto } from './dto/create-payment-intent.dto';
+import { ConfirmPaymentDto } from './dto/confirm-payment.dto';
+import { AuthenticatedRequest } from 'src/common/interfaces/authenticated-request.interface';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+
+@Controller('payments')
+@UseGuards(JwtAuthGuard)
+export class PaymentsController {
+  constructor(private readonly paymentsService: PaymentsService) {}
+
+  /**
+   * POST /payments/intent
+   * Authenticated user requests a payment intent for an event.
+   * Returns the escrow wallet address, amount, and a memo to include in the tx.
+   */
+  @Post('intent')
+  createIntent(
+    @Body() dto: CreatePaymentIntentDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.paymentsService.createPaymentIntent(dto.eventId, req.user.id);
+  }
+
+  /**
+   * POST /payments/confirm
+   * Submit the on-chain transaction hash after broadcasting the payment.
+   * PaymentsService verifies destination, asset type, and amount via StellarService.
+   */
+  @Post('confirm')
+  confirmPayment(@Body() dto: ConfirmPaymentDto) {
+    return this.paymentsService.confirmPayment(dto.transactionHash);
+  }
+}

--- a/src/payments/payments.module.ts
+++ b/src/payments/payments.module.ts
@@ -6,6 +6,7 @@ import { PaymentsController } from './payments.controller';
 import { AuditModule } from '../audit/audit.module';
 import { EventsModule } from '../events/events.module';
 import { StellarModule } from '../stellar/stellar.module';
+import { EscrowModule } from './escrow.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { StellarModule } from '../stellar/stellar.module';
     EventsModule,
     StellarModule,
     AuditModule,
+    EscrowModule,
   ],
   providers: [PaymentsService],
   controllers: [PaymentsController],

--- a/src/payments/payments.module.ts
+++ b/src/payments/payments.module.ts
@@ -3,13 +3,18 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Payment } from './entities/payment.entity';
 import { PaymentsService } from './payments.service';
 import { PaymentsController } from './payments.controller';
+import { AuditModule } from '../audit/audit.module';
 import { EventsModule } from '../events/events.module';
 import { StellarModule } from '../stellar/stellar.module';
-import { AuditService } from 'src/audit/audit.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Payment]), EventsModule, StellarModule],
-  providers: [PaymentsService, AuditService],
+  imports: [
+    TypeOrmModule.forFeature([Payment]),
+    EventsModule,
+    StellarModule,
+    AuditModule,
+  ],
+  providers: [PaymentsService],
   controllers: [PaymentsController],
   exports: [PaymentsService],
 })

--- a/src/payments/payments.module.ts
+++ b/src/payments/payments.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Payment } from './entities/payment.entity';
+import { PaymentsService } from './payments.service';
+import { PaymentsController } from './payments.controller';
+import { EventsModule } from '../events/events.module';
+import { StellarModule } from '../stellar/stellar.module';
+import { AuditService } from 'src/audit/audit.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Payment]), EventsModule, StellarModule],
+  providers: [PaymentsService, AuditService],
+  controllers: [PaymentsController],
+  exports: [PaymentsService],
+})
+export class PaymentsModule {}

--- a/src/payments/payments.service.spec.ts
+++ b/src/payments/payments.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PaymentsService } from './payments.service';
+
+describe('PaymentsService', () => {
+  let service: PaymentsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PaymentsService],
+    }).compile();
+
+    service = module.get<PaymentsService>(PaymentsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/payments/payments.service.ts
+++ b/src/payments/payments.service.ts
@@ -1,0 +1,287 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { Payment, PaymentStatus } from './entities/payment.entity';
+import { EventsService } from '../events/events.service';
+import { StellarService } from '../stellar/stellar.service';
+import { AuditService } from '../audit/audit.service';
+import { EventStatus } from '../events/entities/event.entity';
+
+/** Supported on-chain asset codes */
+const SUPPORTED_ASSETS = ['XLM', 'USDC'] as const;
+type SupportedAsset = (typeof SUPPORTED_ASSETS)[number];
+
+export interface PaymentIntent {
+  paymentId: string;
+  escrowWallet: string;
+  amount: number;
+  currency: string;
+  memo: string;
+}
+
+@Injectable()
+export class PaymentsService {
+  private readonly logger = new Logger(PaymentsService.name);
+  private readonly escrowWallet: string;
+
+  constructor(
+    @InjectRepository(Payment)
+    private readonly paymentsRepository: Repository<Payment>,
+    private readonly eventsService: EventsService,
+    private readonly stellarService: StellarService,
+    private readonly auditService: AuditService,
+    private readonly configService: ConfigService,
+  ) {
+    this.escrowWallet =
+      this.configService.get<string>('ESCROW_WALLET_PUBLIC_KEY') ?? '';
+
+    if (!this.escrowWallet) {
+      this.logger.warn(
+        'ESCROW_WALLET_PUBLIC_KEY is not set. Payment confirmation will fail.',
+      );
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // STEP 1 — Create payment intent
+  // ─────────────────────────────────────────────────────────────────────────
+
+  async createPaymentIntent(
+    eventId: string,
+    userId: string,
+  ): Promise<PaymentIntent> {
+    // 1. Validate event exists
+    const event = await this.eventsService.getEventById(eventId);
+
+    // 2. Validate event is published
+    if (event.status !== EventStatus.PUBLISHED) {
+      throw new BadRequestException(
+        `Event "${event.title}" is not available for purchase (status: ${event.status}).`,
+      );
+    }
+
+    // 3. Validate asset type
+    const currency = event.currency.toUpperCase() as SupportedAsset;
+    if (!SUPPORTED_ASSETS.includes(currency)) {
+      throw new BadRequestException(
+        `Unsupported asset "${event.currency}". Supported assets: ${SUPPORTED_ASSETS.join(', ')}.`,
+      );
+    }
+
+    // 4. Persist a pending payment record
+    const payment = this.paymentsRepository.create({
+      eventId,
+      userId,
+      amount: event.ticketPrice,
+      currency,
+      status: PaymentStatus.PENDING,
+    });
+    const saved = await this.paymentsRepository.save(payment);
+
+    await this.auditService.log({
+      action: 'PAYMENT_INTENT_CREATED',
+      userId,
+      resourceId: saved.id,
+      meta: { eventId, amount: saved.amount, currency: saved.currency },
+    });
+
+    this.logger.log(
+      `Payment intent created: paymentId=${saved.id} event=${eventId} user=${userId}`,
+    );
+
+    return {
+      paymentId: saved.id,
+      escrowWallet: this.escrowWallet,
+      amount: event.ticketPrice,
+      currency,
+      memo: saved.id, // caller sets this as the Stellar memo so we can correlate
+    };
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // STEP 2 — Confirm payment
+  // ─────────────────────────────────────────────────────────────────────────
+
+  async confirmPayment(transactionHash: string): Promise<Payment> {
+    // 1. Fetch the on-chain transaction via StellarService (no direct Horizon calls)
+    let txRecord: Awaited<ReturnType<StellarService['getTransaction']>>;
+    try {
+      txRecord = await this.stellarService.getTransaction(transactionHash);
+    } catch {
+      throw new BadRequestException(
+        `Transaction "${transactionHash}" not found on the Stellar network.`,
+      );
+    }
+
+    // 2. Find pending payment — match via memo (set to paymentId by the client)
+    // TransactionRecord.memo is typed as string | undefined in the Stellar SDK
+    const memoValue: string | undefined =
+      typeof txRecord.memo === 'string' ? txRecord.memo : undefined;
+
+    if (!memoValue) {
+      throw new BadRequestException(
+        'Transaction is missing a memo. Cannot correlate with a payment intent.',
+      );
+    }
+
+    const payment = await this.paymentsRepository.findOne({
+      where: { id: memoValue, status: PaymentStatus.PENDING },
+    });
+
+    if (!payment) {
+      throw new NotFoundException(
+        `No pending payment found for memo "${memoValue}".`,
+      );
+    }
+
+    // 3. Fetch operations to validate destination & amount
+    // StellarService.getTransaction returns the transaction record.
+    // We resolve operations via the _links on the record.
+    const ops = await this.resolvePaymentOperations(txRecord);
+
+    if (ops.length === 0) {
+      await this.markFailed(
+        payment,
+        'No payment operations found in transaction.',
+      );
+      throw new BadRequestException(
+        'Transaction contains no payment operations.',
+      );
+    }
+
+    // 4. Find the operation that matches our escrow wallet
+    const matchingOp = ops.find((op) => op.to === this.escrowWallet);
+
+    if (!matchingOp) {
+      await this.markFailed(
+        payment,
+        `Incorrect destination. Expected ${this.escrowWallet}.`,
+      );
+      throw new BadRequestException(
+        `Payment destination does not match the escrow wallet.`,
+      );
+    }
+
+    // 5. Validate asset type
+    const assetCode: string =
+      matchingOp.asset_type === 'native'
+        ? 'XLM'
+        : (matchingOp.asset_code ?? '');
+
+    if (assetCode.toUpperCase() !== payment.currency.toUpperCase()) {
+      await this.markFailed(
+        payment,
+        `Wrong asset. Expected ${payment.currency}, got ${assetCode}.`,
+      );
+      throw new BadRequestException(
+        `Incorrect asset type. Expected ${payment.currency}, received ${assetCode}.`,
+      );
+    }
+
+    if (!SUPPORTED_ASSETS.includes(assetCode.toUpperCase() as SupportedAsset)) {
+      await this.markFailed(payment, `Unsupported asset "${assetCode}".`);
+      throw new BadRequestException(`Asset "${assetCode}" is not supported.`);
+    }
+
+    // 6. Validate amount (Stellar amounts are strings with 7 decimal places)
+    const onChainAmount = parseFloat(matchingOp.amount);
+    const expectedAmount = parseFloat(String(payment.amount));
+
+    if (Math.abs(onChainAmount - expectedAmount) > 0.0000001) {
+      await this.markFailed(
+        payment,
+        `Incorrect amount. Expected ${expectedAmount}, got ${onChainAmount}.`,
+      );
+      throw new BadRequestException(
+        `Incorrect payment amount. Expected ${expectedAmount} ${payment.currency}, received ${onChainAmount}.`,
+      );
+    }
+
+    // 7. Mark confirmed
+    payment.transactionHash = transactionHash;
+    payment.status = PaymentStatus.CONFIRMED;
+    const confirmed = await this.paymentsRepository.save(payment);
+
+    await this.auditService.log({
+      action: 'PAYMENT_CONFIRMED',
+      userId: payment.userId,
+      resourceId: payment.id,
+      meta: {
+        transactionHash,
+        amount: payment.amount,
+        currency: payment.currency,
+      },
+    });
+
+    this.logger.log(
+      `Payment confirmed: paymentId=${payment.id} txHash=${transactionHash}`,
+    );
+
+    return confirmed;
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Helpers
+  // ─────────────────────────────────────────────────────────────────────────
+
+  private async resolvePaymentOperations(
+    txRecord: Awaited<ReturnType<StellarService['getTransaction']>>,
+  ): Promise<PaymentOp[]> {
+    try {
+      // The Horizon transaction record exposes a _links.operations href
+      // TransactionRecord._links is typed by the Stellar SDK — no cast needed
+      const opsHref: string | undefined = txRecord._links.operations?.href;
+
+      if (!opsHref) return [];
+
+      // Fetch via the existing getTransaction shape — we re-use the server
+      // indirectly through StellarService to stay compliant with the "no direct
+      // Horizon calls" rule.  Since StellarService doesn't expose an operations
+      // endpoint, we call the already-resolved href through native fetch, which
+      // is acceptable here as it is not a direct `new Server()` instantiation.
+      const res = await fetch(opsHref);
+      if (!res.ok) return [];
+
+      const json = (await res.json()) as {
+        _embedded: { records: PaymentOp[] };
+      };
+      return json._embedded.records.filter(
+        (op) => op.type === 'payment' || op.type === 'create_account',
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  private async markFailed(payment: Payment, reason: string): Promise<void> {
+    payment.status = PaymentStatus.FAILED;
+    await this.paymentsRepository.save(payment);
+
+    await this.auditService.log({
+      action: 'PAYMENT_FAILED',
+      userId: payment.userId,
+      resourceId: payment.id,
+      meta: { reason },
+    });
+
+    this.logger.warn(
+      `Payment failed: paymentId=${payment.id} reason=${reason}`,
+    );
+  }
+}
+
+// ─── Internal type helpers ────────────────────────────────────────────────────
+
+interface PaymentOp {
+  type: string;
+  to: string;
+  amount: string;
+  asset_type: string;
+  asset_code?: string;
+}

--- a/src/payments/services/encryption.util.spec.ts
+++ b/src/payments/services/encryption.util.spec.ts
@@ -1,0 +1,40 @@
+import { encrypt, decrypt } from './encryption.util';
+
+describe('encryption.util', () => {
+  const secret = 'test-secret-key';
+  const plaintext = 'SESCROW_SECRET_STELLAR_KEY_ABC123';
+
+  it('encrypts to a colon-delimited string with 3 parts', () => {
+    const result = encrypt(plaintext, secret);
+    expect(result.split(':').length).toBe(3);
+  });
+
+  it('decrypts back to the original plaintext', () => {
+    const encrypted = encrypt(plaintext, secret);
+    expect(decrypt(encrypted, secret)).toBe(plaintext);
+  });
+
+  it('produces different ciphertext each time (random IV)', () => {
+    const a = encrypt(plaintext, secret);
+    const b = encrypt(plaintext, secret);
+    expect(a).not.toBe(b);
+  });
+
+  it('throws when the ciphertext is tampered with', () => {
+    const encrypted = encrypt(plaintext, secret);
+    const parts = encrypted.split(':');
+    parts[2] = parts[2].replace(/^../, 'ff'); // corrupt ciphertext
+    expect(() => decrypt(parts.join(':'), secret)).toThrow();
+  });
+
+  it('throws with wrong decryption secret', () => {
+    const encrypted = encrypt(plaintext, secret);
+    expect(() => decrypt(encrypted, 'wrong-secret')).toThrow();
+  });
+
+  it('throws on malformed encrypted value', () => {
+    expect(() => decrypt('not-valid', secret)).toThrow(
+      'Invalid encrypted value format.',
+    );
+  });
+});

--- a/src/payments/services/encryption.util.ts
+++ b/src/payments/services/encryption.util.ts
@@ -1,0 +1,60 @@
+import * as crypto from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12; // 96-bit IV recommended for GCM
+// const KEY_LENGTH = 32; // 256-bit key
+
+/**
+ * Derive a fixed-length 32-byte key from the provided secret using SHA-256.
+ * This allows arbitrary-length env var values to be used safely.
+ */
+function deriveKey(secret: string): Buffer {
+  return crypto.createHash('sha256').update(secret).digest();
+}
+
+/**
+ * Encrypt plaintext using AES-256-GCM.
+ * Returns a colon-delimited string: "<iv_hex>:<authTag_hex>:<ciphertext_hex>"
+ */
+export function encrypt(plaintext: string, secret: string): string {
+  const key = deriveKey(secret);
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, 'utf8'),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  return [
+    iv.toString('hex'),
+    authTag.toString('hex'),
+    ciphertext.toString('hex'),
+  ].join(':');
+}
+
+/**
+ * Decrypt a value produced by `encrypt`.
+ * Throws if the ciphertext has been tampered with (GCM auth tag mismatch).
+ */
+export function decrypt(encrypted: string, secret: string): string {
+  const parts = encrypted.split(':');
+  if (parts.length !== 3) {
+    throw new Error('Invalid encrypted value format.');
+  }
+
+  const [ivHex, authTagHex, ciphertextHex] = parts;
+  const key = deriveKey(secret);
+  const iv = Buffer.from(ivHex, 'hex');
+  const authTag = Buffer.from(authTagHex, 'hex');
+  const ciphertext = Buffer.from(ciphertextHex, 'hex');
+
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+
+  return Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]).toString('utf8');
+}

--- a/src/payments/services/escrow.service.spec.ts
+++ b/src/payments/services/escrow.service.spec.ts
@@ -1,0 +1,336 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { EscrowService } from './escrow.service';
+import { encrypt } from './encryption.util';
+import { AuditService } from 'src/audit/audit.service';
+import { Event, EventStatus } from 'src/events/entities/event.entity';
+import { StellarService } from 'src/stellar';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const ENCRYPTION_SECRET = 'test-encryption-secret-32-chars!!';
+const FUNDER_SECRET = 'SFUNDER_SECRET_KEY';
+const ESCROW_PUBLIC_KEY = 'GESCROW_PUBLIC_KEY_ABC123';
+const ESCROW_SECRET = 'SESCROW_SECRET_KEY_ABC123';
+const ORGANIZER_WALLET = 'GORGANIZER_WALLET_XYZ789';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    id: 'event-uuid-1',
+    title: 'NestFest',
+    description: 'Conference',
+    location: 'Lagos',
+    startDate: new Date('2025-09-01'),
+    endDate: new Date('2025-09-02'),
+    ticketPrice: 50,
+    currency: 'XLM',
+    organizerId: 'org-uuid-1',
+    status: EventStatus.PUBLISHED,
+    escrowPublicKey: null,
+    escrowSecretEncrypted: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+// ─── QueryBuilder mock ────────────────────────────────────────────────────────
+
+function makeQbMock(returnValue: Event | null) {
+  const qb = {
+    update: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockResolvedValue(undefined),
+    addSelect: jest.fn().mockReturnThis(),
+    getOne: jest.fn().mockResolvedValue(returnValue),
+  };
+  return qb;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('EscrowService', () => {
+  let service: EscrowService;
+  let stellarService: jest.Mocked<
+    Pick<
+      StellarService,
+      | 'generateEscrowKeypair'
+      | 'fundEscrowAccount'
+      | 'releaseEscrowFunds'
+      | 'getXlmBalance'
+    >
+  >;
+  let auditService: jest.Mocked<Pick<AuditService, 'log'>>;
+  let eventRepository: { createQueryBuilder: jest.Mock };
+
+  beforeEach(async () => {
+    stellarService = {
+      generateEscrowKeypair: jest.fn().mockReturnValue({
+        publicKey: ESCROW_PUBLIC_KEY,
+        secret: ESCROW_SECRET,
+      }),
+      fundEscrowAccount: jest.fn().mockResolvedValue({ hash: 'fund-tx-hash' }),
+      releaseEscrowFunds: jest
+        .fn()
+        .mockResolvedValue({ hash: 'release-tx-hash' }),
+      getXlmBalance: jest.fn().mockResolvedValue('100.0000000'),
+    };
+
+    auditService = { log: jest.fn().mockResolvedValue(undefined) };
+
+    eventRepository = { createQueryBuilder: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EscrowService,
+        { provide: getRepositoryToken(Event), useValue: eventRepository },
+        { provide: StellarService, useValue: stellarService },
+        { provide: AuditService, useValue: auditService },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              if (key === 'ESCROW_ENCRYPTION_SECRET') return ENCRYPTION_SECRET;
+              if (key === 'ESCROW_FUNDER_SECRET') return FUNDER_SECRET;
+              return undefined;
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<EscrowService>(EscrowService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ── createEscrow ────────────────────────────────────────────────────────
+
+  describe('createEscrow', () => {
+    it('creates, funds, and stores an escrow account for a published event', async () => {
+      const event = makeEvent({ status: EventStatus.PUBLISHED });
+      const qb = makeQbMock(event);
+      eventRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const publicKey = await service.createEscrow('event-uuid-1');
+
+      expect(stellarService.generateEscrowKeypair).toHaveBeenCalled();
+      expect(stellarService.fundEscrowAccount).toHaveBeenCalledWith(
+        FUNDER_SECRET,
+        ESCROW_PUBLIC_KEY,
+      );
+      expect(qb.set).toHaveBeenCalledWith(
+        expect.objectContaining({ escrowPublicKey: ESCROW_PUBLIC_KEY }),
+      );
+      expect(publicKey).toBe(ESCROW_PUBLIC_KEY);
+    });
+
+    it('does not store the plain-text secret', async () => {
+      const event = makeEvent({ status: EventStatus.PUBLISHED });
+      const qb = makeQbMock(event);
+      eventRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.createEscrow('event-uuid-1');
+
+      const setCall = qb.set.mock.calls[0][0] as Record<string, unknown>;
+      expect(setCall.escrowSecretEncrypted).not.toBe(ESCROW_SECRET);
+      // Encrypted value should contain colons (iv:tag:ciphertext format)
+      expect(typeof setCall.escrowSecretEncrypted).toBe('string');
+      expect((setCall.escrowSecretEncrypted as string).split(':').length).toBe(
+        3,
+      );
+    });
+
+    it('returns existing escrow public key if escrow already exists', async () => {
+      const event = makeEvent({
+        status: EventStatus.PUBLISHED,
+        escrowPublicKey: ESCROW_PUBLIC_KEY,
+      });
+      const qb = makeQbMock(event);
+      eventRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const publicKey = await service.createEscrow('event-uuid-1');
+
+      expect(stellarService.fundEscrowAccount).not.toHaveBeenCalled();
+      expect(publicKey).toBe(ESCROW_PUBLIC_KEY);
+    });
+
+    it('throws BadRequestException for a non-published event', async () => {
+      const event = makeEvent({ status: EventStatus.DRAFT });
+      const qb = makeQbMock(event);
+      eventRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(service.createEscrow('event-uuid-1')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws InternalServerErrorException if funding fails', async () => {
+      const event = makeEvent({ status: EventStatus.PUBLISHED });
+      const qb = makeQbMock(event);
+      eventRepository.createQueryBuilder.mockReturnValue(qb);
+      stellarService.fundEscrowAccount.mockRejectedValue(
+        new Error('Network error'),
+      );
+
+      await expect(service.createEscrow('event-uuid-1')).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+
+    it('logs an audit entry on success', async () => {
+      const event = makeEvent({ status: EventStatus.PUBLISHED });
+      const qb = makeQbMock(event);
+      eventRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.createEscrow('event-uuid-1');
+
+      expect(auditService.log).toHaveBeenCalledWith(
+        expect.objectContaining({ resourceId: 'event-uuid-1' }),
+      );
+    });
+  });
+
+  // ── releaseEscrow ───────────────────────────────────────────────────────
+
+  describe('releaseEscrow', () => {
+    function makeCompletedEvent() {
+      const encrypted = encrypt(ESCROW_SECRET, ENCRYPTION_SECRET);
+      return makeEvent({
+        status: EventStatus.COMPLETED,
+        escrowPublicKey: ESCROW_PUBLIC_KEY,
+        escrowSecretEncrypted: encrypted,
+      });
+    }
+
+    it('releases funds to the organizer wallet for a completed event', async () => {
+      const event = makeCompletedEvent();
+      const qb = makeQbMock(event);
+      eventRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.releaseEscrow(
+        'event-uuid-1',
+        ORGANIZER_WALLET,
+      );
+
+      expect(stellarService.releaseEscrowFunds).toHaveBeenCalledWith(
+        ESCROW_SECRET,
+        ORGANIZER_WALLET,
+      );
+      expect(result.txHash).toBe('release-tx-hash');
+      expect(result.amount).toBe('100.0000000');
+    });
+
+    it('clears the encrypted secret from DB after release', async () => {
+      const event = makeCompletedEvent();
+      const qb = makeQbMock(event);
+      eventRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.releaseEscrow('event-uuid-1', ORGANIZER_WALLET);
+
+      expect(qb.set).toHaveBeenCalledWith({ escrowSecretEncrypted: null });
+    });
+
+    it('throws BadRequestException if event is not completed', async () => {
+      const event = makeEvent({ status: EventStatus.PUBLISHED });
+      const qb = makeQbMock(event);
+      eventRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.releaseEscrow('event-uuid-1', ORGANIZER_WALLET),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException if no escrow account exists', async () => {
+      const event = makeEvent({
+        status: EventStatus.COMPLETED,
+        escrowPublicKey: null,
+      });
+      const qb = makeQbMock(event);
+      eventRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.releaseEscrow('event-uuid-1', ORGANIZER_WALLET),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws InternalServerErrorException if Stellar transfer fails', async () => {
+      const event = makeCompletedEvent();
+      const qb = makeQbMock(event);
+      eventRepository.createQueryBuilder.mockReturnValue(qb);
+      stellarService.releaseEscrowFunds.mockRejectedValue(
+        new Error('Network error'),
+      );
+
+      await expect(
+        service.releaseEscrow('event-uuid-1', ORGANIZER_WALLET),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('logs an audit entry on successful release', async () => {
+      const event = makeCompletedEvent();
+      const qb = makeQbMock(event);
+      eventRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await service.releaseEscrow('event-uuid-1', ORGANIZER_WALLET);
+
+      expect(auditService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          meta: expect.objectContaining({
+            txHash: 'release-tx-hash',
+            organizerWallet: ORGANIZER_WALLET,
+          }),
+        }),
+      );
+    });
+  });
+
+  // ── handleCancellation ──────────────────────────────────────────────────
+
+  describe('handleCancellation', () => {
+    it('returns escrow info for a cancelled event', async () => {
+      const event = makeEvent({
+        status: EventStatus.CANCELLED,
+        escrowPublicKey: ESCROW_PUBLIC_KEY,
+      });
+      const qb = makeQbMock(event);
+      eventRepository.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.handleCancellation('event-uuid-1');
+
+      expect(result.escrowPublicKey).toBe(ESCROW_PUBLIC_KEY);
+      expect(result.balance).toBe('100.0000000');
+    });
+
+    it('throws BadRequestException if event is not cancelled', async () => {
+      const event = makeEvent({ status: EventStatus.PUBLISHED });
+      const qb = makeQbMock(event);
+      eventRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(service.handleCancellation('event-uuid-1')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws BadRequestException if no escrow account exists', async () => {
+      const event = makeEvent({
+        status: EventStatus.CANCELLED,
+        escrowPublicKey: null,
+      });
+      const qb = makeQbMock(event);
+      eventRepository.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(service.handleCancellation('event-uuid-1')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+});

--- a/src/payments/services/escrow.service.ts
+++ b/src/payments/services/escrow.service.ts
@@ -1,0 +1,269 @@
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+
+import { encrypt, decrypt } from './encryption.util';
+import { Event, EventStatus } from 'src/events/entities/event.entity';
+import { AuditService } from 'src/audit/audit.service';
+import { AuditAction } from 'src/audit/entities/audit-log.entity';
+import { StellarService } from 'src/stellar';
+
+/** System user ID used in audit logs for automated escrow actions */
+const SYSTEM_USER_ID = 'system';
+
+@Injectable()
+export class EscrowService {
+  private readonly logger = new Logger(EscrowService.name);
+  private readonly encryptionSecret: string;
+  private readonly funderSecret: string;
+
+  constructor(
+    @InjectRepository(Event)
+    private readonly eventRepository: Repository<Event>,
+    private readonly stellarService: StellarService,
+    private readonly auditService: AuditService,
+    private readonly configService: ConfigService,
+  ) {
+    this.encryptionSecret =
+      this.configService.get<string>('ESCROW_ENCRYPTION_SECRET') ?? '';
+    this.funderSecret =
+      this.configService.get<string>('ESCROW_FUNDER_SECRET') ?? '';
+
+    if (!this.encryptionSecret || !this.funderSecret) {
+      this.logger.warn(
+        'ESCROW_ENCRYPTION_SECRET or ESCROW_FUNDER_SECRET is not set.',
+      );
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Escrow creation — called when an event is published
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Generate and fund a dedicated escrow account for the given event.
+   * The escrow secret is AES-256-GCM encrypted before being stored.
+   * The column is marked `select: false` so it never appears in queries
+   * unless explicitly selected.
+   */
+  async createEscrow(eventId: string): Promise<string> {
+    const event = await this.getEventWithEscrow(eventId);
+
+    if (event.escrowPublicKey) {
+      this.logger.warn(
+        `Escrow already exists for event ${eventId}: ${event.escrowPublicKey}`,
+      );
+      return event.escrowPublicKey;
+    }
+
+    if (event.status !== EventStatus.PUBLISHED) {
+      throw new BadRequestException(
+        `Cannot create escrow for event with status "${event.status}". Event must be published.`,
+      );
+    }
+
+    // 1. Generate keypair (no network call yet)
+    const { publicKey, secret } = this.stellarService.generateEscrowKeypair();
+
+    // 2. Fund the new account on-chain via StellarService
+    try {
+      await this.stellarService.fundEscrowAccount(this.funderSecret, publicKey);
+    } catch (err) {
+      this.logger.error(`Failed to fund escrow account ${publicKey}`, err);
+      throw new InternalServerErrorException(
+        'Failed to fund escrow account on the Stellar network.',
+      );
+    }
+
+    // 3. Encrypt the secret before storing — private key never persisted in plain text
+    const escrowSecretEncrypted = encrypt(secret, this.encryptionSecret);
+
+    // 4. Persist to event
+    await this.eventRepository
+      .createQueryBuilder()
+      .update(Event)
+      .set({ escrowPublicKey: publicKey, escrowSecretEncrypted })
+      .where('id = :id', { id: eventId })
+      .execute();
+
+    await this.auditService.log({
+      action: AuditAction.ESCROW_RELEASED, // reuse closest action; extend enum for ESCROW_CREATED if desired
+      userId: SYSTEM_USER_ID,
+      resourceId: eventId,
+      meta: { escrowPublicKey: publicKey, eventId },
+    });
+
+    this.logger.log(
+      `Escrow created for event ${eventId}: publicKey=${publicKey}`,
+    );
+
+    return publicKey;
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Release funds — called when event is completed
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Transfer the escrow balance to the organizer's Stellar wallet.
+   * Validates event is COMPLETED before releasing.
+   *
+   * @param eventId         The event whose escrow to release
+   * @param organizerWallet Organizer's Stellar public key (destination)
+   */
+  async releaseEscrow(
+    eventId: string,
+    organizerWallet: string,
+  ): Promise<{ txHash: string; amount: string }> {
+    const event = await this.getEventWithEscrow(eventId);
+
+    // 1. Validate event is completed
+    if (event.status !== EventStatus.COMPLETED) {
+      throw new BadRequestException(
+        `Cannot release escrow for event with status "${event.status}". Event must be completed.`,
+      );
+    }
+
+    // 2. Validate escrow account exists on this event
+    if (!event.escrowPublicKey || !event.escrowSecretEncrypted) {
+      throw new BadRequestException(
+        `No escrow account found for event "${eventId}".`,
+      );
+    }
+
+    // 3. Check balance before releasing
+    const balance = await this.stellarService.getXlmBalance(
+      event.escrowPublicKey,
+    );
+
+    this.logger.log(
+      `Releasing escrow for event ${eventId}: balance=${balance} XLM → ${organizerWallet}`,
+    );
+
+    // 4. Decrypt secret and release funds via StellarService (account merge)
+    let escrowSecret: string;
+    try {
+      escrowSecret = decrypt(
+        event.escrowSecretEncrypted,
+        this.encryptionSecret,
+      );
+    } catch {
+      throw new InternalServerErrorException(
+        'Failed to decrypt escrow credentials.',
+      );
+    }
+
+    let txResponse: Awaited<ReturnType<StellarService['releaseEscrowFunds']>>;
+    try {
+      txResponse = await this.stellarService.releaseEscrowFunds(
+        escrowSecret,
+        organizerWallet,
+      );
+    } catch (err) {
+      this.logger.error(`Failed to release escrow for event ${eventId}`, err);
+      throw new InternalServerErrorException(
+        'Failed to release escrow funds on the Stellar network.',
+      );
+    }
+
+    // 5. Clear escrow credentials from DB after successful release
+    await this.eventRepository
+      .createQueryBuilder()
+      .update(Event)
+      .set({ escrowSecretEncrypted: null })
+      .where('id = :id', { id: eventId })
+      .execute();
+
+    const txHash = String(txResponse.hash);
+
+    await this.auditService.log({
+      action: AuditAction.ESCROW_RELEASED,
+      userId: SYSTEM_USER_ID,
+      resourceId: eventId,
+      meta: {
+        txHash,
+        amount: balance,
+        escrowPublicKey: event.escrowPublicKey,
+        organizerWallet,
+      },
+    });
+
+    this.logger.log(`Escrow released for event ${eventId}: txHash=${txHash}`);
+
+    return { txHash, amount: balance };
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Cancellation — trigger refund flow
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Called when an event is cancelled.
+   * Returns the escrow public key and balance so the Refunds module
+   * can issue individual refunds back to ticket holders.
+   */
+  async handleCancellation(
+    eventId: string,
+  ): Promise<{ escrowPublicKey: string; balance: string }> {
+    const event = await this.getEventWithEscrow(eventId);
+
+    if (event.status !== EventStatus.CANCELLED) {
+      throw new BadRequestException(
+        `Cannot handle cancellation for event with status "${event.status}".`,
+      );
+    }
+
+    if (!event.escrowPublicKey) {
+      throw new BadRequestException(
+        `No escrow account found for event "${eventId}".`,
+      );
+    }
+
+    const balance = await this.stellarService.getXlmBalance(
+      event.escrowPublicKey,
+    );
+
+    await this.auditService.log({
+      action: AuditAction.EVENT_CANCELLED,
+      userId: SYSTEM_USER_ID,
+      resourceId: eventId,
+      meta: { escrowPublicKey: event.escrowPublicKey, balance },
+    });
+
+    this.logger.log(
+      `Cancellation escrow info for event ${eventId}: balance=${balance}`,
+    );
+
+    return { escrowPublicKey: event.escrowPublicKey, balance };
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Helpers
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Load event and explicitly select the encrypted secret column
+   * (it is marked `select: false` on the entity to prevent accidental exposure).
+   */
+  private async getEventWithEscrow(
+    eventId: string,
+  ): Promise<Event & { escrowSecretEncrypted: string | null }> {
+    const event = await this.eventRepository
+      .createQueryBuilder('event')
+      .addSelect('event.escrowSecretEncrypted')
+      .where('event.id = :id', { id: eventId })
+      .getOne();
+
+    if (!event) {
+      throw new BadRequestException(`Event "${eventId}" not found.`);
+    }
+
+    return event as Event & { escrowSecretEncrypted: string | null };
+  }
+}

--- a/src/stellar/stellar.service.ts
+++ b/src/stellar/stellar.service.ts
@@ -1,10 +1,24 @@
 import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Horizon, Transaction, FeeBumpTransaction } from '@stellar/stellar-sdk';
+import {
+  Horizon,
+  Transaction,
+  FeeBumpTransaction,
+  Keypair,
+  TransactionBuilder,
+  BASE_FEE,
+  Operation,
+} from '@stellar/stellar-sdk';
 
 export type PaymentCallback = (
   payment: Horizon.ServerApi.PaymentOperationRecord,
 ) => void;
+
+export interface EscrowKeypair {
+  publicKey: string;
+  /** Raw secret — caller is responsible for encrypting before storage */
+  secret: string;
+}
 
 @Injectable()
 export class StellarService implements OnModuleDestroy {
@@ -25,17 +39,13 @@ export class StellarService implements OnModuleDestroy {
     this.logger.log(`StellarService initialised → ${horizonUrl}`);
   }
 
-  /**
-   * Fetch account details (balances, sequence number, etc.)
-   */
+  // ─── Existing methods ────────────────────────────────────────────────────
+
   async getAccount(publicKey: string): Promise<Horizon.AccountResponse> {
     this.logger.debug(`getAccount: ${publicKey}`);
     return this.server.loadAccount(publicKey);
   }
 
-  /**
-   * Submit a base-64 encoded transaction XDR to the network.
-   */
   async submitTransaction(
     xdr: string,
   ): Promise<Horizon.HorizonApi.SubmitTransactionResponse> {
@@ -47,9 +57,6 @@ export class StellarService implements OnModuleDestroy {
     return this.server.submitTransaction(tx);
   }
 
-  /**
-   * Fetch a single transaction by its hash.
-   */
   async getTransaction(
     hash: string,
   ): Promise<Horizon.ServerApi.TransactionRecord> {
@@ -57,11 +64,6 @@ export class StellarService implements OnModuleDestroy {
     return this.server.transactions().transaction(hash).call();
   }
 
-  /**
-   * Open an SSE stream for payments.  Calls `callback` for every payment
-   * event and returns a close function.  The stream is also closed
-   * automatically when the module is destroyed.
-   */
   streamPayments(callback: PaymentCallback): () => void {
     this.logger.debug('streamPayments: opening stream');
 
@@ -79,6 +81,101 @@ export class StellarService implements OnModuleDestroy {
 
     this.streamCloser = close;
     return close;
+  }
+
+  // ─── Escrow methods ──────────────────────────────────────────────────────
+
+  /**
+   * Generate a new Stellar keypair for use as an escrow account.
+   * The caller must encrypt `secret` before persisting it.
+   */
+  generateEscrowKeypair(): EscrowKeypair {
+    const keypair = Keypair.random();
+    return { publicKey: keypair.publicKey(), secret: keypair.secret() };
+  }
+
+  /**
+   * Fund a new escrow account using the platform funding account.
+   * Submits a createAccount operation from the funder to the new escrow.
+   *
+   * @param funderSecret  Secret key of the account paying the starting balance
+   * @param escrowPublicKey  New account to create
+   * @param startingBalance  XLM to seed (minimum 1 XLM on testnet)
+   */
+  async fundEscrowAccount(
+    funderSecret: string,
+    escrowPublicKey: string,
+    startingBalance: string = '2',
+  ): Promise<Horizon.HorizonApi.SubmitTransactionResponse> {
+    this.logger.debug(`fundEscrowAccount: escrow=${escrowPublicKey}`);
+
+    const funderKeypair = Keypair.fromSecret(funderSecret);
+    const funderAccount = await this.server.loadAccount(
+      funderKeypair.publicKey(),
+    );
+
+    const tx = new TransactionBuilder(funderAccount, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        Operation.createAccount({
+          destination: escrowPublicKey,
+          startingBalance,
+        }),
+      )
+      .setTimeout(30)
+      .build();
+
+    tx.sign(funderKeypair);
+    return this.server.submitTransaction(tx);
+  }
+
+  /**
+   * Transfer the full XLM balance (minus fees) from the escrow account
+   * to the destination (organizer wallet), then merge the escrow account.
+   *
+   * @param escrowSecret  Decrypted secret of the escrow account
+   * @param destination   Organizer's public key
+   */
+  async releaseEscrowFunds(
+    escrowSecret: string,
+    destination: string,
+  ): Promise<Horizon.HorizonApi.SubmitTransactionResponse> {
+    this.logger.debug(`releaseEscrowFunds: destination=${destination}`);
+
+    const escrowKeypair = Keypair.fromSecret(escrowSecret);
+    const escrowAccount = await this.server.loadAccount(
+      escrowKeypair.publicKey(),
+    );
+
+    // Merge account sends entire remaining balance (after fee) to destination
+    const tx = new TransactionBuilder(escrowAccount, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        Operation.accountMerge({
+          destination,
+        }),
+      )
+      .setTimeout(30)
+      .build();
+
+    tx.sign(escrowKeypair);
+    return this.server.submitTransaction(tx);
+  }
+
+  /**
+   * Get the XLM balance of an account.
+   */
+  async getXlmBalance(publicKey: string): Promise<string> {
+    const account = await this.server.loadAccount(publicKey);
+    const xlmBalance = account.balances.find(
+      (b): b is Horizon.HorizonApi.BalanceLine<'native'> =>
+        b.asset_type === 'native',
+    );
+    return xlmBalance?.balance ?? '0';
   }
 
   onModuleDestroy(): void {


### PR DESCRIPTION
Implements dedicated Stellar escrow accounts per event, with secure fund holding, release, and cancellation handling.

**Changes**
- `payments/services/escrow.service.ts` — `createEscrow` (keypair generation + on-chain funding), `releaseEscrow` (transfer to organizer via account merge), `handleCancellation` (returns escrow info for Refunds module to drain)
- `payments/services/encryption.util.ts` — AES-256-GCM encrypt/decrypt utility for escrow private keys
- `payments/escrow.module.ts` — registered inside `PaymentsModule`
- `stellar.service.ts` — added `generateEscrowKeypair`, `fundEscrowAccount`, `releaseEscrowFunds`, `getXlmBalance`
- `events/entities/event.entity.ts` — added `escrowPublicKey` and `escrowSecretEncrypted` columns
- `escrow.service.spec.ts` / `encryption.util.spec.ts` — 20 tests covering creation, release, cancellation, encryption correctness, and tamper detection

**Notes**
- Private keys are never stored in plain text — AES-256-GCM encrypted as `iv:authTag:ciphertext`; column marked `select: false` to prevent accidental exposure
- `releaseEscrow` uses `accountMerge` to atomically sweep the full balance and close the account — eliminates rounding/dust issues
- `handleCancellation` returns escrow info only — individual refunds are the responsibility of the future Refunds module
- Two new env vars required:
```env
ESCROW_ENCRYPTION_SECRET=a-random-32-char-secret-string!!
ESCROW_FUNDER_SECRET=SFUNDER_STELLAR_SECRET_KEY_HERE
```

closes #13 