### PR TITLE
feat: Notification Emails Are Never Triggered After Ticket Issuance o…

### DIFF
--- a/backend/src/payments/refunds/refund.module.ts
+++ b/backend/src/payments/refunds/refund.module.ts
@@ -7,6 +7,7 @@ import { User } from '../../users/entities/user.entity';
 import { StellarModule } from '../../stellar/stellar.module';
 import { AuditModule } from '../../audit/audit.module';
 import { EscrowModule } from '../escrow.module';
+import { NotificationModule } from '../../notifications/notification.module';
 import { RefundService } from './refund.service';
 import { RefundController } from './refund.controller';
 
@@ -16,6 +17,7 @@ import { RefundController } from './refund.controller';
     StellarModule,
     AuditModule,
     EscrowModule,
+    NotificationModule,
   ],
   providers: [RefundService],
   controllers: [RefundController],

--- a/backend/src/payments/refunds/refund.service.ts
+++ b/backend/src/payments/refunds/refund.service.ts
@@ -13,6 +13,7 @@ import { User } from '../../users/entities/user.entity';
 import { StellarService } from '../../stellar/stellar.service';
 import { AuditService } from '../../audit/audit.service';
 import { EscrowService } from '../services/escrow.service';
+import { NotificationService } from '../../notifications/notification.service';
 import { RefundResultDto } from './dto/refund-result.dto';
 
 @Injectable()
@@ -35,6 +36,7 @@ export class RefundService {
     private readonly stellarService: StellarService,
     private readonly auditService: AuditService,
     private readonly escrowService: EscrowService,
+    private readonly notificationService: NotificationService,
   ) {}
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -151,7 +153,7 @@ export class RefundService {
       // 2. Resolve the user's Stellar public key
       const user = await this.usersRepository.findOne({
         where: { id: payment.userId },
-        select: ['id', 'stellarPublicKey'],
+        select: ['id', 'email', 'stellarPublicKey'],
       });
 
       if (!user) {
@@ -203,6 +205,14 @@ export class RefundService {
         `Refund issued: paymentId=${payment.id} user=${payment.userId} ` +
           `amount=${amount} ${payment.currency} txHash=${txHash}`,
       );
+
+      if (user.email) {
+        await this.notificationService.queueRefundEmail({
+          email: user.email,
+          amount,
+          refundId: payment.id,
+        });
+      }
 
       return { ...base, success: true, transactionHash: txHash };
     } catch (error: unknown) {

--- a/backend/src/tickets/tickets.module.ts
+++ b/backend/src/tickets/tickets.module.ts
@@ -9,6 +9,7 @@ import { TicketsService } from './tickets.service';
 import { TicketsController } from './tickets.controller';
 import { PaymentsModule } from '../payments/payments.module';
 import { StellarModule } from '../stellar/stellar.module';
+import { NotificationModule } from '../notifications/notification.module';
 import { VerificationController } from './verification/verification.controller';
 
 @Module({
@@ -17,6 +18,7 @@ import { VerificationController } from './verification/verification.controller';
     TypeOrmModule.forFeature([TicketEntity, Event, User]),
     PaymentsModule,
     StellarModule,
+    NotificationModule,
   ],
   providers: [TicketsService, TicketSigningService],
   controllers: [TicketsController, VerificationController],


### PR DESCRIPTION
…r Payment Confirmation
## Overview
Notification emails were never sent after ticket issuance or refund processing because NotificationService was not
available in the relevant modules/services.

## Changes:
- tickets.module.ts — import NotificationModule so NotificationService is resolvable in TicketsService
- refund.module.ts — import NotificationModule so NotificationService is resolvable in RefundService
- refund.service.ts — inject NotificationService, add email to user select, and call queueRefundEmail() on 
successful refund

## Behaviour after fix:
- Users receive a ticket confirmation email when issueTicket() completes successfully
- Users receive a refund notification email when processSingleRefund() completes successfully

## Closes: #98 