### PR TITLE
Add event analytics and admin action tracking

### DIFF
--- a/contract/src/events/mod.rs
+++ b/contract/src/events/mod.rs
@@ -307,3 +307,67 @@ impl EventSalesResumed {
         );
     }
 }
+
+/// Universal event emitted anytime an EventStatus switches (e.g. Draft -> Published, Active -> Cancelled).
+/// Standardizes indexer states minimizing specific listener configuration.
+pub struct GenericEventStateTransition;
+
+impl GenericEventStateTransition {
+    pub fn emit(
+        env: &Env,
+        event_id: u64,
+        caller: Address,
+        old_status: crate::types::EventStatus,
+        new_status: crate::types::EventStatus,
+    ) {
+        env.events().publish(
+            (symbol_short!("genstsch"),),
+            (event_id, caller, old_status, new_status),
+        );
+    }
+}
+
+/// Event emitted when an event's capacity is changed.
+/// Alerts scalpers, waitlists, and potential buyers of capacity changes immediately.
+pub struct EventCapacityChanged;
+
+impl EventCapacityChanged {
+    pub fn emit(env: &Env, event_id: u64, old_capacity: u32, new_capacity: u32) {
+        env.events().publish(
+            (symbol_short!("capchng"),),
+            (event_id, old_capacity, new_capacity),
+        );
+    }
+}
+
+/// Event emitted when a ticket is revoked by an admin.
+/// Provides audit trail for admin tampering actions and builds off-chain trust graphs.
+pub struct TicketRevoked;
+
+impl TicketRevoked {
+    pub fn emit(
+        env: &Env,
+        admin_address: Address,
+        ticket_id: u64,
+        event_id: u64,
+        reason: Option<String>,
+    ) {
+        env.events().publish(
+            (symbol_short!("tktrevok"),),
+            (admin_address, ticket_id, event_id, reason),
+        );
+    }
+}
+
+/// Event emitted when an event's end time is extended.
+/// Notifies attendees of prolonged event times for mobile push alerts.
+pub struct EventTimeExtended;
+
+impl EventTimeExtended {
+    pub fn emit(env: &Env, event_id: u64, previous_end_time: u64, new_end_time: u64) {
+        env.events().publish(
+            (symbol_short!("timeext"),),
+            (event_id, previous_end_time, new_end_time),
+        );
+    }
+}

--- a/contract/src/lumentix_contract.rs
+++ b/contract/src/lumentix_contract.rs
@@ -2,10 +2,11 @@
 
 use crate::error::LumentixError;
 use crate::events::{
-    AdminChanged, EscrowReleased, EventCancelled, EventCompleted, EventCreated, EventMetadataUpdated,
-    EventSalesPaused, EventSalesResumed, EventStatusChanged,
-    EventUpdated, FundsDeposited, FundsWithdrawn, PlatformFeeUpdated, PlatformFeesWithdrawn, ProtocolFeeQueried,
-    TicketPurchased, TicketRefunded, TicketTransferred, TicketUsed,
+    AdminChanged, EscrowReleased, EventCapacityChanged, EventCancelled, EventCompleted, EventCreated,
+    EventMetadataUpdated, EventSalesPaused, EventSalesResumed, EventStatusChanged, EventTimeExtended,
+    EventUpdated, FundsDeposited, FundsWithdrawn, GenericEventStateTransition, PlatformFeeUpdated,
+    PlatformFeesWithdrawn, ProtocolFeeQueried, TicketPurchased, TicketRefunded, TicketRevoked,
+    TicketTransferred, TicketUsed,
 };
 use crate::storage;
 use crate::types::{Event, EventStatus, Ticket, TicketTransferRecord, PERSISTENT_LIFETIME};
@@ -254,7 +255,10 @@ impl LumentixContract {
         storage::set_event(&env, event_id, &event);
 
         // Emit EventStatusChanged event
-        EventStatusChanged::emit(&env, event_id, caller, old_status, new_status);
+        EventStatusChanged::emit(&env, event_id, caller.clone(), old_status.clone(), new_status.clone());
+
+        // Emit GenericEventStateTransition event for universal state transition tracking
+        GenericEventStateTransition::emit(&env, event_id, caller, old_status, new_status);
 
         Ok(())
     }
@@ -279,8 +283,50 @@ impl LumentixContract {
             return Err(LumentixError::CapacityExceeded);
         }
 
+        let old_capacity = event.max_tickets;
         event.max_tickets = new_capacity;
         storage::set_event(&env, event_id, &event);
+
+        // Emit EventCapacityChanged event
+        EventCapacityChanged::emit(&env, event_id, old_capacity, new_capacity);
+
+        Ok(())
+    }
+
+    /// Extend the end time of an event.
+    /// Only the organizer can extend the event end time.
+    /// New end time must be after the current end time.
+    /// Emits EventTimeExtended event for mobile push alerts.
+    pub fn extend_event_end_time(
+        env: Env,
+        organizer: Address,
+        event_id: u64,
+        new_end_time: u64,
+    ) -> Result<(), LumentixError> {
+        organizer.require_auth();
+
+        let mut event = storage::get_event(&env, event_id)?;
+
+        if event.organizer != organizer {
+            return Err(LumentixError::Unauthorized);
+        }
+
+        // Only published events can have end time extended
+        if event.status != EventStatus::Published {
+            return Err(LumentixError::InvalidStatusTransition);
+        }
+
+        // New end time must be after current end time
+        if new_end_time <= event.end_time {
+            return Err(LumentixError::InvalidTimeRange);
+        }
+
+        let previous_end_time = event.end_time;
+        event.end_time = new_end_time;
+        storage::set_event(&env, event_id, &event);
+
+        // Emit EventTimeExtended event
+        EventTimeExtended::emit(&env, event_id, previous_end_time, new_end_time);
 
         Ok(())
     }
@@ -690,6 +736,47 @@ impl LumentixContract {
         Ok(())
     }
 
+    /// Revoke a ticket by admin action.
+    /// Marks the ticket as refunded and used to prevent entry.
+    /// Emits TicketRevoked event for audit trail and off-chain trust graphs.
+    pub fn revoke_ticket(
+        env: Env,
+        admin: Address,
+        ticket_id: u64,
+        reason: Option<String>,
+    ) -> Result<(), LumentixError> {
+        admin.require_auth();
+
+        // Verify caller is the admin
+        let stored_admin = storage::get_admin(&env);
+        if stored_admin != admin {
+            return Err(LumentixError::Unauthorized);
+        }
+
+        let mut ticket = storage::get_ticket(&env, ticket_id)?;
+
+        // Already revoked/refunded tickets cannot be revoked again
+        if ticket.refunded {
+            return Err(LumentixError::RefundNotAllowed);
+        }
+
+        let mut event = storage::get_event(&env, ticket.event_id)?;
+
+        // Mark ticket as refunded and used to prevent entry
+        ticket.refunded = true;
+        ticket.used = true;
+        storage::set_ticket(&env, ticket_id, &ticket);
+
+        // Decrement tickets_sold to free up capacity
+        event.tickets_sold = event.tickets_sold.saturating_sub(1);
+        storage::set_event(&env, ticket.event_id, &event);
+
+        // Emit TicketRevoked event for audit trail
+        TicketRevoked::emit(&env, admin, ticket_id, ticket.event_id, reason);
+
+        Ok(())
+    }
+
     /// Cancel a published event. Only the organizer can cancel.
     pub fn cancel_event(env: Env, organizer: Address, event_id: u64) -> Result<(), LumentixError> {
         organizer.require_auth();
@@ -704,9 +791,13 @@ impl LumentixContract {
             return Err(LumentixError::InvalidStatusTransition);
         }
 
+        let old_status = event.status.clone();
         event.status = EventStatus::Cancelled;
         storage::set_event(&env, event_id, &event);
-        EventCancelled::emit(&env, event_id, organizer, event.tickets_sold);
+        EventCancelled::emit(&env, event_id, organizer.clone(), event.tickets_sold);
+
+        // Emit GenericEventStateTransition event for universal state transition tracking
+        GenericEventStateTransition::emit(&env, event_id, organizer, old_status, EventStatus::Cancelled);
 
         Ok(())
     }
@@ -734,11 +825,15 @@ impl LumentixContract {
             return Err(LumentixError::InvalidStatusTransition);
         }
 
+        let old_status = event.status.clone();
         event.status = EventStatus::Completed;
         storage::set_event(&env, event_id, &event);
 
         // Emit EventCompleted event
-        EventCompleted::emit(&env, event_id, organizer, event.tickets_sold);
+        EventCompleted::emit(&env, event_id, organizer.clone(), event.tickets_sold);
+
+        // Emit GenericEventStateTransition event for universal state transition tracking
+        GenericEventStateTransition::emit(&env, event_id, organizer, old_status, EventStatus::Completed);
 
         Ok(())
     }


### PR DESCRIPTION
- Add GenericEventStateTransition event emission to update_event_status, cancel_event, and complete_event functions for universal state transition tracking
- Add EventCapacityChanged event emission to set_event_capacity function to alert users of capacity changes
- Add revoke_ticket function with TicketRevoked event emission for admin audit trails
- Add extend_event_end_time function with EventTimeExtended event emission to notify attendees of prolonged events

closes #424

closes #417 

closes #418

closes #423