### PR TITLE
feat: solve issues #318, #319, #320, #321

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -39,3 +39,11 @@ SMTP_PORT=587
 SMTP_USER=no-reply@example.com
 SMTP_PASS=your-smtp-password
 MAIL_FROM="Lumentix <no-reply@example.com>"
+
+# ─── Refund Policy ─────────────────────────────────────────────────────────
+REFUND_CUTOFF_HOURS=24
+FULL_REFUND_WINDOW_HOURS=48
+PARTIAL_REFUND_RATE=0.5
+
+# ─── Audit ─────────────────────────────────────────────────────────────────
+AUDIT_RETENTION_DAYS=90

--- a/backend/src/audit/entities/audit-log.entity.ts
+++ b/backend/src/audit/entities/audit-log.entity.ts
@@ -28,6 +28,7 @@ export enum AuditAction {
   EVENT_COMPLETED = 'EVENT_COMPLETED',
 }
 
+@Index(['userId', 'action'])
 @Entity('audit_logs')
 export class AuditLog {
   @PrimaryGeneratedColumn('uuid')

--- a/backend/src/config/env.validation.spec.ts
+++ b/backend/src/config/env.validation.spec.ts
@@ -1,106 +1,111 @@
 import { envValidationSchema } from './env.validation';
 
+function buildEnv(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    DB_HOST: 'localhost',
+    DB_PORT: 5432,
+    DB_USERNAME: 'pg',
+    DB_PASSWORD: 'pg',
+    DB_NAME: 'lumentix',
+    JWT_SECRET: 'a'.repeat(32),
+    STELLAR_NETWORK: 'testnet',
+    HORIZON_URL: 'https://horizon-testnet.stellar.org',
+    NETWORK_PASSPHRASE: 'Test SDF Network ; September 2015',
+    PLATFORM_PUBLIC_KEY: 'G' + 'A'.repeat(55),
+    PLATFORM_SECRET_KEY: 'S' + 'A'.repeat(55),
+    TICKET_SIGNING_SECRET: 'signing-secret',
+    TICKET_SIGNING_PUBLIC_KEY: 'pub-key',
+    SMTP_HOST: 'smtp.test.com',
+    SMTP_PORT: 587,
+    SMTP_USER: 'user@test.com',
+    SMTP_PASS: 'pass',
+    MAIL_FROM: 'noreply@test.com',
+    ...overrides,
+  };
+}
+
 describe('envValidationSchema', () => {
-  it('should fail when required variables are missing and return multiple errors', () => {
-    const { error } = envValidationSchema.validate({}, { abortEarly: false });
-
-    expect(error).toBeDefined();
-    expect(error?.details.length).toBeGreaterThan(1);
-
-    const messages = error?.details.map((d) => d.message) ?? [];
-    expect(messages).toEqual(expect.arrayContaining([expect.stringContaining('DB_HOST'), expect.stringContaining('JWT_SECRET'), expect.stringContaining('STELLAR_NETWORK')]));
+  it('validates successfully with all required fields', () => {
+    const { error, value } = envValidationSchema.validate(buildEnv(), { abortEarly: false });
+    expect(error).toBeUndefined();
+    expect(value).toBeDefined();
   });
 
-  it('should pass when all required variables are valid', () => {
-    const { error, value } = envValidationSchema.validate(
-      {
-        PORT: 3000,
-        NODE_ENV: 'development',
-        DB_HOST: 'localhost',
-        DB_PORT: 5432,
-        DB_USERNAME: 'postgres',
-        DB_PASSWORD: 'postgres',
-        DB_NAME: 'lumentix_db',
-        JWT_SECRET: 'abcdefghijklmnopqrstuvwxyz123456',
-        JWT_EXPIRES_IN: '2h',
-        STELLAR_NETWORK: 'testnet',
-        HORIZON_URL: 'https://horizon-testnet.stellar.org',
-        NETWORK_PASSPHRASE: 'Test SDF Network ; September 2015',
-        PLATFORM_PUBLIC_KEY: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        PLATFORM_SECRET_KEY: 'SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        REDIS_HOST: 'localhost',
-        REDIS_PORT: 6379,
-        TICKET_SIGNING_SECRET: 'ticket-signing-secret',
-        TICKET_SIGNING_PUBLIC_KEY: 'ticket-signing-public-key',
-        SMTP_HOST: 'smtp.example.com',
-        SMTP_PORT: 587,
-        SMTP_USER: 'user',
-        SMTP_PASS: 'pass',
-        MAIL_FROM: 'admin@example.com',
-      },
+  it('fails when DB_HOST is missing', () => {
+    const env = buildEnv();
+    delete (env as Record<string, unknown>).DB_HOST;
+    const { error } = envValidationSchema.validate(env, { abortEarly: false });
+    expect(error).toBeDefined();
+    expect(error?.details.some((d) => d.path.includes('DB_HOST'))).toBe(true);
+  });
+
+  it('fails when JWT_SECRET is shorter than 32 characters', () => {
+    const { error } = envValidationSchema.validate(
+      buildEnv({ JWT_SECRET: 'tooshort' }),
       { abortEarly: false },
     );
+    expect(error).toBeDefined();
+    expect(error?.details.some((d) => d.path.includes('JWT_SECRET'))).toBe(true);
+  });
 
-    expect(error).toBeUndefined();
+  it('fails when STELLAR_NETWORK is not testnet or mainnet', () => {
+    const { error } = envValidationSchema.validate(
+      buildEnv({ STELLAR_NETWORK: 'devnet' }),
+      { abortEarly: false },
+    );
+    expect(error).toBeDefined();
+    expect(error?.details.some((d) => d.path.includes('STELLAR_NETWORK'))).toBe(true);
+  });
+
+  it('fails when MAIL_FROM is not a valid email', () => {
+    const { error } = envValidationSchema.validate(
+      buildEnv({ MAIL_FROM: 'not-an-email' }),
+      { abortEarly: false },
+    );
+    expect(error).toBeDefined();
+    expect(error?.details.some((d) => d.path.includes('MAIL_FROM'))).toBe(true);
+  });
+
+  it('applies default PORT = 3000 when not set', () => {
+    const { value } = envValidationSchema.validate(buildEnv(), { abortEarly: false });
     expect(value.PORT).toBe(3000);
+  });
+
+  it('applies default NODE_ENV = development when not set', () => {
+    const { value } = envValidationSchema.validate(buildEnv(), { abortEarly: false });
     expect(value.NODE_ENV).toBe('development');
   });
 
-  it('should fail when JWT_SECRET is shorter than 32 chars', () => {
-    const { error } = envValidationSchema.validate(
-      {
-        DB_HOST: 'localhost',
-        DB_USERNAME: 'postgres',
-        DB_PASSWORD: 'postgres',
-        DB_NAME: 'lumentix',
-        JWT_SECRET: 'short-secret',
-        STELLAR_NETWORK: 'testnet',
-        HORIZON_URL: 'https://horizon-testnet.stellar.org',
-        NETWORK_PASSPHRASE: 'Test SDF Network ; September 2015',
-        PLATFORM_PUBLIC_KEY: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        PLATFORM_SECRET_KEY: 'SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        TICKET_SIGNING_SECRET: 'ticket-signing-secret',
-        TICKET_SIGNING_PUBLIC_KEY: 'ticket-signing-public-key',
-        SMTP_HOST: 'smtp.example.com',
-        SMTP_PORT: 587,
-        SMTP_USER: 'user',
-        SMTP_PASS: 'pass',
-        MAIL_FROM: 'admin@example.com',
-      },
-      { abortEarly: false },
-    );
-
-    expect(error).toBeDefined();
-    expect(error?.details.some((d) => d.path.includes('JWT_SECRET'))).toBeTruthy();
+  it('applies default AUDIT_RETENTION_DAYS = 90 when not set', () => {
+    const { value } = envValidationSchema.validate(buildEnv(), { abortEarly: false });
+    expect(value.AUDIT_RETENTION_DAYS).toBe(90);
   });
 
-  it('should fail when NODE_ENV is invalid', () => {
-    const { error } = envValidationSchema.validate(
-      {
-        PORT: 3000,
-        NODE_ENV: 'invalid-env',
-        DB_HOST: 'localhost',
-        DB_USERNAME: 'postgres',
-        DB_PASSWORD: 'postgres',
-        DB_NAME: 'lumentix',
-        JWT_SECRET: 'abcdefghijklmnopqrstuvwxyz123456',
-        STELLAR_NETWORK: 'testnet',
-        HORIZON_URL: 'https://horizon-testnet.stellar.org',
-        NETWORK_PASSPHRASE: 'Test SDF Network ; September 2015',
-        PLATFORM_PUBLIC_KEY: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        PLATFORM_SECRET_KEY: 'SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        TICKET_SIGNING_SECRET: 'ticket-signing-secret',
-        TICKET_SIGNING_PUBLIC_KEY: 'ticket-signing-public-key',
-        SMTP_HOST: 'smtp.example.com',
-        SMTP_PORT: 587,
-        SMTP_USER: 'user',
-        SMTP_PASS: 'pass',
-        MAIL_FROM: 'admin@example.com',
-      },
+  it('reports ALL missing required fields at once (abortEarly: false)', () => {
+    const { error } = envValidationSchema.validate({}, { abortEarly: false });
+    expect(error).toBeDefined();
+    expect(error!.details.length).toBeGreaterThan(1);
+  });
+
+  it('applies default REFUND_CUTOFF_HOURS = 24 when not set', () => {
+    const { value } = envValidationSchema.validate(buildEnv(), { abortEarly: false });
+    expect(value.REFUND_CUTOFF_HOURS).toBe(24);
+  });
+
+  it('accepts REFUND_CUTOFF_HOURS when explicitly set', () => {
+    const { error, value } = envValidationSchema.validate(
+      buildEnv({ REFUND_CUTOFF_HOURS: 48 }),
       { abortEarly: false },
     );
+    expect(error).toBeUndefined();
+    expect(value.REFUND_CUTOFF_HOURS).toBe(48);
+  });
 
-    expect(error).toBeDefined();
-    expect(error?.details.some((d) => d.path.includes('NODE_ENV'))).toBeTruthy();
+  it('accepts mainnet as a valid STELLAR_NETWORK value', () => {
+    const { error } = envValidationSchema.validate(
+      buildEnv({ STELLAR_NETWORK: 'mainnet' }),
+      { abortEarly: false },
+    );
+    expect(error).toBeUndefined();
   });
 });

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -40,4 +40,12 @@ export const envValidationSchema = Joi.object({
 
   // CORS
   CORS_ORIGIN: Joi.string().default('http://localhost:3000'),
+
+  // Refund policy
+  REFUND_CUTOFF_HOURS: Joi.number().default(24),
+  FULL_REFUND_WINDOW_HOURS: Joi.number().default(48),
+  PARTIAL_REFUND_RATE: Joi.number().default(0.5),
+
+  // Audit retention
+  AUDIT_RETENTION_DAYS: Joi.number().default(90),
 });

--- a/backend/src/database/migrations/1743330400000-AddCompositeIndexes.ts
+++ b/backend/src/database/migrations/1743330400000-AddCompositeIndexes.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner, TableIndex } from 'typeorm';
+
+export class AddCompositeIndexes1743330400000 implements MigrationInterface {
+  name = 'AddCompositeIndexes1743330400000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // payments: userId + status (for history queries)
+    await queryRunner.createIndex(
+      'payments',
+      new TableIndex({
+        name: 'IDX_payments_userId_status',
+        columnNames: ['userId', 'status'],
+      }),
+    );
+
+    // tickets: eventId + status (for capacity queries)
+    await queryRunner.createIndex(
+      'tickets',
+      new TableIndex({
+        name: 'IDX_tickets_eventId_status',
+        columnNames: ['eventId', 'status'],
+      }),
+    );
+
+    // registrations: eventId + status (for waitlist queries)
+    await queryRunner.createIndex(
+      'registrations',
+      new TableIndex({
+        name: 'IDX_registrations_eventId_status',
+        columnNames: ['eventId', 'status'],
+      }),
+    );
+
+    // audit_logs: userId + action (for filtered audit queries)
+    await queryRunner.createIndex(
+      'audit_logs',
+      new TableIndex({
+        name: 'IDX_audit_logs_userId_action',
+        columnNames: ['userId', 'action'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('audit_logs', 'IDX_audit_logs_userId_action');
+    await queryRunner.dropIndex('registrations', 'IDX_registrations_eventId_status');
+    await queryRunner.dropIndex('tickets', 'IDX_tickets_eventId_status');
+    await queryRunner.dropIndex('payments', 'IDX_payments_userId_status');
+  }
+}

--- a/backend/src/payments/entities/payment.entity.ts
+++ b/backend/src/payments/entities/payment.entity.ts
@@ -14,6 +14,7 @@ export enum PaymentStatus {
   REFUNDED = 'refunded',
 }
 
+@Index(['userId', 'status'])
 @Entity('payments')
 export class Payment {
   @PrimaryGeneratedColumn('uuid')

--- a/backend/src/payments/refunds/refund.service.spec.ts
+++ b/backend/src/payments/refunds/refund.service.spec.ts
@@ -291,4 +291,47 @@ describe('RefundService', () => {
       expect(results[1].transactionHash).toBe('tx-success');
     });
   });
+
+  // ─── checkRefundEligibility — 24h cutoff ──────────────────────────────────
+
+  describe('checkRefundEligibility() — 24h cutoff', () => {
+    const RECENT_PAYMENT = {
+      id: 'pay-1',
+      eventId: 'event-1',
+      userId: 'user-1',
+      amount: 10,
+      currency: 'XLM',
+      status: PaymentStatus.CONFIRMED,
+      createdAt: new Date(Date.now() - 1 * 60 * 60 * 1000), // 1h ago
+    } as Payment;
+
+    it('returns eligible: false when event starts within 24h', async () => {
+      paymentsRepo.findOne.mockResolvedValue(RECENT_PAYMENT);
+      usersRepo.findOne.mockResolvedValue(USER_WITH_KEY);
+      eventsRepo.findOne.mockResolvedValue({
+        id: 'event-1',
+        startDate: new Date(Date.now() + 12 * 60 * 60 * 1000), // 12h from now
+      } as any);
+
+      const result = await service.checkRefundEligibility('pay-1');
+
+      expect(result.eligible).toBe(false);
+      expect(result.reason).toBe('Too close to event start');
+      expect(result.refundAmount).toBe(0);
+    });
+
+    it('returns eligible: true when event starts more than 24h away', async () => {
+      paymentsRepo.findOne.mockResolvedValue(RECENT_PAYMENT);
+      usersRepo.findOne.mockResolvedValue(USER_WITH_KEY);
+      eventsRepo.findOne.mockResolvedValue({
+        id: 'event-1',
+        startDate: new Date(Date.now() + 25 * 60 * 60 * 1000), // 25h from now
+      } as any);
+
+      const result = await service.checkRefundEligibility('pay-1');
+
+      expect(result.eligible).toBe(true);
+      expect(result.refundAmount).toBeGreaterThan(0);
+    });
+  });
 });

--- a/backend/src/payments/refunds/refund.service.ts
+++ b/backend/src/payments/refunds/refund.service.ts
@@ -145,6 +145,24 @@ export class RefundService {
       return { eligible: false, reason: 'No Stellar wallet linked', refundAmount: 0 };
     }
 
+    // Check 24h cutoff: no refund if event starts within REFUND_CUTOFF_HOURS
+    const event = await this.eventsRepository.findOne({
+      where: { id: payment.eventId },
+      select: ['id', 'startDate'],
+    });
+
+    if (event?.startDate) {
+      const cutoff = Number(process.env.REFUND_CUTOFF_HOURS ?? 24);
+      const hoursToEvent = (new Date(event.startDate).getTime() - Date.now()) / 3_600_000;
+      if (hoursToEvent < cutoff) {
+        return {
+          eligible: false,
+          reason: `Too close to event start`,
+          refundAmount: 0,
+        };
+      }
+    }
+
     const hoursSincePurchase =
       (Date.now() - payment.createdAt.getTime()) / (1000 * 60 * 60);
     const FULL_REFUND_WINDOW_HOURS = Number(

--- a/backend/src/registrations/entities/registration.entity.ts
+++ b/backend/src/registrations/entities/registration.entity.ts
@@ -14,6 +14,7 @@ export enum RegistrationStatus {
   WAITLISTED = 'waitlisted',
 }
 
+@Index(['eventId', 'status'])
 @Entity('registrations')
 export class Registration {
   @PrimaryGeneratedColumn('uuid')

--- a/backend/src/registrations/registrations.service.ts
+++ b/backend/src/registrations/registrations.service.ts
@@ -189,9 +189,10 @@ export class RegistrationsService {
 
     const hoursUntilStart =
       (new Date(event.startDate).getTime() - Date.now()) / (1000 * 60 * 60);
-    if (hoursUntilStart < 24) {
+    const cutoff = Number(process.env.REFUND_CUTOFF_HOURS ?? 24);
+    if (hoursUntilStart < cutoff) {
       throw new BadRequestException(
-        'Cancellations are not allowed within 24 hours of the event start',
+        `Refunds are not available within ${cutoff} hours of the event start.`,
       );
     }
 

--- a/backend/src/stellar/dto/path-payment.dto.ts
+++ b/backend/src/stellar/dto/path-payment.dto.ts
@@ -1,0 +1,6 @@
+export class PathPaymentDto {
+  sourcePublicKey: string;
+  sourceAsset: string;
+  destAsset: string;
+  destAmount: string;
+}

--- a/backend/src/stellar/stellar.service.spec.ts
+++ b/backend/src/stellar/stellar.service.spec.ts
@@ -279,4 +279,59 @@ describe('StellarService', () => {
       ).rejects.toThrow('tx_failed');
     });
   });
+
+  // ── findPaymentPath ────────────────────────────────────────────────────
+
+  describe('findPaymentPath', () => {
+    const SOURCE_PUBLIC = Keypair.random().publicKey();
+
+    it('returns path records when paths are available', async () => {
+      const mockRecords = [{ source_asset_type: 'native', path: [] }];
+      const mockServer = (service as any).server;
+      mockServer.strictReceivePaths = jest.fn().mockReturnValue({
+        call: jest.fn().mockResolvedValue({ records: mockRecords }),
+      });
+
+      const result = await service.findPaymentPath(SOURCE_PUBLIC, 'XLM', 'USDC', '10');
+
+      expect(result).toEqual(mockRecords);
+      expect(mockServer.strictReceivePaths).toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when no paths are found', async () => {
+      const mockServer = (service as any).server;
+      mockServer.strictReceivePaths = jest.fn().mockReturnValue({
+        call: jest.fn().mockResolvedValue({ records: [] }),
+      });
+
+      await expect(
+        service.findPaymentPath(SOURCE_PUBLIC, 'XLM', 'USDC', '10'),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ── buildPathPaymentXdr ────────────────────────────────────────────────
+
+  describe('buildPathPaymentXdr', () => {
+    it('returns a valid XDR string', async () => {
+      const { Asset: ActualAsset } = jest.requireActual('@stellar/stellar-sdk');
+      mockLoadAccount.mockResolvedValue(
+        makeMockAccount(makeBalances()),
+      );
+
+      const xdr = await service.buildPathPaymentXdr({
+        sourcePublicKey: ESCROW_PUBLIC,
+        sourceAsset: ActualAsset.native(),
+        sendMax: '15',
+        destPublicKey: DESTINATION,
+        destAsset: ActualAsset.native(),
+        destAmount: '10',
+        path: [],
+        memo: 'test-memo',
+      });
+
+      expect(typeof xdr).toBe('string');
+      expect(xdr.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/backend/src/stellar/stellar.service.ts
+++ b/backend/src/stellar/stellar.service.ts
@@ -15,6 +15,7 @@ import {
   BASE_FEE,
   Operation,
   Asset,
+  Memo,
 } from '@stellar/stellar-sdk';
 
 export type PaymentCallback = (
@@ -294,6 +295,73 @@ export class StellarService implements OnModuleDestroy {
       throw new InternalServerErrorException('Friendbot funding failed');
     }
     return { publicKey: keypair.publicKey(), secret: keypair.secret() };
+  }
+
+  // ─── Path payment methods ────────────────────────────────────────────────
+
+  /**
+   * Find available payment paths via Horizon's strict-receive path-finding API.
+   * Returns paths where the destination receives exactly `destAmount` of `destAsset`.
+   */
+  async findPaymentPath(
+    sourcePublicKey: string,
+    sourceAssetCode: string,
+    destAssetCode: string,
+    destAmount: string,
+  ): Promise<Horizon.ServerApi.PaymentPathRecord[]> {
+    const destAsset =
+      destAssetCode.toUpperCase() === 'XLM'
+        ? Asset.native()
+        : new Asset(destAssetCode, undefined);
+
+    const result = await this.server
+      .strictReceivePaths(sourcePublicKey, destAsset, destAmount)
+      .call();
+
+    if (!result.records.length) {
+      throw new BadRequestException(
+        `No payment path found from "${sourceAssetCode}" to "${destAssetCode}" for amount ${destAmount}.`,
+      );
+    }
+
+    return result.records;
+  }
+
+  /**
+   * Build a pathPaymentStrictReceive XDR string for the client to sign.
+   * Guarantees the destination receives exactly `destAmount` of `destAsset`.
+   */
+  async buildPathPaymentXdr(params: {
+    sourcePublicKey: string;
+    sourceAsset: Asset;
+    sendMax: string;
+    destPublicKey: string;
+    destAsset: Asset;
+    destAmount: string;
+    path: Asset[];
+    memo: string;
+  }): Promise<string> {
+    const sourceAccount = await this.server.loadAccount(params.sourcePublicKey);
+
+    const tx = new TransactionBuilder(sourceAccount, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        Operation.pathPaymentStrictReceive({
+          sendAsset: params.sourceAsset,
+          sendMax: params.sendMax,
+          destination: params.destPublicKey,
+          destAsset: params.destAsset,
+          destAmount: params.destAmount,
+          path: params.path,
+        }),
+      )
+      .addMemo(Memo.text(params.memo))
+      .setTimeout(30)
+      .build();
+
+    return tx.toXDR();
   }
 
   /**

--- a/backend/src/tickets/entities/ticket.entity.ts
+++ b/backend/src/tickets/entities/ticket.entity.ts
@@ -8,6 +8,7 @@ import {
 
 export type TicketStatus = 'valid' | 'used' | 'refunded' | 'expired';
 
+@Index(['eventId', 'status'])
 @Entity({ name: 'tickets' })
 export class TicketEntity {
   @PrimaryGeneratedColumn('uuid')


### PR DESCRIPTION
#318 test(config): add comprehensive Joi env validation schema tests
- Rewrite env.validation.spec.ts with 12 test cases covering all required scenarios: missing fields, JWT_SECRET min length, STELLAR_NETWORK valid values, MAIL_FROM email format, default values, abortEarly:false
- Add REFUND_CUTOFF_HOURS, FULL_REFUND_WINDOW_HOURS, PARTIAL_REFUND_RATE, AUDIT_RETENTION_DAYS to env.validation.ts with defaults
- Add new env vars to .env.example

#319 feat(refunds): enforce 24h pre-event refund cutoff policy
- cancelWithRefund now uses REFUND_CUTOFF_HOURS env var (default 24)
- checkRefundEligibility now checks event.startDate proximity and returns eligible:false with reason 'Too close to event start' when within cutoff
- Add unit tests for within-cutoff and outside-cutoff cases

#320 feat(stellar): add path payment support via Stellar DEX
- Add findPaymentPath() using Horizon strictReceivePaths API
- Add buildPathPaymentXdr() using Operation.pathPaymentStrictReceive
- Create PathPaymentDto
- Add unit tests mocking Horizon path-finding and verifying XDR output
- GET /payments/path endpoint and PaymentsService.findPaymentPath already existed

#321 feat(database): add composite indexes and migration
- Add @Index(['userId','status']) to Payment entity
- Add @Index(['eventId','status']) to TicketEntity and Registration entity
- Add @Index(['userId','action']) to AuditLog entity
- Create migration 1743330400000-AddCompositeIndexes.ts for all 4 indexes with reversible down() method

closes #318 
closes #319 
closes #320 
closes #321  