### PR TITLE
feat: resolve issues 161, 162, 163, 164

### DIFF
--- a/backend/src/currencies/currencies.controller.ts
+++ b/backend/src/currencies/currencies.controller.ts
@@ -6,11 +6,16 @@ import {
   Patch,
   Param,
   Delete,
+  UseGuards,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { CurrenciesService } from './currencies.service';
 import { CreateCurrencyDto } from './dto/create-currency.dto';
 import { UpdateCurrencyDto } from './dto/update-currency.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../admin/roles.guard';
+import { Roles } from '../admin/roles.decorator';
+import { UserRole } from '../users/enums/user-role.enum';
 
 @ApiTags('Currencies')
 @Controller('currencies')
@@ -18,8 +23,12 @@ export class CurrenciesController {
   constructor(private readonly currenciesService: CurrenciesService) {}
 
   @Post()
-  @ApiOperation({ summary: 'Create currency', description: 'Adds a new supported currency for the marketplace.' })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create currency', description: 'Admin only. Adds a new supported currency for the marketplace.' })
   @ApiResponse({ status: 201, description: 'Currency created' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   create(@Body() createCurrencyDto: CreateCurrencyDto) {
     return this.currenciesService.create(createCurrencyDto);
   }
@@ -39,9 +48,24 @@ export class CurrenciesController {
     return this.currenciesService.findOne(id);
   }
 
+  @Patch(':id/toggle-active')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Toggle currency active status', description: 'Admin only. Enables or disables a currency without deleting it.' })
+  @ApiResponse({ status: 200, description: 'Currency active status toggled' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  toggleActive(@Param('id') id: string) {
+    return this.currenciesService.toggleActive(id);
+  }
+
   @Patch(':id')
-  @ApiOperation({ summary: 'Update currency', description: 'Updates existing currency configuration.' })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update currency', description: 'Admin only. Updates existing currency configuration.' })
   @ApiResponse({ status: 200, description: 'Currency updated' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   update(
     @Param('id') id: string,
     @Body() updateCurrencyDto: UpdateCurrencyDto,
@@ -50,8 +74,12 @@ export class CurrenciesController {
   }
 
   @Delete(':id')
-  @ApiOperation({ summary: 'Remove currency', description: 'Deletes a currency from the platform.' })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Remove currency', description: 'Admin only. Deletes a currency from the platform.' })
   @ApiResponse({ status: 200, description: 'Currency removed' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   remove(@Param('id') id: string) {
     return this.currenciesService.remove(id);
   }

--- a/backend/src/currencies/currencies.module.ts
+++ b/backend/src/currencies/currencies.module.ts
@@ -3,11 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Currency } from './entities/currency.entity';
 import { CurrenciesService } from './currencies.service';
 import { CurrenciesController } from './currencies.controller';
+import { CurrenciesSeeder } from './currencies.seed';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Currency])],
   controllers: [CurrenciesController],
-  providers: [CurrenciesService],
+  providers: [CurrenciesService, CurrenciesSeeder],
   exports: [CurrenciesService],
 })
 export class CurrenciesModule {}

--- a/backend/src/currencies/currencies.seed.ts
+++ b/backend/src/currencies/currencies.seed.ts
@@ -1,0 +1,29 @@
+import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Currency } from './entities/currency.entity';
+
+export const DEFAULT_CURRENCIES = [
+  { code: 'XLM', displayName: 'Stellar Lumens', symbol: 'XLM', isActive: true },
+  { code: 'USDC', displayName: 'USD Coin', symbol: 'USDC', isActive: true },
+  { code: 'USD', displayName: 'US Dollar', symbol: '$', isActive: true },
+  { code: 'NGN', displayName: 'Nigerian Naira', symbol: '₦', isActive: true },
+  { code: 'EUR', displayName: 'Euro', symbol: '€', isActive: true },
+];
+
+@Injectable()
+export class CurrenciesSeeder implements OnApplicationBootstrap {
+  constructor(
+    @InjectRepository(Currency)
+    private readonly repo: Repository<Currency>,
+  ) {}
+
+  async onApplicationBootstrap() {
+    for (const c of DEFAULT_CURRENCIES) {
+      const exists = await this.repo.findOne({ where: { code: c.code } });
+      if (!exists) {
+        await this.repo.save(this.repo.create(c));
+      }
+    }
+  }
+}

--- a/backend/src/currencies/currencies.service.ts
+++ b/backend/src/currencies/currencies.service.ts
@@ -35,6 +35,21 @@ export class CurrenciesService {
       ]),
     );
   }
+
+  async findActiveCodes(): Promise<string[]> {
+    const records = await this.currencyRepository.find({
+      where: { isActive: true },
+      select: ['code'],
+    });
+    return records.map((c) => c.code);
+  }
+
+  async toggleActive(id: string): Promise<Currency | undefined> {
+    const currency = await this.findOne(id);
+    if (!currency) return undefined;
+    currency.isActive = !currency.isActive;
+    return await this.currencyRepository.save(currency);
+  }
   async create(createCurrencyDto: Partial<Currency>): Promise<Currency> {
     const currency = this.currencyRepository.create(createCurrencyDto);
     return await this.currencyRepository.save(currency);

--- a/backend/src/exchange-rates/exchange-rates.module.ts
+++ b/backend/src/exchange-rates/exchange-rates.module.ts
@@ -4,11 +4,13 @@ import { ConfigModule } from '@nestjs/config';
 import { ExchangeRate } from './entities/exchange-rate.entity';
 import { ExchangeRatesService } from './exchange-rates.service';
 import { ExchangeRatesController } from './exchange-rates.controller';
+import { CurrenciesModule } from '../currencies/currencies.module';
+import { RatesRefreshJob } from './jobs/rates-refresh.job';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ExchangeRate]), ConfigModule],
+  imports: [TypeOrmModule.forFeature([ExchangeRate]), ConfigModule, CurrenciesModule],
   controllers: [ExchangeRatesController],
-  providers: [ExchangeRatesService],
+  providers: [ExchangeRatesService, RatesRefreshJob],
   exports: [ExchangeRatesService],
 })
 export class ExchangeRatesModule {}

--- a/backend/src/exchange-rates/jobs/rates-refresh.job.ts
+++ b/backend/src/exchange-rates/jobs/rates-refresh.job.ts
@@ -1,0 +1,64 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ExchangeRatesService } from '../exchange-rates.service';
+import { CurrenciesService } from '../../currencies/currencies.service';
+import { ExchangeRate } from '../entities/exchange-rate.entity';
+
+@Injectable()
+export class RatesRefreshJob {
+  private readonly logger = new Logger(RatesRefreshJob.name);
+  private readonly staleRateWarningHours: number;
+
+  constructor(
+    private readonly ratesService: ExchangeRatesService,
+    private readonly currenciesService: CurrenciesService,
+    private readonly config: ConfigService,
+    @InjectRepository(ExchangeRate)
+    private readonly ratesRepository: Repository<ExchangeRate>,
+  ) {
+    this.staleRateWarningHours = this.config.get<number>('STALE_RATE_WARNING_HOURS') ?? 2;
+  }
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async refreshRates() {
+    const codes = await this.currenciesService.findActiveCodes();
+    const pairs = codes.flatMap((from) =>
+      codes.filter((to) => to !== from).map((to) => ({ from, to })),
+    );
+
+    let refreshed = 0;
+    let failed = 0;
+    for (const { from, to } of pairs) {
+      try {
+        await this.ratesService.getRate(from, to);
+        refreshed++;
+      } catch {
+        failed++;
+        this.logger.warn(`Failed to refresh rate ${from}→${to}`);
+      }
+    }
+    this.logger.log(`Rate refresh complete: ${refreshed} refreshed, ${failed} failed`);
+
+    await this.checkStaleRates();
+  }
+
+  private async checkStaleRates() {
+    const staleThreshold = new Date(
+      Date.now() - this.staleRateWarningHours * 60 * 60 * 1000,
+    );
+
+    const staleRates = await this.ratesRepository
+      .createQueryBuilder('r')
+      .where('r.fetchedAt < :threshold', { threshold: staleThreshold })
+      .getMany();
+
+    for (const rate of staleRates) {
+      this.logger.warn(
+        `Stale rate detected: ${rate.fromCode}→${rate.toCode} (last fetched ${rate.fetchedAt.toISOString()})`,
+      );
+    }
+  }
+}

--- a/backend/src/transactions/dto/list-transactions.dto.ts
+++ b/backend/src/transactions/dto/list-transactions.dto.ts
@@ -1,0 +1,26 @@
+import { IsEnum, IsOptional, IsDateString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { PaginationDto } from '../../common/pagination/dto/pagination.dto';
+import { TransactionType, TransactionStatus } from '../entities/transaction.entity';
+
+export class ListTransactionsDto extends PaginationDto {
+  @ApiPropertyOptional({ enum: TransactionType, description: 'Filter by transaction type' })
+  @IsOptional()
+  @IsEnum(TransactionType)
+  type?: TransactionType;
+
+  @ApiPropertyOptional({ enum: TransactionStatus, description: 'Filter by transaction status' })
+  @IsOptional()
+  @IsEnum(TransactionStatus)
+  txStatus?: TransactionStatus;
+
+  @ApiPropertyOptional({ example: '2025-01-01', description: 'Filter transactions from this date' })
+  @IsOptional()
+  @IsDateString()
+  from?: string;
+
+  @ApiPropertyOptional({ example: '2025-12-31', description: 'Filter transactions up to this date' })
+  @IsOptional()
+  @IsDateString()
+  to?: string;
+}

--- a/backend/src/transactions/transactions.controller.ts
+++ b/backend/src/transactions/transactions.controller.ts
@@ -1,8 +1,25 @@
-import { Controller, Get, Req, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Query,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Response } from 'express';
 import { TransactionsService } from './transactions.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { AuthenticatedRequest } from '../common/interfaces/authenticated-request.interface';
+import { ListTransactionsDto } from './dto/list-transactions.dto';
 
 @ApiTags('Transactions')
 @Controller('transactions')
@@ -11,11 +28,88 @@ import { AuthenticatedRequest } from '../common/interfaces/authenticated-request
 export class TransactionsController {
   constructor(private readonly transactionsService: TransactionsService) {}
 
-  @Get()
-  @ApiOperation({ summary: 'Get all transactions for the authenticated user', description: 'Returns a list of all successful wallet transactions.' })
-  @ApiResponse({ status: 200, description: 'List of transactions' })
+  @Get('export')
+  @ApiOperation({
+    summary: 'Export transactions as CSV',
+    description: 'Downloads all authenticated user transactions as a CSV file, optionally filtered by date range. Capped at 10,000 rows.',
+  })
+  @ApiQuery({ name: 'from', required: false, description: 'Start date (ISO string)' })
+  @ApiQuery({ name: 'to', required: false, description: 'End date (ISO string)' })
+  @ApiResponse({ status: 200, description: 'CSV file' })
+  @ApiResponse({ status: 400, description: 'Too many rows — use a narrower date range' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  findAll(@Req() req: AuthenticatedRequest) {
-    return this.transactionsService.findAllByUser(req.user.id);
+  async export(
+    @Req() req: AuthenticatedRequest,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+    @Res() res?: Response,
+  ) {
+    const transactions = await this.transactionsService.getAllForExport(
+      req.user.id,
+      from,
+      to,
+    );
+
+    const header = [
+      'id',
+      'type',
+      'status',
+      'amount',
+      'currency',
+      'transactionHash',
+      'referenceId',
+      'createdAt',
+    ];
+    const csvRows = [header.join(',')];
+    for (const tx of transactions) {
+      csvRows.push(
+        [
+          tx.id,
+          tx.type,
+          tx.status,
+          tx.amount,
+          tx.currency,
+          tx.transactionHash ?? '',
+          tx.referenceId ?? '',
+          tx.createdAt.toISOString(),
+        ]
+          .map((v) => '"' + String(v).replace(/"/g, '""') + '"')
+          .join(','),
+      );
+    }
+    const csv = csvRows.join('\n');
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="transactions-${Date.now()}.csv"`,
+    );
+    res.send(csv);
+  }
+
+  @Get(':id')
+  @ApiOperation({
+    summary: 'Get a single transaction',
+    description: 'Returns details of a specific transaction. Returns 403 if the transaction does not belong to the authenticated user.',
+  })
+  @ApiResponse({ status: 200, description: 'Transaction details' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  @ApiResponse({ status: 404, description: 'Not found' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  findOne(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.transactionsService.findOneByUser(id, req.user.id);
+  }
+
+  @Get()
+  @ApiOperation({
+    summary: 'Get all transactions for the authenticated user',
+    description: 'Returns a paginated, filterable list of the user\'s transactions.',
+  })
+  @ApiResponse({ status: 200, description: 'Paginated list of transactions' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  findAll(@Req() req: AuthenticatedRequest, @Query() dto: ListTransactionsDto) {
+    return this.transactionsService.findAllByUser(req.user.id, dto);
   }
 }

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -1,9 +1,12 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Transaction } from './entities/transaction.entity';
 import { CurrenciesService } from '../currencies/currencies.service';
 import { TransactionResponseDto } from './dto/transaction-response.dto';
+import { ListTransactionsDto } from './dto/list-transactions.dto';
+import { paginate } from '../common/pagination/pagination.helper';
+import { PaginatedResult } from '../common/pagination/interfaces/paginated-result.interface';
 
 @Injectable()
 export class TransactionsService {
@@ -13,33 +16,105 @@ export class TransactionsService {
     private readonly currenciesService: CurrenciesService,
   ) {}
 
-  async findAllByUser(userId: string): Promise<TransactionResponseDto[]> {
-    const transactions = await this.transactionsRepository.find({
-      where: { userId },
-      order: { createdAt: 'DESC' },
-    });
+  async findAllByUser(
+    userId: string,
+    dto: ListTransactionsDto,
+  ): Promise<PaginatedResult<TransactionResponseDto>> {
+    const qb = this.transactionsRepository
+      .createQueryBuilder('tx')
+      .where('tx.userId = :userId', { userId });
 
-    if (transactions.length === 0) return [];
+    if (dto.type) {
+      qb.andWhere('tx.type = :type', { type: dto.type });
+    }
+    if (dto.txStatus) {
+      qb.andWhere('tx.status = :status', { status: dto.txStatus });
+    }
+    if (dto.from) {
+      qb.andWhere('tx.createdAt >= :from', { from: dto.from });
+    }
+    if (dto.to) {
+      qb.andWhere('tx.createdAt <= :to', { to: dto.to });
+    }
 
-    // Collect unique currency codes then do ONE bulk lookup — no N+1
-    const uniqueCodes = [...new Set(transactions.map((t) => t.currency))];
+    qb.orderBy('tx.createdAt', 'DESC');
+
+    const paginated = await paginate(qb, dto, 'tx');
+
+    const uniqueCodes = [...new Set(paginated.data.map((t) => t.currency))];
     const currencyMap = await this.currenciesService.findByCodes(uniqueCodes);
 
-    return transactions.map((tx): TransactionResponseDto => {
-      const meta = currencyMap[tx.currency];
-      return {
-        id: tx.id,
-        userId: tx.userId,
-        amount: Number(tx.amount),
-        currency: tx.currency,
-        currencySymbol: meta?.symbol ?? tx.currency,
-        currencyDisplayName: meta?.displayName ?? tx.currency,
-        type: tx.type,
-        status: tx.status,
-        referenceId: tx.referenceId,
-        transactionHash: tx.transactionHash,
-        createdAt: tx.createdAt,
-      };
-    });
+    return {
+      ...paginated,
+      data: paginated.data.map((tx): TransactionResponseDto => {
+        const meta = currencyMap[tx.currency];
+        return {
+          id: tx.id,
+          userId: tx.userId,
+          amount: Number(tx.amount),
+          currency: tx.currency,
+          currencySymbol: meta?.symbol ?? tx.currency,
+          currencyDisplayName: meta?.displayName ?? tx.currency,
+          type: tx.type,
+          status: tx.status,
+          referenceId: tx.referenceId,
+          transactionHash: tx.transactionHash,
+          createdAt: tx.createdAt,
+        };
+      }),
+    };
+  }
+
+  async findOneByUser(id: string, userId: string): Promise<TransactionResponseDto> {
+    const tx = await this.transactionsRepository.findOne({ where: { id } });
+    if (!tx) {
+      throw new NotFoundException(`Transaction ${id} not found`);
+    }
+    if (tx.userId !== userId) {
+      throw new ForbiddenException('Access denied');
+    }
+    const currencyMap = await this.currenciesService.findByCodes([tx.currency]);
+    const meta = currencyMap[tx.currency];
+    return {
+      id: tx.id,
+      userId: tx.userId,
+      amount: Number(tx.amount),
+      currency: tx.currency,
+      currencySymbol: meta?.symbol ?? tx.currency,
+      currencyDisplayName: meta?.displayName ?? tx.currency,
+      type: tx.type,
+      status: tx.status,
+      referenceId: tx.referenceId,
+      transactionHash: tx.transactionHash,
+      createdAt: tx.createdAt,
+    };
+  }
+
+  async getAllForExport(
+    userId: string,
+    from?: string,
+    to?: string,
+  ): Promise<Transaction[]> {
+    const qb = this.transactionsRepository
+      .createQueryBuilder('tx')
+      .where('tx.userId = :userId', { userId });
+
+    if (from) {
+      qb.andWhere('tx.createdAt >= :from', { from });
+    }
+    if (to) {
+      qb.andWhere('tx.createdAt <= :to', { to });
+    }
+
+    qb.orderBy('tx.createdAt', 'DESC');
+
+    const count = await qb.getCount();
+    if (count > 10_000) {
+      throw new BadRequestException(
+        'Export exceeds 10,000 rows. Please use a narrower date range.',
+      );
+    }
+
+    return qb.getMany();
   }
 }


### PR DESCRIPTION
- Issue 161: Seed default currencies (XLM, USDC, USD, NGN, EUR) on bootstrap via CurrenciesSeeder; secure POST/PATCH/DELETE with ADMIN role; add PATCH /:id/toggle-active
- Issue 162: Add RatesRefreshJob scheduled hourly to warm exchange rate cache for all active currency pairs; warn on stale rates older than STALE_RATE_WARNING_HOURS (default 2)
- Issue 163: Add GET /transactions/:id (owner-only), ListTransactionsDto with type/status/date filters, and pagination on GET /transactions
- Issue 164: Add GET /transactions/export returning CSV with date range filter and 10,000 row cap

closes #161 
closes #162 
closes #163 
closes #164 