### PR TITLE
feat(backend): implement notification preference system with opt-out …

### DIFF
--- a/backend/src/database/migrations/1711380000000-AddNotificationPreferencesToUser.ts
+++ b/backend/src/database/migrations/1711380000000-AddNotificationPreferencesToUser.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddNotificationPreferencesToUser1711380000000
+  implements MigrationInterface
+{
+  name = 'AddNotificationPreferencesToUser1711380000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD "notificationPreferences" jsonb NOT NULL DEFAULT '{"ticketIssued": true, "paymentFailed": true, "eventCancelled": true, "sponsorConfirmed": true, "eventCompleted": true}'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" DROP COLUMN "notificationPreferences"`,
+    );
+  }
+}

--- a/backend/src/notifications/notification.module.ts
+++ b/backend/src/notifications/notification.module.ts
@@ -1,8 +1,9 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { BullModule } from '@nestjs/bull';
 import { NotificationService } from './notification.service';
 import { NotificationProcessor } from './notification.processor';
 import { MailerModule } from '../mailer/mailer.module';
+import { UsersModule } from '../users/users.module';
 
 @Module({
   imports: [
@@ -10,6 +11,7 @@ import { MailerModule } from '../mailer/mailer.module';
       name: 'notifications', // Must match the string in @Processor
     }),
     MailerModule,
+    forwardRef(() => UsersModule),
   ],
   providers: [NotificationService, NotificationProcessor],
   exports: [NotificationService], // Allow Payments/Sponsors to import this

--- a/backend/src/notifications/notification.processor.ts
+++ b/backend/src/notifications/notification.processor.ts
@@ -6,16 +6,52 @@ import {
   OnQueueFailed,
 } from '@nestjs/bull';
 import { Job } from 'bull';
-import { Logger } from '@nestjs/common';
+import { Logger, Inject, forwardRef } from '@nestjs/common';
 import { MailerService } from '../mailer/mailer.service';
+import { UsersService } from '../users/users.service';
 
 @Processor('notifications')
 export class NotificationProcessor {
   private readonly logger = new Logger(NotificationProcessor.name);
-  constructor(private readonly mailerService: MailerService) {}
+  constructor(
+    private readonly mailerService: MailerService,
+    @Inject(forwardRef(() => UsersService))
+    private readonly usersService: UsersService,
+  ) {}
+
+  private async shouldSkip(job: Job, preferenceKey: string): Promise<boolean> {
+    const criticalJobs = ['sendRefundEmail', 'eventCancelled']; // cancellation is critical
+    if (criticalJobs.includes(job.name)) {
+      return false;
+    }
+
+    if (!job.data.userId) {
+      this.logger.warn(`Job ${job.id} (${job.name}) missing userId, sending anyway.`);
+      return false;
+    }
+
+    try {
+      const user = await this.usersService.findById(job.data.userId);
+      // We need the raw entity to access notificationPreferences if findById sanitizes it
+      // Actually UsersService.findById returns sanitized user.
+      // Let's check if notificationPreferences is included in sanitized user.
+      const prefs = (user as any).notificationPreferences;
+      
+      if (prefs && prefs[preferenceKey] === false) {
+        this.logger.log(`Skipping ${job.name} email for user ${job.data.userId} — opted out`);
+        return true;
+      }
+    } catch (error) {
+      this.logger.error(`Failed to check preferences for user ${job.data.userId}: ${error.message}`);
+    }
+    
+    return false;
+  }
 
   @Process('sendTicketEmail')
   async handleTicketEmail(job: Job) {
+    if (await this.shouldSkip(job, 'ticketIssued')) return;
+
     this.logger.log(`Sending ticket email for job ${job.id}...`);
     const { email, ticketId, eventName } = job.data;
     const subject = `Your ticket for ${eventName}`;
@@ -32,6 +68,7 @@ export class NotificationProcessor {
 
   @Process('sendRefundEmail')
   async handleRefundEmail(job: Job) {
+    // Refund is critical, no skip check
     this.logger.log(`Sending refund email for job ${job.id}...`);
     const { email, amount, refundId } = job.data;
     const subject = 'Your refund has been processed';
@@ -47,6 +84,8 @@ export class NotificationProcessor {
 
   @Process('sendSponsorEmail')
   async handleSponsorEmail(job: Job) {
+    if (await this.shouldSkip(job, 'sponsorConfirmed')) return;
+
     this.logger.log(`Sending sponsor confirmation for job ${job.id}...`);
     const { email, sponsorName } = job.data;
     const subject = 'Sponsorship confirmed';

--- a/backend/src/notifications/notification.service.ts
+++ b/backend/src/notifications/notification.service.ts
@@ -9,6 +9,7 @@ export class NotificationService {
   ) {}
 
   async queueTicketEmail(data: {
+    userId: string;
     email: string;
     ticketId: string;
     eventName: string;
@@ -24,6 +25,7 @@ export class NotificationService {
   }
 
   async queueRefundEmail(data: {
+    userId: string;
     email: string;
     amount: number;
     refundId: string;
@@ -31,7 +33,11 @@ export class NotificationService {
     await this.notificationQueue.add('sendRefundEmail', data, { attempts: 3 });
   }
 
-  async queueSponsorEmail(data: { email: string; sponsorName: string }) {
+  async queueSponsorEmail(data: {
+    userId: string;
+    email: string;
+    sponsorName: string;
+  }) {
     await this.notificationQueue.add('sendSponsorEmail', data, { attempts: 3 });
   }
 }

--- a/backend/src/tickets/tickets.service.ts
+++ b/backend/src/tickets/tickets.service.ts
@@ -154,6 +154,7 @@ export class TicketsService {
     });
     if (user && event) {
       await this.notificationService.queueTicketEmail({
+        userId: user.id,
         email: user.email,
         ticketId: saved.id,
         eventName: event.title,

--- a/backend/src/users/dto/update-notification-preferences.dto.ts
+++ b/backend/src/users/dto/update-notification-preferences.dto.ts
@@ -1,0 +1,29 @@
+import { IsBoolean, IsOptional } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateNotificationPreferencesDto {
+  @ApiPropertyOptional()
+  @IsBoolean()
+  @IsOptional()
+  ticketIssued?: boolean;
+
+  @ApiPropertyOptional()
+  @IsBoolean()
+  @IsOptional()
+  paymentFailed?: boolean;
+
+  @ApiPropertyOptional()
+  @IsBoolean()
+  @IsOptional()
+  eventCancelled?: boolean;
+
+  @ApiPropertyOptional()
+  @IsBoolean()
+  @IsOptional()
+  sponsorConfirmed?: boolean;
+
+  @ApiPropertyOptional()
+  @IsBoolean()
+  @IsOptional()
+  eventCompleted?: boolean;
+}

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -54,6 +54,18 @@ export class User {
   @Column({ type: 'timestamptz', nullable: true, default: null })
   balancesUpdatedAt: Date | null;
 
+  @Column({
+    type: 'jsonb',
+    default: {
+      ticketIssued: true,
+      paymentFailed: true,
+      eventCancelled: true,
+      sponsorConfirmed: true,
+      eventCompleted: true,
+    },
+  })
+  notificationPreferences: Record<string, boolean>;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   Param,
+  Patch,
   Post,
   Query,
   Req,
@@ -20,6 +21,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { AuthenticatedRequest } from '../common/interfaces/authenticated-request.interface';
 import { Roles } from 'src/admin/roles.decorator';
 import { UserRole } from './enums/user-role.enum';
+import { UpdateNotificationPreferencesDto } from './dto/update-notification-preferences.dto';
 
 @ApiTags('Users')
 @UseGuards(JwtAuthGuard)
@@ -31,6 +33,26 @@ export class UsersController {
   @Roles(UserRole.ADMIN)
   async create(@Body() createUserDto: CreateUserDto) {
     return this.usersService.createUser(createUserDto);
+  }
+
+  @Get('me')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get current user profile' })
+  async getProfile(@Req() req: AuthenticatedRequest) {
+    return this.usersService.findById(req.user.id);
+  }
+
+  @Patch('me/notification-preferences')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update notification preferences' })
+  async updateNotificationPreferences(
+    @Req() req: AuthenticatedRequest,
+    @Body() updateDto: UpdateNotificationPreferencesDto,
+  ) {
+    return this.usersService.updateNotificationPreferences(
+      req.user.id,
+      updateDto,
+    );
   }
 
   @Get(':id')

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -20,6 +20,7 @@ import {
   PortfolioEntryDto,
   PortfolioResponseDto,
 } from './dto/portfolio-response.dto';
+import { UpdateNotificationPreferencesDto } from './dto/update-notification-preferences.dto';
 
 const BCRYPT_SALT_ROUNDS = 10;
 
@@ -165,6 +166,22 @@ export class UsersService {
       totalValue: parseFloat(totalValue.toFixed(2)),
       breakdown,
     };
+  }
+
+  async updateNotificationPreferences(
+    userId: string,
+    prefs: UpdateNotificationPreferencesDto,
+  ): Promise<Omit<User, 'passwordHash'>> {
+    const user = await this.usersRepository.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new NotFoundException(`User with id ${userId} not found`);
+    }
+    user.notificationPreferences = {
+      ...(user.notificationPreferences || {}),
+      ...prefs,
+    };
+    const saved = await this.usersRepository.save(user);
+    return this.sanitize(saved);
   }
 
   private sanitize(user: User): Omit<User, 'passwordHash'> {


### PR DESCRIPTION
Summary of Changes
   - User Entity: Added a notification Preferences JSONB column with default values for ticketIssued, paymentFailed, eventCancelled,
     sponsorConfirmed, and eventCompleted.
   - API Endpoints:
     - GET /users/me: Returns the current user's profile, including their notification preferences.
     - PATCH /users/me/notification-preferences: Allows users to perform partial updates to their notification preferences.
   - Notification Logic:
     - Updated NotificationService to include userId in all queued notification jobs.
     - Updated NotificationProcessor to check the user's preferences before sending emails.
     - Hardcoded critical emails (refunds and cancellations) to bypass preference checks, ensuring they are always sent.
   - Database: Created a new TypeORM migration in backend/src/database/migrations to add the notificationPreferences column.
   - DTOs: Created UpdateNotificationPreferencesDto for type-safe preference updates.

Closes #169 