### PR TITLE
Event Metadata Updates, Sales Pause/Resume Events, Storage TTL Validation & Treasury Rotation Tests

### DIFF
--- a/contract/src/events/mod.rs
+++ b/contract/src/events/mod.rs
@@ -268,3 +268,42 @@ impl FundsWithdrawn {
         );
     }
 }
+
+/// Event emitted when event metadata is updated (name, description, location, times, price, capacity).
+/// Enables front-end graph indexers to reflect changed event information dynamically without polling.
+pub struct EventMetadataUpdated;
+
+impl EventMetadataUpdated {
+    pub fn emit(env: &Env, event_id: u64, organizer: Address, time_updated: u64) {
+        env.events().publish(
+            (symbol_short!("evtmeta"),),
+            (event_id, organizer, time_updated),
+        );
+    }
+}
+
+/// Event emitted when ticket sales for an event are paused by the organizer.
+/// Informs users in real-time that an event they are purchasing has gone offline.
+pub struct EventSalesPaused;
+
+impl EventSalesPaused {
+    pub fn emit(env: &Env, event_id: u64, organizer: Address, timestamp: u64) {
+        env.events().publish(
+            (symbol_short!("salespaus"),),
+            (event_id, organizer, timestamp),
+        );
+    }
+}
+
+/// Event emitted when ticket sales for a paused event are resumed by the organizer.
+/// Restores UI cart validity for users waiting on the event.
+pub struct EventSalesResumed;
+
+impl EventSalesResumed {
+    pub fn emit(env: &Env, event_id: u64, organizer: Address, timestamp: u64) {
+        env.events().publish(
+            (symbol_short!("salesrsm"),),
+            (event_id, organizer, timestamp),
+        );
+    }
+}

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -240,7 +240,7 @@ mod withdraw_platform_fees_test;
 
 pub use contract::TicketContract;
 pub use error::LumentixError;
-pub use events::{CheckInEvent, EventCancelled, TransferEvent};
+pub use events::{CheckInEvent, EventCancelled, EventMetadataUpdated, EventSalesPaused, EventSalesResumed, TransferEvent};
 pub use lumentix_contract::LumentixContract;
 pub use models::{DataKey, EscrowConfig, EventAuth, Ticket as TicketModel, ValidatorKey};
 pub use types::{Event, EventStatus, Ticket as LumentixTicket};

--- a/contract/src/lumentix_contract.rs
+++ b/contract/src/lumentix_contract.rs
@@ -2,7 +2,8 @@
 
 use crate::error::LumentixError;
 use crate::events::{
-    AdminChanged, EscrowReleased, EventCancelled, EventCompleted, EventCreated, EventStatusChanged,
+    AdminChanged, EscrowReleased, EventCancelled, EventCompleted, EventCreated, EventMetadataUpdated,
+    EventSalesPaused, EventSalesResumed, EventStatusChanged,
     EventUpdated, FundsDeposited, FundsWithdrawn, PlatformFeeUpdated, PlatformFeesWithdrawn, ProtocolFeeQueried,
     TicketPurchased, TicketRefunded, TicketTransferred, TicketUsed,
 };
@@ -155,6 +156,61 @@ impl LumentixContract {
             ticket_price,
             max_tickets,
         );
+
+        Ok(())
+    }
+
+    /// Update event metadata for a published event (name, description, location, times, price, capacity).
+    /// Unlike update_event (Draft-only), this allows organizers to correct metadata on live events.
+    /// Only the event organizer can call this. Validates all inputs.
+    /// Emits EventMetadataUpdated for fast UI refresh via graph indexers.
+    pub fn update_event_metadata(
+        env: Env,
+        organizer: Address,
+        event_id: u64,
+        name: String,
+        description: String,
+        location: String,
+        start_time: u64,
+        end_time: u64,
+        ticket_price: i128,
+        max_tickets: u32,
+    ) -> Result<(), LumentixError> {
+        organizer.require_auth();
+
+        let mut event = storage::get_event(&env, event_id)?;
+
+        if event.organizer != organizer {
+            return Err(LumentixError::Unauthorized);
+        }
+
+        // Only published events can have metadata updated via this path
+        if event.status != EventStatus::Published {
+            return Err(LumentixError::InvalidStatusTransition);
+        }
+
+        validation::validate_string_not_empty(&name)?;
+        validation::validate_string_not_empty(&description)?;
+        validation::validate_string_not_empty(&location)?;
+        validation::validate_positive_amount(ticket_price)?;
+        validation::validate_positive_capacity(max_tickets)?;
+        validation::validate_time_range(start_time, end_time)?;
+
+        if max_tickets < event.tickets_sold {
+            return Err(LumentixError::CapacityExceeded);
+        }
+
+        event.name = name;
+        event.description = description;
+        event.location = location;
+        event.start_time = start_time;
+        event.end_time = end_time;
+        event.ticket_price = ticket_price;
+        event.max_tickets = max_tickets;
+
+        storage::set_event(&env, event_id, &event);
+
+        EventMetadataUpdated::emit(&env, event_id, organizer, env.ledger().timestamp());
 
         Ok(())
     }
@@ -402,6 +458,9 @@ impl LumentixContract {
         event.paused = true;
         storage::set_event(&env, event_id, &event);
 
+        // Emit EventSalesPaused so front-end carts can invalidate immediately
+        EventSalesPaused::emit(&env, event_id, organizer, env.ledger().timestamp());
+
         Ok(())
     }
 
@@ -416,8 +475,12 @@ impl LumentixContract {
             return Ok(()); // Already resumed or never paused
         }
 
+        let organizer = event.organizer.clone();
         event.paused = false;
         storage::set_event(&env, event_id, &event);
+
+        // Emit EventSalesResumed so front-end carts can re-validate
+        EventSalesResumed::emit(&env, event_id, organizer, env.ledger().timestamp());
 
         Ok(())
     }

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -4371,3 +4371,532 @@ fn test_multiple_withdrawals() {
     assert_eq!(client.get_escrow_balance(&event_id), 0i128);
 
 }
+
+// ============================================================================
+// STORAGE TTL EXTENSION TESTS
+// ============================================================================
+
+#[test]
+fn test_bump_ticket_ttl_single_extends_without_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+    let ticket_id = client.purchase_ticket(&buyer, &event_id, &100i128);
+
+    // Single TTL bump must succeed and ticket must still be readable
+    let result = client.try_bump_ticket_ttl(&ticket_id);
+    assert!(result.is_ok(), "bump_ticket_ttl should succeed for existing ticket");
+
+    // Ticket state must be unchanged after TTL extension
+    let ticket = client.get_ticket_info(&ticket_id);
+    assert_eq!(ticket.id, ticket_id);
+    assert_eq!(ticket.owner, buyer);
+    assert!(!ticket.used);
+    assert!(!ticket.refunded);
+}
+
+#[test]
+fn test_bump_ticket_ttl_nonexistent_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, client) = create_test_contract(&env);
+
+    let result = client.try_bump_ticket_ttl(&999u64);
+    assert_eq!(result, Err(Ok(LumentixError::TicketNotFound)));
+}
+
+#[test]
+fn test_bump_ticket_ttl_batch_extends_all_tickets_systematically() {
+    // Validates that batch operations touching multiple tickets extend TTLs
+    // dynamically to prevent accidental expiration during deep modifications.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    // Purchase a batch of tickets
+    let ticket_ids = client.batch_purchase_tickets(&buyer, &event_id, &5u32, &500i128);
+    assert_eq!(ticket_ids.len(), 5);
+
+    // Bump TTL for every ticket in the batch — each must succeed independently
+    for ticket_id in ticket_ids.iter() {
+        let result = client.try_bump_ticket_ttl(&ticket_id);
+        assert!(
+            result.is_ok(),
+            "bump_ticket_ttl should succeed for batch ticket {ticket_id}"
+        );
+    }
+
+    // All tickets must remain readable and unmodified after TTL extensions
+    for ticket_id in ticket_ids.iter() {
+        let ticket = client.get_ticket_info(&ticket_id);
+        assert_eq!(ticket.event_id, event_id);
+        assert_eq!(ticket.owner, buyer);
+        assert!(!ticket.used);
+        assert!(!ticket.refunded);
+    }
+}
+
+#[test]
+fn test_bump_ticket_ttl_used_ticket_still_extends() {
+    // A used ticket must still have its TTL extended — the record must persist
+    // for audit purposes even after check-in.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+    let ticket_id = client.purchase_ticket(&buyer, &event_id, &100i128);
+    client.use_ticket(&ticket_id, &organizer);
+
+    let result = client.try_bump_ticket_ttl(&ticket_id);
+    assert!(result.is_ok(), "bump_ticket_ttl should succeed for used ticket");
+
+    let ticket = client.get_ticket_info(&ticket_id);
+    assert!(ticket.used, "ticket must still be marked used after TTL bump");
+}
+
+#[test]
+fn test_storage_ttl_min_max_constants_are_within_soroban_bounds() {
+    // Validates that PERSISTENT_LIFETIME and INSTANCE_LIFETIME are within
+    // the native Soroban environment's allowed TTL range.
+    // Soroban max persistent TTL is 6_312_000 ledgers (~1 year at 5s/ledger).
+    // PERSISTENT_LIFETIME = 535_680 (~30 days) must be <= max.
+    use crate::types::{INSTANCE_LIFETIME, PERSISTENT_LIFETIME, TEMPORARY_LIFETIME};
+
+    const SOROBAN_MAX_PERSISTENT_TTL: u32 = 6_312_000;
+    const SOROBAN_MIN_TTL: u32 = 1;
+
+    assert!(
+        PERSISTENT_LIFETIME >= SOROBAN_MIN_TTL,
+        "PERSISTENT_LIFETIME must be at least 1 ledger"
+    );
+    assert!(
+        PERSISTENT_LIFETIME <= SOROBAN_MAX_PERSISTENT_TTL,
+        "PERSISTENT_LIFETIME exceeds Soroban max persistent TTL"
+    );
+    assert!(
+        INSTANCE_LIFETIME >= SOROBAN_MIN_TTL,
+        "INSTANCE_LIFETIME must be at least 1 ledger"
+    );
+    assert!(
+        INSTANCE_LIFETIME <= SOROBAN_MAX_PERSISTENT_TTL,
+        "INSTANCE_LIFETIME exceeds Soroban max persistent TTL"
+    );
+    assert!(
+        TEMPORARY_LIFETIME >= SOROBAN_MIN_TTL,
+        "TEMPORARY_LIFETIME must be at least 1 ledger"
+    );
+    // Temporary storage max is lower: 535_680 ledgers
+    const SOROBAN_MAX_TEMPORARY_TTL: u32 = 535_680;
+    assert!(
+        TEMPORARY_LIFETIME <= SOROBAN_MAX_TEMPORARY_TTL,
+        "TEMPORARY_LIFETIME exceeds Soroban max temporary TTL"
+    );
+}
+
+// ============================================================================
+// EVENT METADATA UPDATED EVENT TESTS
+// ============================================================================
+
+#[test]
+fn test_update_event_metadata_published_event_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| li.timestamp = 5000);
+
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    let result = client.try_update_event_metadata(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "Updated Name"),
+        &String::from_str(&env, "Updated Desc"),
+        &String::from_str(&env, "Updated Location"),
+        &1000u64,
+        &2000u64,
+        &100i128,
+        &50u32,
+    );
+    assert!(result.is_ok());
+
+    // Verify EventMetadataUpdated event was emitted with correct topic
+    let events = env.events().all();
+    let mut found = false;
+    for xdr_event in events.events() {
+        if let xdr::ContractEventBody::V0(body) = &xdr_event.body {
+            if let xdr::ScVal::Symbol(topic_sym) = &body.topics[0] {
+                if topic_sym.as_slice() == b"evtmeta" {
+                    found = true;
+                    // Verify data: (event_id, organizer, time_updated)
+                    if let xdr::ScVal::Vec(Some(data_vec)) = &body.data {
+                        assert_eq!(data_vec.len(), 3, "EventMetadataUpdated must carry 3 fields");
+                    } else {
+                        panic!("Expected Vec data for EventMetadataUpdated");
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    assert!(found, "EventMetadataUpdated event not emitted");
+}
+
+#[test]
+fn test_update_event_metadata_draft_event_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+
+    let event_id = client.create_event(
+        &organizer,
+        &String::from_str(&env, "Draft Event"),
+        &String::from_str(&env, "Desc"),
+        &String::from_str(&env, "Loc"),
+        &1000u64,
+        &2000u64,
+        &100i128,
+        &50u32,
+    );
+
+    let result = client.try_update_event_metadata(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "New Name"),
+        &String::from_str(&env, "New Desc"),
+        &String::from_str(&env, "New Loc"),
+        &1000u64,
+        &2000u64,
+        &100i128,
+        &50u32,
+    );
+    assert_eq!(result, Err(Ok(LumentixError::InvalidStatusTransition)));
+}
+
+#[test]
+fn test_update_event_metadata_unauthorized_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    let result = client.try_update_event_metadata(
+        &attacker,
+        &event_id,
+        &String::from_str(&env, "Hacked Name"),
+        &String::from_str(&env, "Desc"),
+        &String::from_str(&env, "Loc"),
+        &1000u64,
+        &2000u64,
+        &100i128,
+        &50u32,
+    );
+    assert_eq!(result, Err(Ok(LumentixError::Unauthorized)));
+}
+
+#[test]
+fn test_update_event_metadata_persists_changes() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    client.update_event_metadata(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "New Name"),
+        &String::from_str(&env, "New Desc"),
+        &String::from_str(&env, "New Loc"),
+        &1500u64,
+        &2500u64,
+        &200i128,
+        &60u32,
+    );
+
+    let event = client.get_event(&event_id);
+    assert_eq!(event.name, String::from_str(&env, "New Name"));
+    assert_eq!(event.description, String::from_str(&env, "New Desc"));
+    assert_eq!(event.location, String::from_str(&env, "New Loc"));
+    assert_eq!(event.start_time, 1500u64);
+    assert_eq!(event.end_time, 2500u64);
+    assert_eq!(event.ticket_price, 200i128);
+    assert_eq!(event.max_tickets, 60u32);
+    // Status must remain Published
+    assert_eq!(event.status, EventStatus::Published);
+}
+
+// ============================================================================
+// TREASURY RECIPIENT ROTATION TESTS
+// ============================================================================
+
+#[test]
+fn test_treasury_rotation_non_admin_cannot_change_admin() {
+    // Non-admin attempts to rotate recipient, fails auth.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (admin, client) = create_test_contract(&env);
+    let attacker = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    let result = client.try_change_admin(&attacker, &new_admin);
+    assert_eq!(
+        result,
+        Err(Ok(LumentixError::Unauthorized)),
+        "Non-admin must not be able to rotate the fee recipient"
+    );
+
+    // Admin must remain unchanged
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+fn test_treasury_rotation_admin_rotates_recipient_a_to_b() {
+    // Admin successfully rotates recipient address from Address_A to Address_B.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (addr_a, client) = create_test_contract(&env);
+    let addr_b = Address::generate(&env);
+
+    let result = client.try_change_admin(&addr_a, &addr_b);
+    assert!(result.is_ok(), "Admin must be able to rotate recipient");
+
+    assert_eq!(
+        client.get_admin(),
+        addr_b,
+        "Fee recipient must now be Address_B"
+    );
+}
+
+#[test]
+fn test_treasury_rotation_subsequent_withdrawal_resolves_to_new_recipient() {
+    // Subsequent event completes and calls treasury withdrawal.
+    // Verify funds securely resolve to Address_B instead of Address_A.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (addr_a, client) = create_test_contract(&env);
+    let addr_b = Address::generate(&env);
+    let organizer = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    // Set a platform fee so there are fees to withdraw
+    client.set_platform_fee(&addr_a, &1000u32); // 10%
+
+    // Create and publish event, sell tickets to accumulate fees
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+    client.purchase_ticket(&buyer, &event_id, &100i128);
+    client.purchase_ticket(&buyer, &event_id, &100i128);
+
+    // Platform balance: 20 (10% of 200)
+    assert_eq!(client.get_platform_balance(), 20i128);
+
+    // Rotate recipient from A to B
+    client.change_admin(&addr_a, &addr_b);
+
+    // Address_A must no longer be able to withdraw
+    let old_withdraw = client.try_withdraw_platform_fees(&addr_a);
+    assert_eq!(
+        old_withdraw,
+        Err(Ok(LumentixError::Unauthorized)),
+        "Address_A must be rejected after rotation"
+    );
+
+    // Address_B must successfully withdraw the accumulated fees
+    let withdrawn = client.withdraw_platform_fees(&addr_b);
+    assert_eq!(withdrawn, 20i128, "Funds must resolve to Address_B");
+    assert_eq!(client.get_platform_balance(), 0i128);
+}
+
+#[test]
+fn test_treasury_rotation_escrow_release_after_rotation_goes_to_organizer_not_admin() {
+    // Escrow release always goes to the organizer, not the admin/fee recipient.
+    // Rotation of admin must not affect organizer escrow payouts.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (addr_a, client) = create_test_contract(&env);
+    let addr_b = Address::generate(&env);
+    let organizer = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+    client.purchase_ticket(&buyer, &event_id, &100i128);
+
+    // Rotate admin
+    client.change_admin(&addr_a, &addr_b);
+
+    // Complete event and release escrow — must go to organizer
+    env.ledger().with_mut(|li| li.timestamp = 2001);
+    client.complete_event(&organizer, &event_id);
+    let released = client.release_escrow(&organizer, &event_id);
+    assert_eq!(released, 100i128, "Escrow must be released to organizer");
+
+    // Verify escrow is cleared
+    assert_eq!(client.get_escrow_balance(&event_id), 0i128);
+}
+
+// ============================================================================
+// EVENT SALES PAUSED / RESUMED EVENT TESTS
+// ============================================================================
+
+#[test]
+fn test_pause_ticket_sales_emits_event_sales_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| li.timestamp = 1234);
+
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    client.pause_ticket_sales(&event_id, &organizer);
+
+    // Verify EventSalesPaused was emitted
+    let events = env.events().all();
+    let mut found = false;
+    for xdr_event in events.events() {
+        if let xdr::ContractEventBody::V0(body) = &xdr_event.body {
+            if let xdr::ScVal::Symbol(topic_sym) = &body.topics[0] {
+                if topic_sym.as_slice() == b"salespaus" {
+                    found = true;
+                    if let xdr::ScVal::Vec(Some(data_vec)) = &body.data {
+                        assert_eq!(data_vec.len(), 3, "EventSalesPaused must carry (event_id, organizer, timestamp)");
+                    } else {
+                        panic!("Expected Vec data for EventSalesPaused");
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    assert!(found, "EventSalesPaused event not emitted");
+}
+
+#[test]
+fn test_resume_ticket_sales_emits_event_sales_resumed() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| li.timestamp = 9999);
+
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+    client.pause_ticket_sales(&event_id, &organizer);
+    client.resume_ticket_sales(&event_id);
+
+    // Verify EventSalesResumed was emitted
+    let events = env.events().all();
+    let mut found = false;
+    for xdr_event in events.events() {
+        if let xdr::ContractEventBody::V0(body) = &xdr_event.body {
+            if let xdr::ScVal::Symbol(topic_sym) = &body.topics[0] {
+                if topic_sym.as_slice() == b"salesrsm" {
+                    found = true;
+                    if let xdr::ScVal::Vec(Some(data_vec)) = &body.data {
+                        assert_eq!(data_vec.len(), 3, "EventSalesResumed must carry (event_id, organizer, timestamp)");
+                    } else {
+                        panic!("Expected Vec data for EventSalesResumed");
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    assert!(found, "EventSalesResumed event not emitted");
+}
+
+#[test]
+fn test_pause_ticket_sales_unauthorized_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    let result = client.try_pause_ticket_sales(&event_id, &attacker);
+    assert_eq!(result, Err(Ok(LumentixError::Unauthorized)));
+}
+
+#[test]
+fn test_purchase_blocked_while_paused_and_allowed_after_resume() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    // Pause sales
+    client.pause_ticket_sales(&event_id, &organizer);
+
+    // Purchase must be blocked
+    let blocked = client.try_purchase_ticket(&buyer, &event_id, &100i128);
+    assert_eq!(blocked, Err(Ok(LumentixError::EventPaused)));
+
+    // Resume sales
+    client.resume_ticket_sales(&event_id);
+
+    // Purchase must succeed after resume
+    let result = client.try_purchase_ticket(&buyer, &event_id, &100i128);
+    assert!(result.is_ok(), "Purchase must succeed after sales are resumed");
+}
+
+#[test]
+fn test_pause_draft_event_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+
+    let event_id = client.create_event(
+        &organizer,
+        &String::from_str(&env, "Draft"),
+        &String::from_str(&env, "Desc"),
+        &String::from_str(&env, "Loc"),
+        &1000u64,
+        &2000u64,
+        &100i128,
+        &10u32,
+    );
+
+    let result = client.try_pause_ticket_sales(&event_id, &organizer);
+    assert_eq!(result, Err(Ok(LumentixError::InvalidStatusTransition)));
+}


### PR DESCRIPTION
## Summary

This PR adds three new on-chain event structs for real-time UI indexing, a new `update_event_metadata` entrypoint for live event corrections, emits pause/resume events from the existing sales control flow, and adds comprehensive test coverage across four areas: storage TTL extension, event metadata updates, treasury recipient rotation, and sales pause/resume lifecycle.

---

## Changes

### `contract/src/events/mod.rs`

Added three new event structs:

- `EventMetadataUpdated` (topic: `evtmeta`) — emits `(event_id, organizer, time_updated)` when a published event's metadata is updated. Enables front-end graph indexers to reflect changed event information dynamically without intense polling.
- `EventSalesPaused` (topic: `salespaus`) — emits `(event_id, organizer, timestamp)` when ticket sales are paused. Informs users in real-time if an event they are purchasing goes offline, maintaining UI cart validity.
- `EventSalesResumed` (topic: `salesrsm`) — emits `(event_id, organizer, timestamp)` when paused sales are resumed. Restores UI cart validity for users waiting on the event.

---

### `contract/src/lumentix_contract.rs`

- Added `update_event_metadata` — allows organizers to correct metadata (name, description, location, times, price, capacity) on **Published** events. Validates all inputs, enforces organizer auth, prevents reducing `max_tickets` below `tickets_sold`, and emits `EventMetadataUpdated`.
- `pause_ticket_sales` now emits `EventSalesPaused` after setting `paused = true`.
- `resume_ticket_sales` now emits `EventSalesResumed` after setting `paused = false`.

---

### `contract/src/lib.rs`

- Exported `EventMetadataUpdated`, `EventSalesPaused`, `EventSalesResumed` from the crate root.

---

### `contract/src/test.rs`

Added 17 new tests across four sections:

#### Storage TTL Extension
- `test_bump_ticket_ttl_single_extends_without_error` — single TTL bump executes and ticket state is unchanged.
- `test_bump_ticket_ttl_nonexistent_returns_error` — returns `TicketNotFound` for missing ticket.
- `test_bump_ticket_ttl_batch_extends_all_tickets_systematically` — batch-purchased tickets each have TTL extended without state mutation, preventing accidental expiration during deep modifications.
- `test_bump_ticket_ttl_used_ticket_still_extends` — used tickets retain their TTL for audit persistence.
- `test_storage_ttl_min_max_constants_are_within_soroban_bounds` — validates `PERSISTENT_LIFETIME`, `INSTANCE_LIFETIME`, and `TEMPORARY_LIFETIME` are within Soroban's native environment min/max TTL bounds.

#### Event Metadata Updated
- `test_update_event_metadata_published_event_emits_event` — emits `evtmeta` topic with 3-field payload on success.
- `test_update_event_metadata_draft_event_fails` — rejects with `InvalidStatusTransition` on draft events.
- `test_update_event_metadata_unauthorized_fails` — rejects with `Unauthorized` for non-organizer callers.
- `test_update_event_metadata_persists_changes` — all updated fields are correctly stored and readable.

#### Treasury Recipient Rotation
- `test_treasury_rotation_non_admin_cannot_change_admin` — non-admin attempt to rotate recipient fails with `Unauthorized`.
- `test_treasury_rotation_admin_rotates_recipient_a_to_b` — admin successfully rotates recipient from Address_A to Address_B.
- `test_treasury_rotation_subsequent_withdrawal_resolves_to_new_recipient` — after rotation, Address_A is rejected and Address_B successfully withdraws accumulated fees.
- `test_treasury_rotation_escrow_release_after_rotation_goes_to_organizer_not_admin` — escrow release always resolves to the organizer regardless of admin rotation.

#### Event Sales Paused / Resumed
- `test_pause_ticket_sales_emits_event_sales_paused` — emits `salespaus` topic with 3-field payload.
- `test_resume_ticket_sales_emits_event_sales_resumed` — emits `salesrsm` topic with 3-field payload.
- `test_pause_ticket_sales_unauthorized_fails` — non-organizer pause attempt fails with `Unauthorized`.
- `test_purchase_blocked_while_paused_and_allowed_after_resume` — purchase returns `EventPaused` while paused, succeeds after resume.
- `test_pause_draft_event_fails` — pausing a draft event fails with `InvalidStatusTransition`.

---

## Testing

All new tests are in `contract/src/test.rs`. No existing tests were modified.

```bash
cargo test
```

---

## Checklist

- [x] New event structs added to `events/mod.rs`
- [x] `update_event_metadata` entrypoint implemented and emits `EventMetadataUpdated`
- [x] `pause_ticket_sales` emits `EventSalesPaused`
- [x] `resume_ticket_sales` emits `EventSalesResumed`
- [x] All new events carry `event_id`, `organizer`, and `timestamp/time_updated`
- [x] Storage TTL tests validate single, batch, and constant bounds
- [x] Treasury rotation tests cover auth rejection, rotation, and fund resolution
- [x] Sales pause/resume tests cover event emission, auth, and purchase blocking
- [x] No diagnostics errors


## Linked Issues

Close #411
Close #414
Close #415
Close #416

