### PR TITLE
Fixed the Security — Swagger UI Is Exposed in Production with No Envi…

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -22,14 +22,20 @@ async function bootstrap() {
     }),
   );
 
-  const config = new DocumentBuilder()
-    .setTitle('API')
-    .setVersion('1.0')
-    .addBearerAuth()
-    .build();
+  // ── Swagger security: only expose in non-production environments ────────
+  if (process.env.NODE_ENV !== 'production') {
+    const config = new DocumentBuilder()
+      .setTitle('Lumentix API')
+      .setDescription('Internal development documentation')
+      .setVersion('1.0')
+      .addBearerAuth()
+      .build();
 
-  const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api', app, document);
+    const document = SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup('api', app, document);
+
+    console.log('🔍 Swagger available at /api (development only)');
+  }
 
   await app.listen(process.env.PORT ?? 3000);
 }


### PR DESCRIPTION
Close: #100 
Fix: #118
Changes made:

Wrapped the Swagger configuration and setup in an if (process.env.NODE_ENV !== 'production') check
Updated the title to "Lumentix API" and added a description for internal development documentation
Added a console log to indicate Swagger is available only in development mode
The Swagger UI is now completely disabled in production
Security improvements:
1. Swagger UI and full API documentation are no longer exposed in production
2. Endpoint paths, request/response schemas, and authentication details remain hidden from external parties
3. Development environments still have full Swagger access for debugging and API exploration
4. Production deployments are protected from schema-based attack reconnaissance