### PR TITLE
feat(contract): add get_events_by_status read function for Soroban events

### DIFF
--- a/contract/src/lumentix_contract.rs
+++ b/contract/src/lumentix_contract.rs
@@ -623,6 +623,27 @@ impl LumentixContract {
         events
     }
 
+    /// Get all events matching a specific status.
+    /// Iterates through all event IDs up to the current counter and skips missing entries safely.
+    /// Returns an empty vector if no matching events exist.
+    /// No auth required.
+    pub fn get_events_by_status(env: Env, status: EventStatus) -> Vec<Event> {
+        let mut events = Vec::new(&env);
+        let next_event_id = storage::get_next_event_id(&env);
+        let mut event_id: u64 = 1;
+
+        while event_id < next_event_id {
+            if let Ok(event) = storage::get_event(&env, event_id) {
+                if event.status == status {
+                    events.push_back(event);
+                }
+            }
+            event_id += 1;
+        }
+
+        events
+    }
+
     /// Get all active (published) events.
     /// Iterates through all events and filters for status == Published.
     /// Returns an empty vector if no published events exist.

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -1821,6 +1821,209 @@ fn test_get_active_events_empty() {
 }
 
 #[test]
+fn test_get_events_by_status_mixed_statuses_filters_correctly() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+
+    let draft_event = client.create_event(
+        &organizer,
+        &String::from_str(&env, "Draft Event"),
+        &String::from_str(&env, "Description"),
+        &String::from_str(&env, "Location"),
+        &1000u64,
+        &2000u64,
+        &100i128,
+        &50u32,
+    );
+
+    let published_event = client.create_event(
+        &organizer,
+        &String::from_str(&env, "Published Event"),
+        &String::from_str(&env, "Description"),
+        &String::from_str(&env, "Location"),
+        &3000u64,
+        &4000u64,
+        &150i128,
+        &40u32,
+    );
+    client.update_event_status(&published_event, &EventStatus::Published, &organizer);
+
+    let cancelled_event = client.create_event(
+        &organizer,
+        &String::from_str(&env, "Cancelled Event"),
+        &String::from_str(&env, "Description"),
+        &String::from_str(&env, "Location"),
+        &5000u64,
+        &6000u64,
+        &200i128,
+        &30u32,
+    );
+    client.update_event_status(&cancelled_event, &EventStatus::Published, &organizer);
+    client.cancel_event(&organizer, &cancelled_event);
+
+    let draft_events = client.get_events_by_status(&EventStatus::Draft);
+    assert_eq!(draft_events.len(), 1);
+    assert_eq!(draft_events.get(0).unwrap().id, draft_event);
+    assert_eq!(draft_events.get(0).unwrap().status, EventStatus::Draft);
+
+    let published_events = client.get_events_by_status(&EventStatus::Published);
+    assert_eq!(published_events.len(), 1);
+    assert_eq!(published_events.get(0).unwrap().id, published_event);
+    assert_eq!(published_events.get(0).unwrap().status, EventStatus::Published);
+
+    let cancelled_events = client.get_events_by_status(&EventStatus::Cancelled);
+    assert_eq!(cancelled_events.len(), 1);
+    assert_eq!(cancelled_events.get(0).unwrap().id, cancelled_event);
+    assert_eq!(cancelled_events.get(0).unwrap().status, EventStatus::Cancelled);
+}
+
+#[test]
+fn test_get_events_by_status_empty_storage_returns_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, client) = create_test_contract(&env);
+
+    let events = client.get_events_by_status(&EventStatus::Published);
+    assert_eq!(events.len(), 0);
+}
+
+#[test]
+fn test_get_events_by_status_no_matches_returns_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+
+    client.create_event(
+        &organizer,
+        &String::from_str(&env, "Draft Event 1"),
+        &String::from_str(&env, "Description"),
+        &String::from_str(&env, "Location"),
+        &1000u64,
+        &2000u64,
+        &100i128,
+        &50u32,
+    );
+
+    client.create_event(
+        &organizer,
+        &String::from_str(&env, "Draft Event 2"),
+        &String::from_str(&env, "Description"),
+        &String::from_str(&env, "Location"),
+        &3000u64,
+        &4000u64,
+        &150i128,
+        &40u32,
+    );
+
+    let completed_events = client.get_events_by_status(&EventStatus::Completed);
+    assert_eq!(completed_events.len(), 0);
+}
+
+#[test]
+fn test_get_events_by_status_all_match_returns_all() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+
+    let event_id_1 = client.create_event(
+        &organizer,
+        &String::from_str(&env, "Published Event 1"),
+        &String::from_str(&env, "Description"),
+        &String::from_str(&env, "Location"),
+        &1000u64,
+        &2000u64,
+        &100i128,
+        &50u32,
+    );
+    client.update_event_status(&event_id_1, &EventStatus::Published, &organizer);
+
+    let event_id_2 = client.create_event(
+        &organizer,
+        &String::from_str(&env, "Published Event 2"),
+        &String::from_str(&env, "Description"),
+        &String::from_str(&env, "Location"),
+        &3000u64,
+        &4000u64,
+        &150i128,
+        &40u32,
+    );
+    client.update_event_status(&event_id_2, &EventStatus::Published, &organizer);
+
+    let published_events = client.get_events_by_status(&EventStatus::Published);
+    assert_eq!(published_events.len(), 2);
+    assert_eq!(published_events.get(0).unwrap().id, event_id_1);
+    assert_eq!(published_events.get(1).unwrap().id, event_id_2);
+
+    for event in published_events.iter() {
+        assert_eq!(event.status, EventStatus::Published);
+    }
+}
+
+#[test]
+fn test_get_events_by_status_skips_sparse_ids() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, contract_id, client) = create_test_contract_with_id(&env);
+    let organizer = Address::generate(&env);
+
+    let event_id_1 = client.create_event(
+        &organizer,
+        &String::from_str(&env, "Published Event 1"),
+        &String::from_str(&env, "Description"),
+        &String::from_str(&env, "Location"),
+        &1000u64,
+        &2000u64,
+        &100i128,
+        &50u32,
+    );
+    client.update_event_status(&event_id_1, &EventStatus::Published, &organizer);
+
+    let missing_event_id = client.create_event(
+        &organizer,
+        &String::from_str(&env, "Removed Event"),
+        &String::from_str(&env, "Description"),
+        &String::from_str(&env, "Location"),
+        &3000u64,
+        &4000u64,
+        &150i128,
+        &40u32,
+    );
+    client.update_event_status(&missing_event_id, &EventStatus::Published, &organizer);
+
+    let event_id_3 = client.create_event(
+        &organizer,
+        &String::from_str(&env, "Published Event 3"),
+        &String::from_str(&env, "Description"),
+        &String::from_str(&env, "Location"),
+        &5000u64,
+        &6000u64,
+        &200i128,
+        &30u32,
+    );
+    client.update_event_status(&event_id_3, &EventStatus::Published, &organizer);
+
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .remove(&("EVENT_", missing_event_id));
+    });
+
+    let published_events = client.get_events_by_status(&EventStatus::Published);
+    assert_eq!(published_events.len(), 2);
+    assert_eq!(published_events.get(0).unwrap().id, event_id_1);
+    assert_eq!(published_events.get(1).unwrap().id, event_id_3);
+}
+
+#[test]
 fn test_get_events_by_organizer_empty() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Summary

This PR adds a new read-only contract function, `get_events_by_status`, to the Soroban contract so callers can retrieve all events matching a given `EventStatus`.

The implementation follows the existing event query pattern in the contract:
- iterates through created event IDs from `1` to the current event counter boundary
- safely attempts to load each event from persistent storage
- skips missing event IDs without panicking
- returns only events whose `status` matches the requested filter

This PR also adds focused unit tests for the new query behavior, including sparse storage scenarios.

## What Changed

### Contract
Added:

- `pub fn get_events_by_status(env: Env, status: EventStatus) -> Vec<Event>`

Behavior:
- reads the current event counter using existing storage patterns
- loops through all possible event IDs
- uses safe event loading instead of assuming every ID exists
- appends matching events to the returned `Vec<Event>`
- performs no state mutation
- requires no auth

### Tests
Added unit coverage for:

1. multiple events with mixed statuses
2. no events in storage
3. events exist but none match the requested status
4. all events match the requested status
5. sparse IDs / missing stored events are skipped safely

### Merge Resolution
While syncing this branch with `main`, `src/lumentix_contract.rs` had a conflict in the event query section.

The resolution preserves both query helpers:
- `get_events_by_status`
- `get_events_by_org_and_status`

This avoids dropping functionality introduced on either side.

## Why

Consumers already have event-specific and organizer-specific read helpers, but there was no direct way to query events by status alone.

This addition makes it easier to:
- fetch all `Draft` events
- list all `Published` events
- inspect `Completed` or `Cancelled` events
- support backend/indexer/UI filtering with a simpler contract query

## Implementation Notes

- no storage schema changes
- no breaking interface changes to existing functions
- no auth requirements added
- no write-path behavior changed
- safe handling for missing IDs using existing storage access conventions
- gas usage remains straightforward and acceptable for this pattern

## Edge Cases Covered

- `EVENT_CTR = 0` returns an empty vector
- missing event IDs are skipped without failure
- multiple matching events are all returned
- no matching events returns an empty vector

## Files Changed

- `contract/src/lumentix_contract.rs`
- `contract/src/test.rs`

## Testing

Targeted tests added and verified for:

- `test_get_events_by_status_mixed_statuses_filters_correctly`
- `test_get_events_by_status_empty_storage_returns_empty`
- `test_get_events_by_status_no_matches_returns_empty`
- `test_get_events_by_status_all_match_returns_all`
- `test_get_events_by_status_skips_sparse_ids`

Command used:
```bash
cargo test get_events_by_status
```


Result:

5 passed
0 failed
Risk Assessment
Low risk.

Reasons:

change is additive
function is read-only
no existing storage keys or serialization formats were modified
tests cover both happy path and edge cases
sparse storage behavior is explicitly validated
Reviewer Notes
Please pay special attention to:

iteration boundary behavior using the existing event counter pattern
safe handling of missing event IDs
consistency with existing read/query helpers
whether the new helper should later be exposed alongside any frontend/backend event filtering workflows


Closes #333 


