### PR TITLE
feat(payments/refunds/sponsors): history, eligibility, contributions, escrow

### DIFF
--- a/backend/src/payments/payments.controller.spec.ts
+++ b/backend/src/payments/payments.controller.spec.ts
@@ -2,14 +2,26 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { PaymentsController } from './payments.controller';
 import { PaymentsService } from './payments.service';
 
+const mockPaymentsService = {
+  getHistory: jest.fn(),
+  getPending: jest.fn(),
+  createPaymentIntent: jest.fn(),
+  confirmPayment: jest.fn(),
+  getPaymentById: jest.fn(),
+};
+
+const mockUser = { id: 'user-1', email: 'user@test.com' };
+const mockReq = { user: mockUser };
+
 describe('PaymentsController', () => {
   let controller: PaymentsController;
 
   beforeEach(async () => {
+    jest.clearAllMocks();
     const module: TestingModule = await Test.createTestingModule({
       controllers: [PaymentsController],
       providers: [
-        { provide: PaymentsService, useValue: {} },
+        { provide: PaymentsService, useValue: mockPaymentsService },
       ],
     }).compile();
 
@@ -18,5 +30,68 @@ describe('PaymentsController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  // ─── GET /payments/history ────────────────────────────────────────────────
+
+  describe('GET /payments/history', () => {
+    it('calls PaymentsService.getHistory with userId and pagination dto', async () => {
+      const paginatedResult = { data: [], total: 0, page: 1, limit: 10 };
+      mockPaymentsService.getHistory.mockResolvedValue(paginatedResult);
+
+      const dto = { page: 1, limit: 10 };
+      const result = await controller.getHistory(mockReq as any, dto as any);
+
+      expect(mockPaymentsService.getHistory).toHaveBeenCalledWith('user-1', dto);
+      expect(result).toEqual(paginatedResult);
+    });
+
+    it('returns paginated payment history', async () => {
+      const payments = [
+        { id: 'pay-1', status: 'confirmed', amount: 10 },
+        { id: 'pay-2', status: 'refunded', amount: 5 },
+      ];
+      mockPaymentsService.getHistory.mockResolvedValue({
+        data: payments,
+        total: 2,
+        page: 1,
+        limit: 10,
+      });
+
+      const result = await controller.getHistory(mockReq as any, {} as any);
+
+      expect(result.data).toHaveLength(2);
+      expect(result.total).toBe(2);
+    });
+  });
+
+  // ─── GET /payments/pending ────────────────────────────────────────────────
+
+  describe('GET /payments/pending', () => {
+    it('calls PaymentsService.getPending with userId and pagination dto', async () => {
+      const paginatedResult = { data: [], total: 0, page: 1, limit: 10 };
+      mockPaymentsService.getPending.mockResolvedValue(paginatedResult);
+
+      const dto = { page: 1, limit: 10 };
+      const result = await controller.getPending(mockReq as any, dto as any);
+
+      expect(mockPaymentsService.getPending).toHaveBeenCalledWith('user-1', dto);
+      expect(result).toEqual(paginatedResult);
+    });
+
+    it('returns only pending payments', async () => {
+      const pending = [{ id: 'pay-3', status: 'pending', amount: 20 }];
+      mockPaymentsService.getPending.mockResolvedValue({
+        data: pending,
+        total: 1,
+        page: 1,
+        limit: 10,
+      });
+
+      const result = await controller.getPending(mockReq as any, {} as any);
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].status).toBe('pending');
+    });
   });
 });


### PR DESCRIPTION
Adds user-facing payment history, refund management, and sponsor escrow distribution.

- GET /payments/history and GET /payments/pending — paginated endpoints for authenticated users
- GET /refunds/event/:eventId (admin) and GET /refunds/me (user) — refund history endpoints
- GET /refunds/:paymentId/eligibility — per-payment eligibility check
- GET /events/:eventId/tiers/contributions — contributions list with funding progress
- POST /events/:eventId/sponsors/distribute — release escrow to organizer after event completion
- Expand PaymentsController spec with history and pending endpoint coverage

Closes #288
Closes #289
Closes #290
Closes #291