### PR TITLE
Add get_event_attendees read function to list addresses

### DIFF
--- a/contract/src/lumentix_contract.rs
+++ b/contract/src/lumentix_contract.rs
@@ -901,4 +901,40 @@ impl LumentixContract {
     pub fn get_is_initialized(env: Env) -> bool {
         storage::is_initialized(&env)
     }
+
+    /// Get the addresses of all checked-in (used ticket) attendees for an event.
+    /// Verifies the event exists, then iterates all tickets collecting owners of
+    /// used tickets matching event_id. Deduplicates so each address appears once.
+    pub fn get_event_attendees(
+        env: Env,
+        event_id: u64,
+    ) -> Result<Vec<Address>, LumentixError> {
+        // Verify event exists
+        let _ = storage::get_event(&env, event_id)?;
+
+        let mut attendees: Vec<Address> = Vec::new(&env);
+        let next_ticket_id = storage::get_next_ticket_id(&env);
+        let mut ticket_id: u64 = 1;
+
+        while ticket_id < next_ticket_id {
+            if let Ok(ticket) = storage::get_ticket(&env, ticket_id) {
+                if ticket.event_id == event_id && ticket.used {
+                    // Deduplicate: only add if not already present
+                    let mut already_added = false;
+                    for i in 0..attendees.len() {
+                        if attendees.get(i).unwrap() == ticket.owner {
+                            already_added = true;
+                            break;
+                        }
+                    }
+                    if !already_added {
+                        attendees.push_back(ticket.owner);
+                    }
+                }
+            }
+            ticket_id += 1;
+        }
+
+        Ok(attendees)
+    }
 }


### PR DESCRIPTION
closes #340 


This PR implements a read function to retrieve all attendees (checked-in users) for a given event. It enables organizers to view unique participant addresses based on used tickets.

Changes Included
Added get_event_attendees(env, event_id: u64) in lumentix_contract.rs
Validates event existence before processing

Iterates through tickets and filters by:
Matching event_id
used == true (checked-in tickets)

Collects owner addresses of valid tickets
Deduplicates addresses to ensure unique attendees
Returns vector of attendee addresses