### PR TITLE
feat(tickets/payments): bulk issuance, expiry job, QR regen

### DIFF
--- a/backend/src/payments/jobs/payment-expiry.job.ts
+++ b/backend/src/payments/jobs/payment-expiry.job.ts
@@ -1,0 +1,52 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThan, Repository } from 'typeorm';
+import { Payment, PaymentStatus } from '../entities/payment.entity';
+import { AuditService } from '../../audit/audit.service';
+import { NotificationService } from '../../notifications/notification.service';
+
+@Injectable()
+export class PaymentExpiryJob {
+  private readonly logger = new Logger(PaymentExpiryJob.name);
+
+  constructor(
+    @InjectRepository(Payment)
+    private readonly paymentsRepository: Repository<Payment>,
+    private readonly auditService: AuditService,
+    private readonly notificationService: NotificationService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_10_MINUTES)
+  async expireStalePayments(): Promise<void> {
+    this.logger.log('Running payment expiry job...');
+
+    const expired = await this.paymentsRepository.find({
+      where: {
+        status: PaymentStatus.PENDING,
+        expiresAt: LessThan(new Date()),
+      },
+    });
+
+    if (expired.length === 0) {
+      this.logger.log('No stale payment intents to expire.');
+      return;
+    }
+
+    this.logger.log(`Expiring ${expired.length} stale payment intent(s).`);
+
+    for (const payment of expired) {
+      payment.status = PaymentStatus.FAILED;
+      await this.paymentsRepository.save(payment);
+
+      await this.auditService.log({
+        action: 'PAYMENT_EXPIRED',
+        userId: payment.userId,
+        resourceId: payment.id,
+        meta: { eventId: payment.eventId, expiredAt: payment.expiresAt },
+      });
+    }
+
+    this.logger.log('Payment expiry job completed.');
+  }
+}


### PR DESCRIPTION
Adds batch processing and lifecycle management for tickets and payments.

- Bulk ticket issuance endpoint (POST /tickets/issue/bulk) with per-item failure isolation
- Scheduled job to mark tickets as `expired` after event end date
- GET /tickets/:id/qr for QR code regeneration (owner-only) and public validity check
- PaymentExpiryJob cron that expires stale PENDING payment intents every 10 minutes, logs audit entries

Closes #284
Closes #285
Closes #286
Closes #287