### PR TITLE
fix(backend): resolve issues #119, #120, #263, #264

### DIFF
--- a/backend/src/audit/audit.controller.ts
+++ b/backend/src/audit/audit.controller.ts
@@ -120,7 +120,7 @@ export class AuditController {
   @ApiResponse({ status: 200, description: 'Log found', type: AuditLog })
   @ApiResponse({ status: 404, description: 'Log not found' })
   async getAuditLogById(@Param('id') id: string): Promise<AuditLog> {
-    const log = await this.auditService.auditLogRepository.findOneBy({ id });
+    const log = await this.auditService.findById(id);
     if (!log) {
       throw new NotFoundException('Audit log not found');
     }

--- a/backend/src/audit/audit.service.ts
+++ b/backend/src/audit/audit.service.ts
@@ -23,6 +23,10 @@ export class AuditService {
     return this.auditLogRepository.createQueryBuilder('audit');
   }
 
+  findById(id: string): Promise<AuditLog | null> {
+    return this.auditLogRepository.findOneBy({ id });
+  }
+
   async log(entry: AuditLogEntry): Promise<AuditLog> {
     const record = this.auditLogRepository.create({
       action: entry.action,

--- a/backend/src/registrations/registrations.controller.spec.ts
+++ b/backend/src/registrations/registrations.controller.spec.ts
@@ -1,0 +1,42 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RegistrationsController } from './registrations.controller';
+import { RegistrationsService } from './registrations.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+
+describe('RegistrationsController', () => {
+  let controller: RegistrationsController;
+
+  const mockRegistrationsService = {
+    register: jest.fn(),
+    listForEvent: jest.fn(),
+    listForUser: jest.fn(),
+    cancel: jest.fn(),
+    cancelWithRefund: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [RegistrationsController],
+      providers: [
+        { provide: RegistrationsService, useValue: mockRegistrationsService },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<RegistrationsController>(RegistrationsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should have JwtAuthGuard applied', () => {
+    const guards = Reflect.getMetadata('__guards__', RegistrationsController);
+    expect(guards).toContain(JwtAuthGuard);
+  });
+});

--- a/backend/src/registrations/registrations.controller.ts
+++ b/backend/src/registrations/registrations.controller.ts
@@ -13,14 +13,18 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { Response } from 'express';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { RegistrationsService } from './registrations.service';
 import { ListRegistrationsDto } from './dto/list-registrations.dto';
 import { Roles, Role } from '../common/decorators/roles.decorator';
 import { RolesGuard } from '../common/guards/roles.guard';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { AuthenticatedRequest } from '../common/interfaces/authenticated-request.interface';
 
+@ApiTags('Registrations')
+@ApiBearerAuth()
 @Controller()
-@UseGuards(RolesGuard)
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class RegistrationsController {
   constructor(private readonly service: RegistrationsService) {}
 

--- a/backend/src/tickets/tickets.service.ts
+++ b/backend/src/tickets/tickets.service.ts
@@ -21,7 +21,7 @@ import { PaymentsService } from '../payments/payments.service';
 import { PaymentStatus } from '../payments/entities/payment.entity';
 import { StellarService } from '../stellar/stellar.service';
 import { NotificationService } from '../notifications/notification.service';
-import { Event } from '../events/entities/event.entity';
+import { paginate } from '../common/pagination/pagination.helper';
 import { User } from '../users/entities/user.entity';
 
 @Injectable()
@@ -59,7 +59,6 @@ export class TicketsService {
       });
     }
 
-    const { paginate } = await import('../common/pagination/pagination.helper');
     return paginate(queryBuilder, paginationDto, 'ticket');
   }
 
@@ -101,7 +100,6 @@ export class TicketsService {
       .where('ticket.ownerId = :ownerId', { ownerId })
       .orderBy('ticket.createdAt', 'DESC');
 
-    const { paginate } = await import('../common/pagination/pagination.helper');
     return paginate(queryBuilder, paginationDto, 'ticket');
   }
 

--- a/backend/src/tickets/verification/verification.controller.ts
+++ b/backend/src/tickets/verification/verification.controller.ts
@@ -1,10 +1,19 @@
 import { Controller, Post, Body, UseGuards } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiBody,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { TicketsService } from '../tickets.service';
 import { VerifyTicketDto } from './dto/verify-ticket.dto';
 import { Roles, Role } from '../../common/decorators/roles.decorator';
 import { RolesGuard } from '../../common/guards/roles.guard';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 
+@ApiTags('Tickets')
+@ApiBearerAuth()
 @Controller('tickets')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class VerificationController {
@@ -12,7 +21,14 @@ export class VerificationController {
 
   @Post('verify')
   @Roles(Role.ADMIN, Role.ORGANIZER)
-  @Roles(Role.ADMIN, Role.ORGANIZER)
+  @ApiOperation({
+    summary: 'Verify a ticket at the gate',
+    description: 'Admin or organizer only. Verifies a ticket signature and marks it as used.',
+  })
+  @ApiBody({ type: VerifyTicketDto })
+  @ApiResponse({ status: 200, description: 'Ticket verified and marked as used' })
+  @ApiResponse({ status: 400, description: 'Invalid signature or ticket already used' })
+  @ApiResponse({ status: 403, description: 'Caller is not admin or organizer' })
   async verify(@Body() verifyTicketDto: VerifyTicketDto) {
     const { ticketId, signature } = verifyTicketDto;
     const ticket = await this.ticketsService.verifyTicket(ticketId, signature);

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -101,17 +101,6 @@ export class UsersController {
     return this.usersService.requestRole(req.user.id, dto);
   }
 
-  @Get(':id')
-  @ApiOperation({
-    summary: 'Find a user by ID',
-    description: 'Retrieves user details.',
-  })
-  @ApiResponse({ status: 200, description: 'User found.' })
-  @ApiResponse({ status: 404, description: 'User not found.' })
-  async findOne(@Param('id') id: string) {
-    return this.usersService.findById(id);
-  }
-
   // ── Wallet ─────────────────────────────────────────────────────────────────
 
   @Get('wallet/balances')
@@ -136,5 +125,16 @@ export class UsersController {
     @Query('base') baseCurrency: string = 'USD',
   ) {
     return this.usersService.getPortfolioValue(req.user.id, baseCurrency);
+  }
+
+  @Get(':id')
+  @ApiOperation({
+    summary: 'Find a user by ID',
+    description: 'Retrieves user details.',
+  })
+  @ApiResponse({ status: 200, description: 'User found.' })
+  @ApiResponse({ status: 404, description: 'User not found.' })
+  async findOne(@Param('id') id: string) {
+    return this.usersService.findById(id);
   }
 }


### PR DESCRIPTION
#119: Already resolved in codebase (TicketsModule imports NotificationModule, AuditController has correct import paths, EventsController injects TicketsService, EventsModule imports TicketsModule).

#120:
- fix(users): move wallet/balances and wallet/portfolio routes above :id to prevent route shadowing
- fix(audit): add AuditService.findById() and use it in AuditController instead of accessing auditLogRepository directly
- fix(tickets): replace dynamic await import() calls with static import of paginate helper in TicketsService

#263:
- fix(registrations): add JwtAuthGuard before RolesGuard so req.user is populated; add @ApiTags and @ApiBearerAuth Swagger decorators
- test(registrations): add registrations.controller.spec.ts

#264:
- fix(verification): remove duplicate @Roles decorator on verify endpoint
- feat(verification): add @ApiTags, @ApiBearerAuth, @ApiOperation, @ApiBody, and @ApiResponse Swagger decorators to VerificationController
closes #119 
closes #120 
closes #263 
closes #264 