### PR TITLE
feat(wallet,exchange-rates): resolve issues 157, 158, 159, 160

### DIFF
--- a/backend/src/database/migrations/1711380000001-CreateUserWalletsTable.ts
+++ b/backend/src/database/migrations/1711380000001-CreateUserWalletsTable.ts
@@ -1,0 +1,59 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateUserWalletsTable1711380000001 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'user_wallets',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'userId',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'publicKey',
+            type: 'varchar',
+            isUnique: true,
+            isNullable: false,
+          },
+          {
+            name: 'isPrimary',
+            type: 'boolean',
+            default: false,
+          },
+          {
+            name: 'label',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamptz',
+            default: 'now()',
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'user_wallets',
+      new TableIndex({
+        name: 'IDX_user_wallets_userId',
+        columnNames: ['userId'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('user_wallets');
+  }
+}

--- a/backend/src/exchange-rates/exchange-rates.controller.ts
+++ b/backend/src/exchange-rates/exchange-rates.controller.ts
@@ -1,16 +1,23 @@
 import {
-  Controller,
-  Get,
-  Post,
+  BadRequestException,
   Body,
-  Patch,
-  Param,
+  Controller,
   Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
 import { ExchangeRatesService } from './exchange-rates.service';
 import { CreateExchangeRateDto } from './dto/create-exchange-rate.dto';
 import { UpdateExchangeRateDto } from './dto/update-exchange-rate.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../admin/roles.guard';
+import { Roles } from '../admin/roles.decorator';
+import { UserRole } from '../users/enums/user-role.enum';
 
 @ApiTags('Exchange Rates')
 @Controller('exchange-rates')
@@ -18,8 +25,12 @@ export class ExchangeRatesController {
   constructor(private readonly exchangeRatesService: ExchangeRatesService) {}
 
   @Post()
-  @ApiOperation({ summary: 'Create exchange rate', description: 'Adds or updates a conversion rate between currencies.' })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create exchange rate', description: 'Admin only. Adds or updates a conversion rate between currencies.' })
   @ApiResponse({ status: 201, description: 'Rate created' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   create(@Body() createExchangeRateDto: CreateExchangeRateDto) {
     return this.exchangeRatesService.create(createExchangeRateDto);
   }
@@ -31,6 +42,39 @@ export class ExchangeRatesController {
     return this.exchangeRatesService.findAll();
   }
 
+  @Get('convert')
+  @ApiOperation({ summary: 'Convert currency', description: 'Public. Converts an amount from one currency to another using the latest rate.' })
+  @ApiQuery({ name: 'from', required: true, description: 'Source currency code (e.g. XLM)' })
+  @ApiQuery({ name: 'to', required: true, description: 'Target currency code (e.g. USD)' })
+  @ApiQuery({ name: 'amount', required: true, description: 'Amount to convert (positive number)' })
+  @ApiResponse({ status: 200, description: 'Conversion result' })
+  @ApiResponse({ status: 400, description: 'Invalid query params' })
+  async convert(
+    @Query('from') from: string,
+    @Query('to') to: string,
+    @Query('amount') amount: string,
+  ): Promise<{ from: string; to: string; amount: number; converted: number; rate: number }> {
+    if (!from || !to || !amount) {
+      throw new BadRequestException('from, to, and amount are required');
+    }
+    const numAmount = parseFloat(amount);
+    if (isNaN(numAmount) || numAmount <= 0) {
+      throw new BadRequestException('Amount must be a positive number');
+    }
+
+    const rate = await this.exchangeRatesService.getRate(
+      from.toUpperCase(),
+      to.toUpperCase(),
+    );
+    return {
+      from: from.toUpperCase(),
+      to: to.toUpperCase(),
+      amount: numAmount,
+      converted: parseFloat((numAmount * rate).toFixed(7)),
+      rate,
+    };
+  }
+
   @Get(':id')
   @ApiOperation({ summary: 'Get exchange rate', description: 'Returns details for a single exchange rate entry.' })
   @ApiResponse({ status: 200, description: 'Rate found' })
@@ -40,8 +84,12 @@ export class ExchangeRatesController {
   }
 
   @Patch(':id')
-  @ApiOperation({ summary: 'Update exchange rate', description: 'Updates an existing conversion rate.' })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update exchange rate', description: 'Admin only. Updates an existing conversion rate.' })
   @ApiResponse({ status: 200, description: 'Rate updated' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   update(
     @Param('id') id: string,
     @Body() updateExchangeRateDto: UpdateExchangeRateDto,
@@ -50,8 +98,12 @@ export class ExchangeRatesController {
   }
 
   @Delete(':id')
-  @ApiOperation({ summary: 'Remove exchange rate', description: 'Deletes a conversion rate entry.' })
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Remove exchange rate', description: 'Admin only. Deletes a conversion rate entry.' })
   @ApiResponse({ status: 200, description: 'Rate removed' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   remove(@Param('id') id: string) {
     return this.exchangeRatesService.remove(id);
   }

--- a/backend/src/stellar/stellar.service.ts
+++ b/backend/src/stellar/stellar.service.ts
@@ -230,6 +230,32 @@ export class StellarService implements OnModuleDestroy {
   }
 
   /**
+   * Get paginated transaction history for a Stellar account.
+   * Returns an empty records array for new/unfunded accounts (Horizon 404).
+   */
+  async getAccountTransactions(
+    publicKey: string,
+    cursor?: string,
+    limit = 10,
+  ): Promise<{ records: Horizon.ServerApi.TransactionRecord[] }> {
+    try {
+      let query = this.server
+        .transactions()
+        .forAccount(publicKey)
+        .limit(limit)
+        .order('desc');
+      if (cursor) query = query.cursor(cursor);
+      return await query.call();
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 404) {
+        return { records: [] };
+      }
+      throw err;
+    }
+  }
+
+  /**
    * Get the XLM balance of an account.
    */
   async getXlmBalance(publicKey: string): Promise<string> {

--- a/backend/src/wallet/entities/user-wallet.entity.ts
+++ b/backend/src/wallet/entities/user-wallet.entity.ts
@@ -1,0 +1,29 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('user_wallets')
+export class UserWallet {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index()
+  @Column()
+  userId: string;
+
+  @Column({ unique: true })
+  publicKey: string;
+
+  @Column({ default: false })
+  isPrimary: boolean;
+
+  @Column({ nullable: true, type: 'varchar' })
+  label: string | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/wallet/wallet.controller.ts
+++ b/backend/src/wallet/wallet.controller.ts
@@ -1,5 +1,17 @@
-import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
-import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
 import { WalletService } from './wallet.service';
 import { ChallengeRequestDto } from './dto/challenge-request.dto';
 import { VerifySignatureDto } from './dto/verify-signature.dto';
@@ -32,10 +44,88 @@ export class WalletController {
     @Body() dto: VerifySignatureDto,
   ) {
     const { id: userId } = req.user;
-    return this.walletService.verifyAndLink(
-      userId,
-      dto.publicKey,
-      dto.signature,
-    );
+    return this.walletService.verifyAndLink(userId, dto.publicKey, dto.signature);
+  }
+
+  // ── Issue 157 ──────────────────────────────────────────────────────────
+
+  @UseGuards(JwtAuthGuard)
+  @Get('status')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get wallet status', description: 'Returns whether the user has a linked wallet and its public key.' })
+  @ApiResponse({ status: 200, description: 'Wallet status returned' })
+  async getStatus(@Req() req: AuthenticatedRequest) {
+    return this.walletService.getWalletStatus(req.user.id);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete('unlink')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Unlink wallet', description: 'Removes the linked Stellar wallet from the user account.' })
+  @ApiResponse({ status: 200, description: 'Wallet unlinked' })
+  @ApiResponse({ status: 400, description: 'No wallet is currently linked' })
+  async unlink(@Req() req: AuthenticatedRequest) {
+    return this.walletService.unlinkWallet(req.user.id);
+  }
+
+  // ── Issue 158 ──────────────────────────────────────────────────────────
+
+  @UseGuards(JwtAuthGuard)
+  @Get('list')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'List all linked wallets', description: 'Returns all Stellar wallets linked to the user account.' })
+  @ApiResponse({ status: 200, description: 'Wallet list returned' })
+  async listWallets(@Req() req: AuthenticatedRequest) {
+    return this.walletService.listWallets(req.user.id);
+  }
+
+  // ── Issue 159 ──────────────────────────────────────────────────────────
+
+  @UseGuards(JwtAuthGuard)
+  @Get('transactions')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get transaction history', description: 'Returns paginated Stellar transaction history for the linked wallet.' })
+  @ApiQuery({ name: 'cursor', required: false, description: 'Paging cursor from previous response' })
+  @ApiQuery({ name: 'limit', required: false, description: 'Number of records to return (max 50, default 10)' })
+  @ApiResponse({ status: 200, description: 'Transaction history returned' })
+  @ApiResponse({ status: 400, description: 'No wallet linked' })
+  async getTransactions(
+    @Req() req: AuthenticatedRequest,
+    @Query('cursor') cursor?: string,
+    @Query('limit') limit = 10,
+  ) {
+    const status = await this.walletService.getWalletStatus(req.user.id);
+    if (!status.publicKey) {
+      throw new BadRequestException('No wallet linked');
+    }
+    return this.walletService.getTransactionHistory(status.publicKey, cursor, Number(limit));
+  }
+
+  // ── Issue 158 (continued — these must come after /transactions to avoid route shadowing) ──
+
+  @UseGuards(JwtAuthGuard)
+  @Patch(':publicKey/primary')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Set primary wallet', description: 'Designates a linked wallet as the primary wallet.' })
+  @ApiResponse({ status: 200, description: 'Primary wallet updated' })
+  @ApiResponse({ status: 400, description: 'Wallet not found' })
+  async setPrimary(
+    @Req() req: AuthenticatedRequest,
+    @Param('publicKey') publicKey: string,
+  ) {
+    return this.walletService.setPrimaryWallet(req.user.id, publicKey);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete(':publicKey')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Remove a wallet', description: 'Removes a specific linked wallet. Cannot remove primary wallet when other wallets exist.' })
+  @ApiResponse({ status: 200, description: 'Wallet removed' })
+  @ApiResponse({ status: 400, description: 'Cannot remove primary wallet or wallet not found' })
+  async removeWallet(
+    @Req() req: AuthenticatedRequest,
+    @Param('publicKey') publicKey: string,
+  ) {
+    return this.walletService.removeWallet(req.user.id, publicKey);
   }
 }

--- a/backend/src/wallet/wallet.module.ts
+++ b/backend/src/wallet/wallet.module.ts
@@ -6,11 +6,12 @@ import { WalletController } from './wallet.controller';
 import { UsersModule } from '../users/users.module';
 import { StellarModule } from '../stellar/stellar.module';
 import { User } from '../users/entities/user.entity';
+import { UserWallet } from './entities/user-wallet.entity';
 import { RedisProvider } from '../common/redis/redis.provider';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User]),
+    TypeOrmModule.forFeature([User, UserWallet]),
     ConfigModule,
     UsersModule,
     StellarModule,

--- a/backend/src/wallet/wallet.service.ts
+++ b/backend/src/wallet/wallet.service.ts
@@ -15,6 +15,7 @@ import { User } from '../users/entities/user.entity';
 import { UsersService } from '../users/users.service';
 import { StellarService } from '../stellar/stellar.service';
 import { REDIS_CLIENT } from '../common/redis/redis.provider';
+import { UserWallet } from './entities/user-wallet.entity';
 
 const NONCE_TTL_SECONDS = 300; // 5 minutes
 
@@ -27,9 +28,130 @@ export class WalletService {
     private readonly stellarService: StellarService,
     @InjectRepository(User)
     private readonly usersRepository: Repository<User>,
+    @InjectRepository(UserWallet)
+    private readonly userWalletsRepository: Repository<UserWallet>,
     @Inject(REDIS_CLIENT)
     private readonly redis: Redis,
   ) {}
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Issue 157 — GET /wallet/status
+  // ─────────────────────────────────────────────────────────────────────────
+
+  async getWalletStatus(userId: string): Promise<{ linked: boolean; publicKey: string | null }> {
+    const user = await this.usersService.findById(userId);
+    return {
+      linked: !!user.stellarPublicKey,
+      publicKey: user.stellarPublicKey ?? null,
+    };
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Issue 157 — DELETE /wallet/unlink
+  // ─────────────────────────────────────────────────────────────────────────
+
+  async unlinkWallet(userId: string): Promise<{ unlinked: boolean }> {
+    const user = await this.usersRepository.findOne({ where: { id: userId } });
+    if (!user?.stellarPublicKey) {
+      throw new BadRequestException('No wallet is currently linked');
+    }
+    user.stellarPublicKey = null;
+    await this.usersRepository.save(user);
+
+    // Remove all UserWallet records for this user
+    await this.userWalletsRepository.delete({ userId });
+
+    return { unlinked: true };
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Issue 158 — GET /wallet/list
+  // ─────────────────────────────────────────────────────────────────────────
+
+  async listWallets(userId: string): Promise<UserWallet[]> {
+    return this.userWalletsRepository.find({ where: { userId } });
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Issue 158 — PATCH /wallet/:publicKey/primary
+  // ─────────────────────────────────────────────────────────────────────────
+
+  async setPrimaryWallet(userId: string, publicKey: string): Promise<UserWallet> {
+    const wallet = await this.userWalletsRepository.findOne({
+      where: { userId, publicKey },
+    });
+    if (!wallet) {
+      throw new BadRequestException('Wallet not found for this user');
+    }
+
+    // Reset all user's wallets to non-primary
+    await this.userWalletsRepository.update({ userId }, { isPrimary: false });
+
+    // Set the selected wallet as primary
+    wallet.isPrimary = true;
+    await this.userWalletsRepository.save(wallet);
+
+    // Keep User.stellarPublicKey in sync with primary wallet
+    await this.usersRepository.update({ id: userId }, { stellarPublicKey: publicKey });
+
+    return wallet;
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Issue 158 — DELETE /wallet/:publicKey
+  // ─────────────────────────────────────────────────────────────────────────
+
+  async removeWallet(userId: string, publicKey: string): Promise<{ removed: boolean }> {
+    const wallet = await this.userWalletsRepository.findOne({
+      where: { userId, publicKey },
+    });
+    if (!wallet) {
+      throw new BadRequestException('Wallet not found for this user');
+    }
+
+    const walletCount = await this.userWalletsRepository.count({ where: { userId } });
+    if (wallet.isPrimary && walletCount > 1) {
+      throw new BadRequestException(
+        'Cannot delete the primary wallet while other wallets exist. Set a different primary wallet first.',
+      );
+    }
+
+    await this.userWalletsRepository.remove(wallet);
+
+    // If the removed wallet was the primary, clear User.stellarPublicKey
+    const user = await this.usersRepository.findOne({ where: { id: userId } });
+    if (user?.stellarPublicKey === publicKey) {
+      const nextPrimary = await this.userWalletsRepository.findOne({
+        where: { userId, isPrimary: true },
+      });
+      user.stellarPublicKey = nextPrimary?.publicKey ?? null;
+      await this.usersRepository.save(user);
+    }
+
+    return { removed: true };
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Issue 159 — Transaction history
+  // ─────────────────────────────────────────────────────────────────────────
+
+  async getTransactionHistory(
+    publicKey: string,
+    cursor?: string,
+    limit: number = 10,
+  ) {
+    const cappedLimit = Math.min(Number(limit), 50);
+    const result = await this.stellarService.getAccountTransactions(publicKey, cursor, cappedLimit);
+
+    const records = result.records ?? [];
+    const nextCursor =
+      records.length > 0 ? records[records.length - 1].paging_token : null;
+
+    return {
+      transactions: records,
+      nextCursor,
+    };
+  }
 
   // ─────────────────────────────────────────────────────────────────────────
   // STEP 1 — Issue challenge
@@ -54,7 +176,7 @@ export class WalletService {
   }
 
   // ─────────────────────────────────────────────────────────────────────────
-  // STEP 2 — Verify signature & link wallet
+  // STEP 2 — Verify signature & link wallet (Issue 157 improved error + Issue 158 multi-wallet)
   // ─────────────────────────────────────────────────────────────────────────
 
   async verifyAndLink(
@@ -68,7 +190,7 @@ export class WalletService {
 
     if (!nonce) {
       throw new BadRequestException(
-        'No active challenge found for this public key. Request a new challenge.',
+        'Challenge has expired or was never issued. Request a new challenge via POST /wallet/challenge.',
       );
     }
 
@@ -98,6 +220,28 @@ export class WalletService {
       this.logger.warn(
         `Stellar account ${publicKey} not found on network (may be unfunded). Proceeding with link.`,
       );
+    }
+
+    // Issue 158: create UserWallet record if not already present
+    const existingWallet = await this.userWalletsRepository.findOne({
+      where: { userId, publicKey },
+    });
+
+    if (!existingWallet) {
+      const walletCount = await this.userWalletsRepository.count({ where: { userId } });
+      const isPrimary = walletCount === 0;
+
+      const userWallet = this.userWalletsRepository.create({
+        userId,
+        publicKey,
+        isPrimary,
+      });
+      await this.userWalletsRepository.save(userWallet);
+
+      // Keep User.stellarPublicKey pointing at the primary wallet
+      if (isPrimary) {
+        await this.usersRepository.update({ id: userId }, { stellarPublicKey: publicKey });
+      }
     }
 
     return this.usersService.updateWallet(userId, publicKey);


### PR DESCRIPTION
Issue 157 - Wallet status, unlink, and improved nonce expiry error:
- GET /wallet/status returns linked status and public key
- DELETE /wallet/unlink removes linked wallet (400 if none linked)
- Improved nonce expiry error message in verifyAndLink()

Issue 158 - Multi-wallet support with primary designation:
- New UserWallet entity and migration (user_wallets table)
- GET /wallet/list returns all linked wallets with isPrimary flag
- PATCH /wallet/:publicKey/primary designates a wallet as primary
- DELETE /wallet/:publicKey removes a specific wallet (400 if trying to remove primary while others exist)
- User.stellarPublicKey always reflects the primary wallet
- verifyAndLink() now creates UserWallet records on success

Issue 159 - Transaction history endpoint proxying Horizon:
- Added getAccountTransactions() to StellarService with cursor pagination
- GET /wallet/transactions returns paginated Stellar transactions
- Returns nextCursor for pagination, empty list for new accounts (Horizon 404)
- Limit capped at 50 per request

Issue 160 - Secure exchange-rate mutating endpoints + convert endpoint:
- POST, PATCH, DELETE /exchange-rates now require ADMIN role (JwtAuthGuard + RolesGuard)
- GET /exchange-rates and GET /exchange-rates/:id remain public
- Added GET /exchange-rates/convert?from=XLM&to=USD&amount=100 (placed before /:id to avoid route shadowing)
- 400 returned for missing/invalid query params
closes #157 
closes #158 
closes #159 
closes #160 