### PR TITLE
feat: resolve issues 165, 166, 167, 168

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,6 +21,10 @@ JWT_SECRET=your-super-secret-key
 
 # ─── Payment Intent Expiry ────────────────────────────────────────────────
 PAYMENT_INTENT_TTL_MINUTES=30
+
+# ─── Audit Log Retention ──────────────────────────────────────────────────
+# Number of days to retain audit logs. Logs older than this are deleted daily at midnight.
+AUDIT_RETENTION_DAYS=90
 JWT_EXPIRES_IN = 7d
 
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org

--- a/backend/src/audit/audit.controller.ts
+++ b/backend/src/audit/audit.controller.ts
@@ -16,6 +16,7 @@ import {
 import { AuditService } from './audit.service';
 import { AuditLog } from './entities/audit-log.entity';
 import { PaginationDto } from '../common/pagination/dto/pagination.dto';
+import { ListAuditLogsDto } from './dto/list-audit-logs.dto';
 import { paginate } from '../common/pagination/pagination.helper';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../admin/roles.guard';
@@ -32,26 +33,43 @@ export class AuditController {
   constructor(private readonly auditService: AuditService) {}
 
   @Get()
-  @ApiOperation({ summary: 'Get audit logs', description: 'Admin-only. Returns paginated list of system audit logs.' })
+  @ApiOperation({ summary: 'Get audit logs', description: 'Admin-only. Returns paginated list of system audit logs with optional filters.' })
   @ApiResponse({ status: 200, description: 'List of logs' })
   @ApiResponse({ status: 403, description: 'Forbidden' })
-  async getAuditLogs(@Query() paginationDto: PaginationDto) {
-    const queryBuilder =
-      this.auditService.auditLogRepository.createQueryBuilder('audit');
-    return await paginate(queryBuilder, paginationDto, 'audit');
+  async getAuditLogs(@Query() dto: ListAuditLogsDto) {
+    const qb = this.auditService.getQueryBuilder();
+
+    if (dto.action) {
+      qb.andWhere('audit.action = :action', { action: dto.action });
+    }
+
+    if (dto.userId) {
+      qb.andWhere('audit.userId = :userId', { userId: dto.userId });
+    }
+
+    if (dto.from) {
+      qb.andWhere('audit.createdAt >= :from', { from: new Date(dto.from) });
+    }
+
+    if (dto.to) {
+      qb.andWhere('audit.createdAt <= :to', { to: new Date(dto.to) });
+    }
+
+    return paginate(qb, dto, 'audit');
   }
 
-
-  @Get(':id')
-  @ApiOperation({ summary: 'Get audit log by ID', description: 'Admin-only. Retrieves details for a specific log entry.' })
-  @ApiResponse({ status: 200, description: 'Log found', type: AuditLog })
-  @ApiResponse({ status: 404, description: 'Log not found' })
-  async getAuditLogById(@Param('id') id: string): Promise<AuditLog> {
-    const log = await this.auditService.auditLogRepository.findOneBy({ id });
-    if (!log) {
-      throw new NotFoundException('Audit log not found');
-    }
-    return log;
+  @Get('user/:userId')
+  @ApiOperation({ summary: 'Get audit logs for a specific user', description: 'Admin-only. Returns paginated audit logs scoped to a single user.' })
+  @ApiResponse({ status: 200, description: 'List of logs for user' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  async getAuditLogsForUser(
+    @Param('userId') userId: string,
+    @Query() paginationDto: PaginationDto,
+  ) {
+    const qb = this.auditService.getQueryBuilder()
+      .where('audit.userId = :userId', { userId })
+      .orderBy('audit.createdAt', 'DESC');
+    return paginate(qb, paginationDto, 'audit');
   }
 
   @Get('export')
@@ -61,9 +79,8 @@ export class AuditController {
     @Query() paginationDto: PaginationDto,
     @Res() res: Response,
   ) {
-    const queryBuilder =
-      this.auditService.auditLogRepository.createQueryBuilder('audit');
-    const paginated = await paginate(queryBuilder, paginationDto, 'audit');
+    const qb = this.auditService.getQueryBuilder();
+    const paginated = await paginate(qb, paginationDto, 'audit');
     const logs = paginated.data;
 
     const header = [
@@ -96,5 +113,17 @@ export class AuditController {
       'attachment; filename="audit_logs.csv"',
     );
     res.send(csv);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get audit log by ID', description: 'Admin-only. Retrieves details for a specific log entry.' })
+  @ApiResponse({ status: 200, description: 'Log found', type: AuditLog })
+  @ApiResponse({ status: 404, description: 'Log not found' })
+  async getAuditLogById(@Param('id') id: string): Promise<AuditLog> {
+    const log = await this.auditService.auditLogRepository.findOneBy({ id });
+    if (!log) {
+      throw new NotFoundException('Audit log not found');
+    }
+    return log;
   }
 }

--- a/backend/src/audit/audit.module.ts
+++ b/backend/src/audit/audit.module.ts
@@ -1,11 +1,18 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScheduleModule } from '@nestjs/schedule';
+import { ConfigModule } from '@nestjs/config';
 import { AuditLog } from './entities/audit-log.entity';
 import { AuditService } from './audit.service';
+import { AuditRetentionJob } from './jobs/audit-retention.job';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([AuditLog])],
-  providers: [AuditService],
+  imports: [
+    TypeOrmModule.forFeature([AuditLog]),
+    ScheduleModule.forRoot(),
+    ConfigModule,
+  ],
+  providers: [AuditService, AuditRetentionJob],
   exports: [AuditService],
 })
 export class AuditModule {}

--- a/backend/src/audit/audit.service.ts
+++ b/backend/src/audit/audit.service.ts
@@ -19,6 +19,10 @@ export class AuditService {
     public readonly auditLogRepository: Repository<AuditLog>,
   ) {}
 
+  getQueryBuilder() {
+    return this.auditLogRepository.createQueryBuilder('audit');
+  }
+
   async log(entry: AuditLogEntry): Promise<AuditLog> {
     const record = this.auditLogRepository.create({
       action: entry.action,

--- a/backend/src/audit/dto/list-audit-logs.dto.ts
+++ b/backend/src/audit/dto/list-audit-logs.dto.ts
@@ -1,0 +1,25 @@
+import { IsOptional, IsString, IsDateString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { PaginationDto } from '../../common/pagination/dto/pagination.dto';
+
+export class ListAuditLogsDto extends PaginationDto {
+  @ApiPropertyOptional({ example: 'PAYMENT_CONFIRMED', description: 'Filter by audit action type' })
+  @IsString()
+  @IsOptional()
+  action?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by user ID' })
+  @IsString()
+  @IsOptional()
+  userId?: string;
+
+  @ApiPropertyOptional({ example: '2025-01-01', description: 'Filter logs created on or after this date' })
+  @IsDateString()
+  @IsOptional()
+  from?: string;
+
+  @ApiPropertyOptional({ example: '2025-12-31', description: 'Filter logs created on or before this date' })
+  @IsDateString()
+  @IsOptional()
+  to?: string;
+}

--- a/backend/src/audit/jobs/audit-retention.job.ts
+++ b/backend/src/audit/jobs/audit-retention.job.ts
@@ -1,0 +1,35 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { AuditLog } from '../entities/audit-log.entity';
+
+@Injectable()
+export class AuditRetentionJob {
+  private readonly logger = new Logger(AuditRetentionJob.name);
+
+  constructor(
+    @InjectRepository(AuditLog)
+    private readonly repo: Repository<AuditLog>,
+    private readonly config: ConfigService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async deleteOldLogs() {
+    const retentionDays = this.config.get<number>('AUDIT_RETENTION_DAYS') ?? 90;
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - retentionDays);
+
+    const result = await this.repo
+      .createQueryBuilder()
+      .delete()
+      .from(AuditLog)
+      .where('createdAt < :cutoff', { cutoff })
+      .execute();
+
+    this.logger.log(
+      `Audit retention: deleted ${result.affected ?? 0} logs older than ${retentionDays} days`,
+    );
+  }
+}

--- a/backend/src/events/events.module.ts
+++ b/backend/src/events/events.module.ts
@@ -5,9 +5,16 @@ import { EventsService } from './events.service';
 import { EventsController } from './events.controller';
 import { EventStateService } from './state/event-state.service';
 import { TicketsModule } from '../tickets/tickets.module';
+import { NotificationModule } from '../notifications/notification.module';
+import { User } from '../users/entities/user.entity';
+import { TicketEntity } from '../tickets/entities/ticket.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Event]), forwardRef(() => TicketsModule)],
+  imports: [
+    TypeOrmModule.forFeature([Event, User, TicketEntity]),
+    forwardRef(() => TicketsModule),
+    NotificationModule,
+  ],
   controllers: [EventsController],
   providers: [EventsService, EventStateService],
   exports: [EventsService],

--- a/backend/src/events/events.service.ts
+++ b/backend/src/events/events.service.ts
@@ -1,15 +1,18 @@
 import {
-  ForbiddenException, // ← add
+  ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, Like, FindOptionsWhere } from 'typeorm';
-import { Event } from './entities/event.entity';
+import { Event, EventStatus } from './entities/event.entity';
 import { CreateEventDto } from './dto/create-event.dto';
 import { UpdateEventDto } from './dto/update-event.dto';
 import { ListEventsDto } from './dto/list-events.dto';
 import { EventStateService } from './state/event-state.service';
+import { NotificationService } from '../notifications/notification.service';
+import { User } from '../users/entities/user.entity';
+import { TicketEntity } from '../tickets/entities/ticket.entity';
 
 export interface PaginatedResult<T> {
   data: T[];
@@ -24,7 +27,12 @@ export class EventsService {
   constructor(
     @InjectRepository(Event)
     private readonly eventRepository: Repository<Event>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(TicketEntity)
+    private readonly ticketRepository: Repository<TicketEntity>,
     private readonly eventStateService: EventStateService,
+    private readonly notificationService: NotificationService,
   ) {}
 
   async createEvent(dto: CreateEventDto, organizerId: string): Promise<Event> {
@@ -40,7 +48,7 @@ export class EventsService {
   async updateEvent(
     id: string,
     dto: UpdateEventDto,
-    callerId: string, // ← add
+    callerId: string,
   ): Promise<Event> {
     const event = await this.getEventById(id);
 
@@ -52,6 +60,8 @@ export class EventsService {
     if (dto.status !== undefined && dto.status !== event.status) {
       this.eventStateService.validateTransition(event.status, dto.status);
     }
+
+    const previousStatus = event.status;
 
     const updates: Partial<Event> = {
       ...(dto.title !== undefined && { title: dto.title }),
@@ -67,11 +77,16 @@ export class EventsService {
     };
 
     Object.assign(event, updates);
-    return this.eventRepository.save(event);
+    const saved = await this.eventRepository.save(event);
+
+    if (dto.status !== undefined && dto.status !== previousStatus) {
+      this.queueLifecycleEmail(saved).catch(() => undefined);
+    }
+
+    return saved;
   }
 
   async deleteEvent(id: string, callerId: string): Promise<void> {
-    // ← add callerId
     const event = await this.getEventById(id);
 
     // ── Ownership check ────────────────────────────────────────────────────
@@ -113,5 +128,46 @@ export class EventsService {
       limit,
       totalPages: Math.ceil(total / limit),
     };
+  }
+
+  private async queueLifecycleEmail(event: Event): Promise<void> {
+    if (event.status === EventStatus.CANCELLED) {
+      const tickets = await this.ticketRepository.find({
+        where: { eventId: event.id },
+      });
+
+      const ownerIds = [...new Set(tickets.map((t) => t.ownerId))];
+      if (ownerIds.length === 0) return;
+
+      const users = await this.userRepository.findByIds(ownerIds);
+      const emails = users.map((u) => u.email).filter(Boolean);
+      if (emails.length === 0) return;
+
+      await this.notificationService.queueEventCancelledEmail({
+        emails,
+        eventTitle: event.title,
+        refundInfo: 'A refund will be processed for eligible tickets.',
+      });
+    } else if (event.status === EventStatus.PUBLISHED) {
+      const organizer = await this.userRepository.findOne({
+        where: { id: event.organizerId },
+      });
+      if (!organizer) return;
+
+      await this.notificationService.queueEventPublishedEmail({
+        email: organizer.email,
+        eventTitle: event.title,
+      });
+    } else if (event.status === EventStatus.COMPLETED) {
+      const organizer = await this.userRepository.findOne({
+        where: { id: event.organizerId },
+      });
+      if (!organizer) return;
+
+      await this.notificationService.queueEventCompletedEmail({
+        email: organizer.email,
+        eventTitle: event.title,
+      });
+    }
   }
 }

--- a/backend/src/notifications/notification.processor.ts
+++ b/backend/src/notifications/notification.processor.ts
@@ -98,6 +98,94 @@ export class NotificationProcessor {
     await this.mailerService.send(email, subject, html);
   }
 
+  @Process('sendSponsorConfirmedEmail')
+  async handleSponsorConfirmedEmail(job: Job) {
+    this.logger.log(`Sending sponsor confirmed email for job ${job.id}...`);
+    const { email, sponsorName, eventTitle, amount, currency, transactionHash } = job.data;
+    const subject = `Sponsorship Confirmed: ${eventTitle}`;
+    const html = `
+      <div style="font-family: Arial, sans-serif;">
+        <h2>Your Sponsorship Has Been Confirmed</h2>
+        <p>Thank you, <strong>${sponsorName}</strong>, for sponsoring <strong>${eventTitle}</strong>!</p>
+        <p>Amount: <strong>${amount} ${currency}</strong></p>
+        <p>Transaction: <strong>${transactionHash}</strong></p>
+      </div>
+    `;
+    await this.mailerService.send(email, subject, html);
+    return { sent: true };
+  }
+
+  @Process('sendPaymentFailedEmail')
+  async handlePaymentFailedEmail(job: Job) {
+    // Payment failure is critical, no skip check
+    this.logger.log(`Sending payment failed email for job ${job.id}...`);
+    const { email, eventTitle, amount, currency, reason } = job.data;
+    const subject = `Payment Failed: ${eventTitle}`;
+    const html = `
+      <div style="font-family: Arial, sans-serif;">
+        <h2>Payment Could Not Be Processed</h2>
+        <p>Your payment of <strong>${amount} ${currency}</strong> for <strong>${eventTitle}</strong> could not be confirmed.</p>
+        <p>Reason: <strong>${reason}</strong></p>
+        <p>Please try again or contact support if the issue persists.</p>
+      </div>
+    `;
+    await this.mailerService.send(email, subject, html);
+    return { sent: true };
+  }
+
+  @Process('sendEventCancelledEmail')
+  async handleEventCancelledEmail(job: Job<{ emails: string[]; eventTitle: string; refundInfo: string }>) {
+    // Cancellation is critical, no skip check
+    this.logger.log(`Sending event cancelled emails for job ${job.id}...`);
+    const { emails, eventTitle, refundInfo } = job.data;
+    const subject = `Event Cancelled: ${eventTitle}`;
+    const html = `
+      <div style="font-family: Arial, sans-serif;">
+        <h2>Event Cancelled: ${eventTitle}</h2>
+        <p>We regret to inform you that the event <strong>${eventTitle}</strong> has been cancelled.</p>
+        <p>${refundInfo}</p>
+      </div>
+    `;
+    for (const email of emails) {
+      await this.mailerService.send(email, subject, html);
+    }
+    return { sent: true, count: emails.length };
+  }
+
+  @Process('sendEventPublishedEmail')
+  async handleEventPublishedEmail(job: Job) {
+    if (await this.shouldSkip(job, 'eventPublished')) return;
+
+    this.logger.log(`Sending event published email for job ${job.id}...`);
+    const { email, eventTitle } = job.data;
+    const subject = `Your Event is Live: ${eventTitle}`;
+    const html = `
+      <div style="font-family: Arial, sans-serif;">
+        <h2>Your Event is Now Live!</h2>
+        <p>Congratulations! Your event <strong>${eventTitle}</strong> has been published and is now accepting registrations.</p>
+      </div>
+    `;
+    await this.mailerService.send(email, subject, html);
+    return { sent: true };
+  }
+
+  @Process('sendEventCompletedEmail')
+  async handleEventCompletedEmail(job: Job) {
+    if (await this.shouldSkip(job, 'eventCompleted')) return;
+
+    this.logger.log(`Sending event completed email for job ${job.id}...`);
+    const { email, eventTitle } = job.data;
+    const subject = `Event Completed: ${eventTitle}`;
+    const html = `
+      <div style="font-family: Arial, sans-serif;">
+        <h2>Event Completed: ${eventTitle}</h2>
+        <p>Your event <strong>${eventTitle}</strong> has been marked as completed. Thank you for hosting on Lumentix!</p>
+      </div>
+    `;
+    await this.mailerService.send(email, subject, html);
+    return { sent: true };
+  }
+
   // Monitor status
   @OnQueueActive()
   onActive(job: Job) {

--- a/backend/src/notifications/notification.service.ts
+++ b/backend/src/notifications/notification.service.ts
@@ -40,4 +40,47 @@ export class NotificationService {
   }) {
     await this.notificationQueue.add('sendSponsorEmail', data, { attempts: 3 });
   }
+
+  async queueSponsorConfirmedEmail(data: {
+    email: string;
+    sponsorName: string;
+    eventTitle: string;
+    amount: number;
+    currency: string;
+    transactionHash: string;
+  }) {
+    await this.notificationQueue.add('sendSponsorConfirmedEmail', data, { attempts: 3 });
+  }
+
+  async queuePaymentFailedEmail(data: {
+    email: string;
+    eventTitle: string;
+    amount: number;
+    currency: string;
+    reason: string;
+  }) {
+    await this.notificationQueue.add('sendPaymentFailedEmail', data, { attempts: 3 });
+  }
+
+  async queueEventCancelledEmail(data: {
+    emails: string[];
+    eventTitle: string;
+    refundInfo: string;
+  }) {
+    await this.notificationQueue.add('sendEventCancelledEmail', data, { attempts: 3 });
+  }
+
+  async queueEventPublishedEmail(data: {
+    email: string;
+    eventTitle: string;
+  }) {
+    await this.notificationQueue.add('sendEventPublishedEmail', data, { attempts: 3 });
+  }
+
+  async queueEventCompletedEmail(data: {
+    email: string;
+    eventTitle: string;
+  }) {
+    await this.notificationQueue.add('sendEventCompletedEmail', data, { attempts: 3 });
+  }
 }

--- a/backend/src/payments/payments.module.ts
+++ b/backend/src/payments/payments.module.ts
@@ -9,15 +9,18 @@ import { EventsModule } from '../events/events.module';
 import { StellarModule } from '../stellar/stellar.module';
 import { EscrowModule } from './escrow.module';
 import { RefundModule } from './refunds/refund.module';
+import { NotificationModule } from '../notifications/notification.module';
+import { User } from '../users/entities/user.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Payment]),
+    TypeOrmModule.forFeature([Payment, User]),
     forwardRef(() => EventsModule),
     StellarModule,
     AuditModule,
     EscrowModule,
     RefundModule,
+    NotificationModule,
   ],
   providers: [PaymentsService, PaymentExpiryService],
   controllers: [PaymentsController],

--- a/backend/src/payments/payments.service.ts
+++ b/backend/src/payments/payments.service.ts
@@ -16,6 +16,8 @@ import { EventStatus } from '../events/entities/event.entity';
 import { EventsService } from '../events/events.service';
 import { StellarService } from '../stellar/stellar.service';
 import { Payment, PaymentStatus } from './entities/payment.entity';
+import { NotificationService } from '../notifications/notification.service';
+import { User } from '../users/entities/user.entity';
 
 /** Supported on-chain asset codes */
 const SUPPORTED_ASSETS = ['XLM', 'USDC'] as const;
@@ -38,11 +40,14 @@ export class PaymentsService {
   constructor(
     @InjectRepository(Payment)
     private readonly paymentsRepository: Repository<Payment>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
     @Inject(forwardRef(() => EventsService))
     private readonly eventsService: EventsService,
     private readonly stellarService: StellarService,
     private readonly auditService: AuditService,
     private readonly configService: ConfigService,
+    private readonly notificationService: NotificationService,
   ) {
     this.escrowWallet =
       this.configService.get<string>('ESCROW_WALLET_PUBLIC_KEY') ?? '';
@@ -377,6 +382,29 @@ export class PaymentsService {
     this.logger.warn(
       `Payment failed: paymentId=${payment.id} reason=${reason}`,
     );
+
+    // Queue payment failed email (non-blocking)
+    this.queuePaymentFailedEmail(payment, reason).catch(() => undefined);
+  }
+
+  private async queuePaymentFailedEmail(
+    payment: Payment,
+    reason: string,
+  ): Promise<void> {
+    const [user, event] = await Promise.all([
+      this.userRepository.findOne({ where: { id: payment.userId } }),
+      this.eventsService.getEventById(payment.eventId),
+    ]);
+
+    if (!user) return;
+
+    await this.notificationService.queuePaymentFailedEmail({
+      email: user.email,
+      eventTitle: event.title,
+      amount: Number(payment.amount),
+      currency: payment.currency,
+      reason,
+    });
   }
 }
 

--- a/backend/src/sponsors/contributions.service.ts
+++ b/backend/src/sponsors/contributions.service.ts
@@ -16,6 +16,9 @@ import {
   ContributionStatus,
 } from './entities/sponsor-contribution.entity';
 import { SponsorTier } from './entities/sponsor-tier.entity';
+import { NotificationService } from 'src/notifications/notification.service';
+import { User } from 'src/users/entities/user.entity';
+import { Event } from 'src/events/entities/event.entity';
 
 const SUPPORTED_ASSETS = ['XLM', 'USDC'] as const;
 type SupportedAsset = (typeof SUPPORTED_ASSETS)[number];
@@ -38,9 +41,14 @@ export class ContributionsService {
     private readonly contributionRepository: Repository<SponsorContribution>,
     @InjectRepository(SponsorTier)
     private readonly tierRepository: Repository<SponsorTier>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(Event)
+    private readonly eventRepository: Repository<Event>,
     private readonly stellarService: StellarService,
     private readonly auditService: AuditService,
     private readonly configService: ConfigService,
+    private readonly notificationService: NotificationService,
   ) {
     this.escrowWallet =
       this.configService.get<string>('ESCROW_WALLET_PUBLIC_KEY') ?? '';
@@ -208,12 +216,38 @@ export class ContributionsService {
       `Contribution confirmed: id=${contribution.id} txHash=${transactionHash}`,
     );
 
+    // 9. Queue sponsor confirmation email (non-blocking)
+    this.queueSponsorConfirmedEmail(contribution, transactionHash).catch(
+      () => undefined,
+    );
+
     return confirmed;
   }
 
   // ─────────────────────────────────────────────────────────────────────────
   // Helpers
   // ─────────────────────────────────────────────────────────────────────────
+
+  private async queueSponsorConfirmedEmail(
+    contribution: SponsorContribution,
+    transactionHash: string,
+  ): Promise<void> {
+    const [sponsor, event] = await Promise.all([
+      this.userRepository.findOne({ where: { id: contribution.sponsorId } }),
+      this.eventRepository.findOne({ where: { id: contribution.tier.eventId } }),
+    ]);
+
+    if (!sponsor || !event) return;
+
+    await this.notificationService.queueSponsorConfirmedEmail({
+      email: sponsor.email,
+      sponsorName: sponsor.email,
+      eventTitle: event.title,
+      amount: Number(contribution.amount),
+      currency: 'XLM',
+      transactionHash,
+    });
+  }
 
   private async getTierById(id: string): Promise<SponsorTier> {
     const tier = await this.tierRepository.findOne({ where: { id } });

--- a/backend/src/sponsors/sponsors.module.ts
+++ b/backend/src/sponsors/sponsors.module.ts
@@ -8,13 +8,17 @@ import { SponsorContribution } from './entities/sponsor-contribution.entity';
 import { EventsModule } from 'src/events/events.module';
 import { StellarModule } from 'src/stellar/stellar.module';
 import { AuditModule } from 'src/audit/audit.module';
+import { NotificationModule } from 'src/notifications/notification.module';
+import { User } from 'src/users/entities/user.entity';
+import { Event } from 'src/events/entities/event.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([SponsorTier, SponsorContribution]),
+    TypeOrmModule.forFeature([SponsorTier, SponsorContribution, User, Event]),
     EventsModule,
     StellarModule,
     AuditModule,
+    NotificationModule,
   ],
   controllers: [SponsorsController],
   providers: [SponsorsService, ContributionsService],


### PR DESCRIPTION
Issue #165 – Audit user-scoped endpoint & action filter:
- Add getQueryBuilder() to AuditService
- Add ListAuditLogsDto with action, userId, from, to filters
- Add GET /admin/audit/user/:userId endpoint
- Fix route ordering (list → user/:userId → export → :id)
- Apply optional filters in GET /admin/audit

Issue #166 – Audit log retention job:
- Add AuditRetentionJob running daily at midnight via @Cron
- Deletes logs older than AUDIT_RETENTION_DAYS (default 90)
- Register ScheduleModule and ConfigModule in AuditModule
- Document AUDIT_RETENTION_DAYS in .env.example

Issue #167 – Event lifecycle notification emails:
- Add queueEventCancelledEmail, queueEventPublishedEmail, queueEventCompletedEmail to NotificationService
- Add job processors in NotificationProcessor for each type
- Detect status transitions in EventsService.updateEvent and queue appropriate emails (non-blocking)
- Inject NotificationService, User repo, TicketEntity repo in EventsService
- Import NotificationModule and add User/TicketEntity to EventsModule

Issue #168 – Sponsor confirmed & payment failed emails:
- Add queueSponsorConfirmedEmail and queuePaymentFailedEmail to NotificationService with job processors
- Queue sponsor confirmation email after contribution confirmed in ContributionsService (non-blocking)
- Queue payment failed email in PaymentsService.markFailed (non-blocking)
- Inject NotificationService and User repo into both services
- Import NotificationModule in PaymentsModule and SponsorsModule

closes #165 
closes #166 
closes #167 
closes #168 