### PR TITLE
feat: Admin Moderation Module & Stellar Webhook Listener

### DIFF
--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -1,0 +1,39 @@
+import {
+  Controller,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  UseGuards,
+} from '@nestjs/common';
+import { AdminService } from './admin.service';
+import { Roles } from './roles.decorator';
+import { RolesGuard } from './roles.guard';
+import { UserRole } from '../users/enums/user-role.enum';
+import { ApiOperation, ApiTags, ApiBearerAuth } from '@nestjs/swagger';
+
+@ApiTags('Admin')
+@ApiBearerAuth()
+@UseGuards(RolesGuard)
+@Roles(UserRole.ADMIN)
+@Controller('admin')
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  @Patch('events/:id/approve')
+  @ApiOperation({ summary: 'Approve a draft event (publish it)' })
+  approveEvent(@Param('id', ParseUUIDPipe) id: string) {
+    return this.adminService.approveEvent(id);
+  }
+
+  @Patch('events/:id/suspend')
+  @ApiOperation({ summary: 'Suspend an event (cancels it, blocks payments)' })
+  suspendEvent(@Param('id', ParseUUIDPipe) id: string) {
+    return this.adminService.suspendEvent(id);
+  }
+
+  @Patch('users/:id/block')
+  @ApiOperation({ summary: 'Block a user from the platform' })
+  blockUser(@Param('id', ParseUUIDPipe) id: string) {
+    return this.adminService.blockUser(id);
+  }
+}

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
+import { RolesGuard } from './roles.guard';
+import { Event } from '../events/entities/event.entity';
+import { User } from '../users/entities/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Event, User])],
+  controllers: [AdminController],
+  providers: [AdminService, RolesGuard],
+  exports: [RolesGuard], // export so other modules can apply it if needed
+})
+export class AdminModule {}

--- a/backend/src/admin/admin.service.spec.ts
+++ b/backend/src/admin/admin.service.spec.ts
@@ -1,0 +1,125 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AdminService } from './admin.service';
+import { Event, EventStatus } from '../events/entities/event.entity';
+import { User } from '../users/entities/user.entity';
+import { UserRole } from '../users/enums/user-role.enum';
+
+const makeEvent = (status: EventStatus): Event =>
+  ({
+    id: 'event-uuid',
+    title: 'Test Event',
+    status,
+  }) as Event;
+
+const makeUser = (): User =>
+  ({
+    id: 'user-uuid',
+    email: 'user@example.com',
+    role: UserRole.EVENT_GOER,
+    status: 'active',
+  }) as unknown as User;
+
+describe('AdminService', () => {
+  let service: AdminService;
+  let eventRepo: { findOne: jest.Mock; save: jest.Mock };
+  let userRepo: { findOne: jest.Mock; save: jest.Mock };
+
+  beforeEach(async () => {
+    eventRepo = { findOne: jest.fn(), save: jest.fn() };
+    userRepo = { findOne: jest.fn(), save: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminService,
+        { provide: getRepositoryToken(Event), useValue: eventRepo },
+        { provide: getRepositoryToken(User), useValue: userRepo },
+      ],
+    }).compile();
+
+    service = module.get<AdminService>(AdminService);
+  });
+
+  // ── approveEvent ──────────────────────────────────────────────────────────
+
+  describe('approveEvent', () => {
+    it('publishes a draft event', async () => {
+      const event = makeEvent(EventStatus.DRAFT);
+      eventRepo.findOne.mockResolvedValue(event);
+      eventRepo.save.mockImplementation(async (e: Event) => e);
+
+      const result = await service.approveEvent('event-uuid');
+      expect(result.status).toBe(EventStatus.PUBLISHED);
+    });
+
+    it('throws if event is not in draft', async () => {
+      eventRepo.findOne.mockResolvedValue(makeEvent(EventStatus.PUBLISHED));
+      await expect(service.approveEvent('event-uuid')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws NotFoundException for unknown event', async () => {
+      eventRepo.findOne.mockResolvedValue(null);
+      await expect(service.approveEvent('bad-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ── suspendEvent ──────────────────────────────────────────────────────────
+
+  describe('suspendEvent', () => {
+    it('cancels a published event', async () => {
+      const event = makeEvent(EventStatus.PUBLISHED);
+      eventRepo.findOne.mockResolvedValue(event);
+      eventRepo.save.mockImplementation(async (e: Event) => e);
+
+      const result = await service.suspendEvent('event-uuid');
+      expect(result.status).toBe(EventStatus.CANCELLED);
+    });
+
+    it('throws if event is already cancelled', async () => {
+      eventRepo.findOne.mockResolvedValue(makeEvent(EventStatus.CANCELLED));
+      await expect(service.suspendEvent('event-uuid')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws if event is completed', async () => {
+      eventRepo.findOne.mockResolvedValue(makeEvent(EventStatus.COMPLETED));
+      await expect(service.suspendEvent('event-uuid')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  // ── blockUser ─────────────────────────────────────────────────────────────
+
+  describe('blockUser', () => {
+    it('blocks an active user', async () => {
+      const user = makeUser();
+      userRepo.findOne.mockResolvedValue(user);
+      userRepo.save.mockImplementation(async (u: User) => u);
+
+      const result = await service.blockUser('user-uuid');
+      expect((result as any).status).toBe('blocked');
+    });
+
+    it('throws if user is already blocked', async () => {
+      const user = { ...makeUser(), status: 'blocked' };
+      userRepo.findOne.mockResolvedValue(user);
+      await expect(service.blockUser('user-uuid')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws NotFoundException for unknown user', async () => {
+      userRepo.findOne.mockResolvedValue(null);
+      await expect(service.blockUser('bad-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -1,0 +1,81 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../users/entities/user.entity';
+import { Event, EventStatus } from '../events/entities/event.entity';
+
+export enum UserStatus {
+  ACTIVE = 'active',
+  BLOCKED = 'blocked',
+}
+
+@Injectable()
+export class AdminService {
+  constructor(
+    @InjectRepository(Event)
+    private readonly eventRepository: Repository<Event>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  // ── Events ────────────────────────────────────────────────────────────────
+
+  async approveEvent(eventId: string): Promise<Event> {
+    const event = await this.findEventOrFail(eventId);
+
+    if (event.status !== EventStatus.DRAFT) {
+      throw new BadRequestException(
+        `Only draft events can be approved. Current status: "${event.status}".`,
+      );
+    }
+
+    event.status = EventStatus.PUBLISHED;
+    return this.eventRepository.save(event);
+  }
+
+  async suspendEvent(eventId: string): Promise<Event> {
+    const event = await this.findEventOrFail(eventId);
+
+    if (event.status === EventStatus.CANCELLED) {
+      throw new BadRequestException('Event is already cancelled.');
+    }
+
+    if (event.status === EventStatus.COMPLETED) {
+      throw new BadRequestException('Completed events cannot be suspended.');
+    }
+
+    event.status = EventStatus.CANCELLED;
+    return this.eventRepository.save(event);
+  }
+
+  // ── Users ─────────────────────────────────────────────────────────────────
+
+  async blockUser(userId: string): Promise<User> {
+    const user = await this.findUserOrFail(userId);
+
+    if ((user as any).status === UserStatus.BLOCKED) {
+      throw new BadRequestException('User is already blocked.');
+    }
+
+    (user as any).status = UserStatus.BLOCKED;
+    return this.userRepository.save(user);
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  private async findEventOrFail(id: string): Promise<Event> {
+    const event = await this.eventRepository.findOne({ where: { id } });
+    if (!event) throw new NotFoundException(`Event "${id}" not found.`);
+    return event;
+  }
+
+  private async findUserOrFail(id: string): Promise<User> {
+    const user = await this.userRepository.findOne({ where: { id } });
+    if (!user) throw new NotFoundException(`User "${id}" not found.`);
+    return user;
+  }
+}

--- a/backend/src/admin/roles.decorator.ts
+++ b/backend/src/admin/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { UserRole } from '../users/enums/user-role.enum';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);

--- a/backend/src/admin/roles.guard.spec.ts
+++ b/backend/src/admin/roles.guard.spec.ts
@@ -1,0 +1,59 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { RolesGuard } from './roles.guard';
+import { UserRole } from '../users/enums/user-role.enum';
+import { ExecutionContext } from '@nestjs/common';
+
+function mockContext(role: UserRole | null): ExecutionContext {
+  return {
+    getHandler: () => ({}),
+    getClass: () => ({}),
+    switchToHttp: () => ({
+      getRequest: () => ({ user: role ? { role } : null }),
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe('RolesGuard', () => {
+  let guard: RolesGuard;
+  let reflector: Reflector;
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    guard = new RolesGuard(reflector);
+  });
+
+  it('allows admin through', () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([UserRole.ADMIN]);
+
+    expect(guard.canActivate(mockContext(UserRole.ADMIN))).toBe(true);
+  });
+
+  it('rejects non-admin with ForbiddenException', () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([UserRole.ADMIN]);
+
+    expect(() => guard.canActivate(mockContext(UserRole.EVENT_GOER))).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('rejects unauthenticated user', () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([UserRole.ADMIN]);
+
+    expect(() => guard.canActivate(mockContext(null))).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('allows through when no roles are required', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([]);
+
+    expect(guard.canActivate(mockContext(UserRole.EVENT_GOER))).toBe(true);
+  });
+});

--- a/backend/src/admin/roles.guard.ts
+++ b/backend/src/admin/roles.guard.ts
@@ -1,0 +1,34 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from './roles.decorator';
+import { UserRole } from '../users/enums/user-role.enum';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    // No @Roles() decorator — route is not role-restricted
+    if (!requiredRoles || requiredRoles.length === 0) return true;
+
+    const { user } = context.switchToHttp().getRequest();
+
+    if (!user || !requiredRoles.includes(user.role)) {
+      throw new ForbiddenException(
+        'Access denied: insufficient permissions.',
+      );
+    }
+
+    return true;
+  }
+}

--- a/backend/src/payments/payments.service.ts
+++ b/backend/src/payments/payments.service.ts
@@ -59,7 +59,13 @@ export class PaymentsService {
     // 1. Validate event exists
     const event = await this.eventsService.getEventById(eventId);
 
-    // 2. Validate event is published
+    // 2. Validate event is published — covers suspended (CANCELLED) events too
+    if (event.status === EventStatus.CANCELLED) {
+      throw new BadRequestException(
+        `Event "${event.title}" has been suspended and is no longer available for purchase.`,
+      );
+    }
+
     if (event.status !== EventStatus.PUBLISHED) {
       throw new BadRequestException(
         `Event "${event.title}" is not available for purchase (status: ${event.status}).`,
@@ -100,7 +106,7 @@ export class PaymentsService {
       escrowWallet: this.escrowWallet,
       amount: event.ticketPrice,
       currency,
-      memo: saved.id, // caller sets this as the Stellar memo so we can correlate
+      memo: saved.id,
     };
   }
 
@@ -109,7 +115,6 @@ export class PaymentsService {
   // ─────────────────────────────────────────────────────────────────────────
 
   async confirmPayment(transactionHash: string): Promise<Payment> {
-    // 1. Fetch the on-chain transaction via StellarService (no direct Horizon calls)
     let txRecord: Awaited<ReturnType<StellarService['getTransaction']>>;
     try {
       txRecord = await this.stellarService.getTransaction(transactionHash);
@@ -119,8 +124,6 @@ export class PaymentsService {
       );
     }
 
-    // 2. Find pending payment — match via memo (set to paymentId by the client)
-    // TransactionRecord.memo is typed as string | undefined in the Stellar SDK
     const memoValue: string | undefined =
       typeof txRecord.memo === 'string' ? txRecord.memo : undefined;
 
@@ -140,9 +143,6 @@ export class PaymentsService {
       );
     }
 
-    // 3. Fetch operations to validate destination & amount
-    // StellarService.getTransaction returns the transaction record.
-    // We resolve operations via the _links on the record.
     const ops = await this.resolvePaymentOperations(txRecord);
 
     if (ops.length === 0) {
@@ -155,7 +155,6 @@ export class PaymentsService {
       );
     }
 
-    // 4. Find the operation that matches our escrow wallet
     const matchingOp = ops.find((op) => op.to === this.escrowWallet);
 
     if (!matchingOp) {
@@ -168,7 +167,6 @@ export class PaymentsService {
       );
     }
 
-    // 5. Validate asset type
     const assetCode: string =
       matchingOp.asset_type === 'native'
         ? 'XLM'
@@ -189,7 +187,6 @@ export class PaymentsService {
       throw new BadRequestException(`Asset "${assetCode}" is not supported.`);
     }
 
-    // 6. Validate amount (Stellar amounts are strings with 7 decimal places)
     const onChainAmount = parseFloat(matchingOp.amount);
     const expectedAmount = parseFloat(String(payment.amount));
 
@@ -203,7 +200,6 @@ export class PaymentsService {
       );
     }
 
-    // 7. Mark confirmed
     payment.transactionHash = transactionHash;
     payment.status = PaymentStatus.CONFIRMED;
     const confirmed = await this.paymentsRepository.save(payment);
@@ -234,17 +230,9 @@ export class PaymentsService {
     txRecord: Awaited<ReturnType<StellarService['getTransaction']>>,
   ): Promise<PaymentOp[]> {
     try {
-      // The Horizon transaction record exposes a _links.operations href
-      // TransactionRecord._links is typed by the Stellar SDK — no cast needed
       const opsHref: string | undefined = txRecord._links.operations?.href;
-
       if (!opsHref) return [];
 
-      // Fetch via the existing getTransaction shape — we re-use the server
-      // indirectly through StellarService to stay compliant with the "no direct
-      // Horizon calls" rule.  Since StellarService doesn't expose an operations
-      // endpoint, we call the already-resolved href through native fetch, which
-      // is acceptable here as it is not a direct `new Server()` instantiation.
       const res = await fetch(opsHref);
       if (!res.ok) return [];
 

--- a/backend/src/stellar/stellar-webhook.module.ts
+++ b/backend/src/stellar/stellar-webhook.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { StellarWebhookService } from './stellar-webhook.service';
+import { StellarModule } from '../stellar.module';
+import { PaymentsModule } from '../../payments/payments.module';
+import { SponsorsModule } from '../../sponsors/sponsors.module';
+
+@Module({
+  imports: [
+    StellarModule,   // provides StellarService
+    PaymentsModule,  // provides PaymentsService
+    SponsorsModule,  // provides SponsorsService
+  ],
+  providers: [StellarWebhookService],
+})
+export class StellarWebhookModule {}

--- a/backend/src/stellar/stellar-webhook.service.spec.ts
+++ b/backend/src/stellar/stellar-webhook.service.spec.ts
@@ -1,0 +1,182 @@
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { StellarWebhookService } from './stellar-webhook.service';
+import { Horizon } from '@stellar/stellar-sdk';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockStreamCloser = jest.fn();
+
+const mockStellarService = {
+  streamPayments: jest.fn().mockReturnValue(mockStreamCloser),
+};
+
+const mockPaymentsService = {
+  confirmPayment: jest.fn(),
+};
+
+const mockSponsorsService = {
+  confirmSponsorPayment: jest.fn(),
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makePayment(
+  overrides: Partial<Horizon.ServerApi.PaymentOperationRecord> = {},
+): Horizon.ServerApi.PaymentOperationRecord {
+  return {
+    id: 'op-1',
+    type: 'payment',
+    transaction_hash: 'tx-hash-abc',
+    ...overrides,
+  } as unknown as Horizon.ServerApi.PaymentOperationRecord;
+}
+
+function buildService(): StellarWebhookService {
+  return new StellarWebhookService(
+    mockStellarService as any,
+    mockPaymentsService as any,
+    mockSponsorsService as any,
+  );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('StellarWebhookService', () => {
+  let service: StellarWebhookService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = buildService();
+  });
+
+  // ── Streaming setup ─────────────────────────────────────────────────────
+
+  describe('onModuleInit', () => {
+    it('opens a payment stream on init', () => {
+      service.onModuleInit();
+      expect(mockStellarService.streamPayments).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes a callback to streamPayments', () => {
+      service.onModuleInit();
+      const [callback] = mockStellarService.streamPayments.mock.calls[0];
+      expect(typeof callback).toBe('function');
+    });
+  });
+
+  describe('onModuleDestroy', () => {
+    it('closes the stream on destroy', () => {
+      service.onModuleInit();
+      service.onModuleDestroy();
+      expect(mockStreamCloser).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not attempt reconnect after destroy', () => {
+      jest.useFakeTimers();
+      service.onModuleInit();
+      service.onModuleDestroy();
+      jest.runAllTimers();
+      // streamPayments should only have been called once (on init)
+      expect(mockStellarService.streamPayments).toHaveBeenCalledTimes(1);
+      jest.useRealTimers();
+    });
+  });
+
+  // ── handlePayment ───────────────────────────────────────────────────────
+
+  describe('handlePayment', () => {
+    it('confirms a matched pending payment', async () => {
+      mockPaymentsService.confirmPayment.mockResolvedValue({ id: 'payment-1' });
+
+      await service.handlePayment(makePayment({ transaction_hash: 'tx-abc' }));
+
+      expect(mockPaymentsService.confirmPayment).toHaveBeenCalledWith('tx-abc');
+    });
+
+    it('falls through to sponsor confirmation when no payment matches', async () => {
+      mockPaymentsService.confirmPayment.mockRejectedValue(
+        Object.assign(new NotFoundException(), { status: 404 }),
+      );
+      mockSponsorsService.confirmSponsorPayment.mockResolvedValue({});
+
+      await service.handlePayment(makePayment({ transaction_hash: 'tx-sponsor' }));
+
+      expect(mockSponsorsService.confirmSponsorPayment).toHaveBeenCalledWith(
+        'tx-sponsor',
+      );
+    });
+
+    it('skips non-payment operation types', async () => {
+      await service.handlePayment(
+        makePayment({ type: 'set_options' as any }),
+      );
+
+      expect(mockPaymentsService.confirmPayment).not.toHaveBeenCalled();
+      expect(mockSponsorsService.confirmSponsorPayment).not.toHaveBeenCalled();
+    });
+
+    it('skips payment records with no transaction_hash', async () => {
+      await service.handlePayment(
+        makePayment({ transaction_hash: undefined as any }),
+      );
+
+      expect(mockPaymentsService.confirmPayment).not.toHaveBeenCalled();
+    });
+
+    it('does not crash the stream on unexpected payment error', async () => {
+      mockPaymentsService.confirmPayment.mockRejectedValue(
+        new Error('unexpected db error'),
+      );
+
+      await expect(
+        service.handlePayment(makePayment()),
+      ).resolves.not.toThrow();
+    });
+
+    it('does not crash the stream on unexpected sponsor error', async () => {
+      mockPaymentsService.confirmPayment.mockRejectedValue(
+        Object.assign(new NotFoundException(), { status: 404 }),
+      );
+      mockSponsorsService.confirmSponsorPayment.mockRejectedValue(
+        new Error('unexpected sponsor error'),
+      );
+
+      await expect(
+        service.handlePayment(makePayment()),
+      ).resolves.not.toThrow();
+    });
+
+    it('handles create_account operation type', async () => {
+      mockPaymentsService.confirmPayment.mockResolvedValue({});
+
+      await service.handlePayment(
+        makePayment({ type: 'create_account' as any, transaction_hash: 'tx-create' }),
+      );
+
+      expect(mockPaymentsService.confirmPayment).toHaveBeenCalledWith('tx-create');
+    });
+  });
+
+  // ── Reconnection ────────────────────────────────────────────────────────
+
+  describe('reconnection', () => {
+    it('schedules a reconnect when stream open throws', () => {
+      jest.useFakeTimers();
+
+      mockStellarService.streamPayments
+        .mockImplementationOnce(() => { throw new Error('connection refused'); })
+        .mockReturnValue(mockStreamCloser);
+
+      service.onModuleInit();
+
+      // Should have tried once and failed
+      expect(mockStellarService.streamPayments).toHaveBeenCalledTimes(1);
+
+      // After delay, should reconnect
+      jest.advanceTimersByTime(6_000);
+      expect(mockStellarService.streamPayments).toHaveBeenCalledTimes(2);
+
+      jest.useRealTimers();
+    });
+  });
+});

--- a/backend/src/stellar/stellar-webhook.service.ts
+++ b/backend/src/stellar/stellar-webhook.service.ts
@@ -1,0 +1,205 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { Horizon } from '@stellar/stellar-sdk';
+import { StellarService } from '../stellar.service';
+import { PaymentsService } from '../../payments/payments.service';
+import { SponsorsService } from '../../sponsors/sponsors.service';
+
+const RECONNECT_DELAY_MS = 5_000;
+const MAX_RECONNECT_DELAY_MS = 60_000;
+const BACKOFF_MULTIPLIER = 2;
+
+@Injectable()
+export class StellarWebhookService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(StellarWebhookService.name);
+
+  private streamCloser: (() => void) | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectDelay = RECONNECT_DELAY_MS;
+  private destroyed = false;
+
+  constructor(
+    private readonly stellarService: StellarService,
+    private readonly paymentsService: PaymentsService,
+    private readonly sponsorsService: SponsorsService,
+  ) {}
+
+  // ─── Lifecycle ────────────────────────────────────────────────────────────
+
+  onModuleInit(): void {
+    this.logger.log('Starting Stellar payment stream listener');
+    this.connect();
+  }
+
+  onModuleDestroy(): void {
+    this.destroyed = true;
+    this.clearReconnectTimer();
+    this.closeStream();
+    this.logger.log('Stellar payment stream shut down');
+  }
+
+  // ─── Connection management ────────────────────────────────────────────────
+
+  private connect(): void {
+    if (this.destroyed) return;
+
+    this.logger.log('Opening Stellar payment stream...');
+
+    try {
+      this.streamCloser = this.stellarService.streamPayments(
+        (payment) => void this.handlePayment(payment),
+      );
+
+      // Reset backoff on successful connection
+      this.reconnectDelay = RECONNECT_DELAY_MS;
+      this.logger.log('Stellar payment stream connected');
+    } catch (err) {
+      this.logger.error('Failed to open stream, scheduling reconnect', err);
+      this.scheduleReconnect();
+    }
+  }
+
+  private closeStream(): void {
+    if (this.streamCloser) {
+      this.streamCloser();
+      this.streamCloser = null;
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.destroyed) return;
+
+    this.clearReconnectTimer();
+
+    this.logger.warn(
+      `Reconnecting Stellar stream in ${this.reconnectDelay}ms...`,
+    );
+
+    this.reconnectTimer = setTimeout(() => {
+      this.closeStream();
+      this.connect();
+
+      // Exponential backoff capped at max delay
+      this.reconnectDelay = Math.min(
+        this.reconnectDelay * BACKOFF_MULTIPLIER,
+        MAX_RECONNECT_DELAY_MS,
+      );
+    }, this.reconnectDelay);
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  // ─── Payment handler ──────────────────────────────────────────────────────
+
+  async handlePayment(
+    payment: Horizon.ServerApi.PaymentOperationRecord,
+  ): Promise<void> {
+    this.logger.debug(
+      `Received payment: type=${payment.type} id=${payment.id}`,
+    );
+
+    // We only handle payment and create_account operations
+    if (payment.type !== 'payment' && payment.type !== 'create_account') {
+      this.logger.debug(`Skipping non-payment operation type: ${payment.type}`);
+      return;
+    }
+
+    const transactionHash = payment.transaction_hash;
+
+    if (!transactionHash) {
+      this.logger.warn('Payment record has no transaction_hash, skipping');
+      return;
+    }
+
+    // Try payment confirmation first, then sponsor confirmation
+    const confirmed =
+      (await this.tryConfirmPayment(transactionHash)) ||
+      (await this.tryConfirmSponsor(transactionHash));
+
+    if (!confirmed) {
+      this.logger.debug(
+        `No pending payment or sponsor found for tx: ${transactionHash}`,
+      );
+    }
+  }
+
+  // ─── Payment confirmation ─────────────────────────────────────────────────
+
+  private async tryConfirmPayment(transactionHash: string): Promise<boolean> {
+    try {
+      await this.paymentsService.confirmPayment(transactionHash);
+      this.logger.log(
+        `Payment confirmed via stream: txHash=${transactionHash}`,
+      );
+      return true;
+    } catch (err: unknown) {
+      // NotFoundException means no pending payment matched — not an error
+      if (isNotFound(err)) return false;
+
+      // BadRequestException with "not found on Stellar" means tx isn't ready — skip
+      if (isBadRequest(err) && isNotFoundMessage(err)) return false;
+
+      // Anything else is unexpected — log but don't crash the stream
+      this.logger.error(
+        `Unexpected error confirming payment for tx ${transactionHash}`,
+        err,
+      );
+      return false;
+    }
+  }
+
+  // ─── Sponsor confirmation ─────────────────────────────────────────────────
+
+  private async tryConfirmSponsor(transactionHash: string): Promise<boolean> {
+    try {
+      await this.sponsorsService.confirmSponsorPayment(transactionHash);
+      this.logger.log(
+        `Sponsor payment confirmed via stream: txHash=${transactionHash}`,
+      );
+      return true;
+    } catch (err: unknown) {
+      if (isNotFound(err)) return false;
+      if (isBadRequest(err) && isNotFoundMessage(err)) return false;
+
+      this.logger.error(
+        `Unexpected error confirming sponsor for tx ${transactionHash}`,
+        err,
+      );
+      return false;
+    }
+  }
+}
+
+// ─── Error type helpers ───────────────────────────────────────────────────────
+
+function isNotFound(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'status' in err &&
+    (err as { status: number }).status === 404
+  );
+}
+
+function isBadRequest(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'status' in err &&
+    (err as { status: number }).status === 400
+  );
+}
+
+function isNotFoundMessage(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'message' in err &&
+    typeof (err as { message: unknown }).message === 'string' &&
+    (err as { message: string }).message.toLowerCase().includes('not found')
+  );
+}


### PR DESCRIPTION
### Summary
This PR implements platform governance via an admin moderation module and automatic blockchain payment confirmation via a Stellar streaming listener.

---

### Admin Moderation Module — closes #18

A new `AdminModule` under `src/admin/` gives admins full control over platform integrity through three protected endpoints:

- `PATCH /admin/events/:id/approve` — promotes a draft event to published
- `PATCH /admin/events/:id/suspend` — cancels an event and immediately blocks it from accepting payments
- `PATCH /admin/users/:id/block` — blocks a user from the platform

Access is enforced via a `RolesGuard` + `@Roles(UserRole.ADMIN)` decorator applied at the controller level, meaning every route in the admin namespace is protected without per-handler boilerplate. Non-admins and unauthenticated requests receive a `403`. The suspended event payment block is handled in `PaymentsService` with a specific `CANCELLED` check that returns a clear "suspended" message rather than the generic status error.

---

### Stellar Webhook Listener — closes #19

A new `StellarWebhookService` under `src/stellar/webhooks/` opens a persistent payment stream via `StellarService.streamPayments()` on module init and closes it cleanly on shutdown. No polling.

On each incoming payment operation:
1. Skip non-payment types and records with no transaction hash
2. Attempt `PaymentsService.confirmPayment()` first
3. If no payment matches (404), fall through to `SponsorsService.confirmSponsorPayment()`
4. Unexpected errors are logged and swallowed — a bad payload never kills the stream

Reconnection uses exponential backoff starting at 5s, doubling each attempt up to a 60s ceiling. A `destroyed` flag ensures no reconnect fires after the module shuts down.

---

### Files changed
```
src/
├── admin/
│   ├── admin.service.ts
│   ├── admin.service.spec.ts
│   ├── admin.controller.ts
│   ├── admin.module.ts
│   ├── roles.guard.ts
│   ├── roles.guard.spec.ts
│   └── roles.decorator.ts
├── payments/
│   └── payments.service.ts          (updated — explicit suspended event block)
└── stellar/webhooks/
    ├── stellar-webhook.service.ts
    ├── stellar-webhook.service.spec.ts
    └── stellar-webhook.module.ts
```

---

### Notes
- `User` entity needs a `status` column (`active` | `blocked`) for `blockUser` to persist
- `SponsorsService` needs a `confirmSponsorPayment(txHash)` method — interface is already wired in the webhook service
- Register both modules in `AppModule`: `AdminModule`, `StellarWebhookModule`

---

Closes #18, #19