### PR TITLE
feat: Add get_admin read function to expose contract admin

### DIFF
--- a/contract/src/lumentix_contract.rs
+++ b/contract/src/lumentix_contract.rs
@@ -391,4 +391,14 @@ impl LumentixContract {
 
         Ok(balance)
     }
+
+    /// Get the contract admin address.
+    /// Returns the admin address if the contract is initialized.
+    /// No auth required - provides transparency.
+    pub fn get_admin(env: Env) -> Result<Address, LumentixError> {
+        if !storage::is_initialized(&env) {
+            return Err(LumentixError::NotInitialized);
+        }
+        Ok(storage::get_admin(&env))
+    }
 }


### PR DESCRIPTION
- Implements get_admin(env) -> Result<Address, LumentixError>
- Checks if contract is initialized before returning admin
- Returns NotInitialized error if contract not initialized
- No auth required for transparency

Closes #184