### PR TITLE
feat: add get_tickets_by_buyer read function

### DIFF
--- a/contract/src/events/mod.rs
+++ b/contract/src/events/mod.rs
@@ -28,6 +28,7 @@ impl CheckInEvent {
 pub struct EventCreated;
 
 impl EventCreated {
+    #[allow(clippy::too_many_arguments)]
     pub fn emit(
         env: &Env,
         event_id: u64,
@@ -112,9 +113,7 @@ pub struct PlatformFeesWithdrawn;
 
 impl PlatformFeesWithdrawn {
     pub fn emit(env: &Env, admin: Address, amount: i128) {
-        env.events().publish(
-            (symbol_short!("feewith"),),
-            (admin, amount),
-        );
+        env.events()
+            .publish((symbol_short!("feewith"),), (admin, amount));
     }
 }

--- a/contract/src/lumentix_contract.rs
+++ b/contract/src/lumentix_contract.rs
@@ -1,7 +1,10 @@
 #![allow(clippy::too_many_arguments)]
 
 use crate::error::LumentixError;
-use crate::events::{EventCancelled, EventCreated, PlatformFeeUpdated, EventStatusChanged, EventCompleted, PlatformFeesWithdrawn};
+use crate::events::{
+    EventCancelled, EventCompleted, EventCreated, EventStatusChanged, PlatformFeeUpdated,
+    PlatformFeesWithdrawn,
+};
 use crate::storage;
 use crate::types::{Event, EventStatus, Ticket};
 use crate::validation;
@@ -424,6 +427,23 @@ impl LumentixContract {
         }
 
         Ok(tickets)
+    }
+
+    pub fn get_tickets_by_buyer(env: Env, buyer: Address) -> Vec<Ticket> {
+        let mut tickets = Vec::new(&env);
+        let next_ticket_id = storage::get_next_ticket_id(&env);
+        let mut ticket_id: u64 = 1;
+
+        while ticket_id < next_ticket_id {
+            if let Ok(ticket) = storage::get_ticket(&env, ticket_id) {
+                if ticket.owner == buyer {
+                    tickets.push_back(ticket);
+                }
+            }
+            ticket_id += 1;
+        }
+
+        tickets
     }
 
     /// Extend the TTL of an event. Only the organizer can call this.

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -1466,7 +1466,7 @@ fn test_get_active_events_only_published() {
     let organizer = Address::generate(&env);
 
     // 1. Create 3 events: 1 Published, 1 Draft, 1 Published
-    
+
     // Event 1: Published
     let event_id_1 = client.create_event(
         &organizer,
@@ -1512,7 +1512,7 @@ fn test_get_active_events_only_published() {
     assert_eq!(active_events.len(), 2);
     assert_eq!(active_events.get(0).unwrap().id, event_id_1);
     assert_eq!(active_events.get(1).unwrap().id, event_id_3);
-    
+
     for event in active_events.iter() {
         assert_eq!(event.status, EventStatus::Published);
     }


### PR DESCRIPTION
close #180 

Adds a new read-only function to LumentixContract that returns all tickets owned by a given buyer.

What changed
- get_tickets_by_buyer(env, buyer: Address) -> Vec<Ticket> — iterates ticket IDs 1..TICKET_CTR, filters by ticket.owner == buyer, returns empty Vec if none found. No auth required.
- Fixed pre-existing clippy::too_many_arguments on EventCreated::emit and rustfmt issues that would have failed CI.

Testing
All 88 existing tests pass. cargo fmt --check and cargo clippy -- -D warnings clean.




<img width="550" height="654" alt="image" src="https://github.com/user-attachments/assets/b5e8ca90-afb4-42ef-b18b-a645fde259e6" />
