### PR TITLE
feat: Add get_event_revenue read function to calculate event revenue

### DIFF
--- a/contract/src/lumentix_contract.rs
+++ b/contract/src/lumentix_contract.rs
@@ -373,6 +373,16 @@ impl LumentixContract {
         storage::get_platform_balance(&env)
     }
 
+    /// Get event revenue (gross ticket sales).
+    /// Calculates revenue as tickets_sold * ticket_price.
+    /// Returns i128 representing total gross revenue.
+    /// No auth required.
+    pub fn get_event_revenue(env: Env, event_id: u64) -> Result<i128, LumentixError> {
+        let event = storage::get_event(&env, event_id)?;
+        let revenue = event.tickets_sold as i128 * event.ticket_price;
+        Ok(revenue)
+    }
+
     /// Withdraw all accumulated platform fees. Only the admin can withdraw.
     pub fn withdraw_platform_fees(env: Env, admin: Address) -> Result<i128, LumentixError> {
         admin.require_auth();


### PR DESCRIPTION
- Implements get_event_revenue(env, event_id) -> Result<i128, LumentixError>
- Calculates revenue as tickets_sold * ticket_price
- Returns EventNotFound if event doesn't exist
- No auth required - represents gross ticket sales

Closes #188