### PR TITLE
test(registrations/events/sponsors/admin): add unit test coverage

### DIFF
--- a/backend/src/registrations/registrations.service.spec.ts
+++ b/backend/src/registrations/registrations.service.spec.ts
@@ -1,0 +1,173 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { RegistrationsService } from './registrations.service';
+import { Registration, RegistrationStatus } from './entities/registration.entity';
+import { EventsService } from '../events/events.service';
+import { RefundService } from '../payments/refunds/refund.service';
+import { AuditService } from '../audit/audit.service';
+import { Event, EventStatus } from '../events/entities/event.entity';
+
+const mockRepo = () => ({
+  findOne: jest.fn(),
+  find: jest.fn(),
+  count: jest.fn(),
+  save: jest.fn(),
+  create: jest.fn(),
+});
+
+const PUBLISHED_EVENT = {
+  id: 'event-1',
+  status: EventStatus.PUBLISHED,
+  maxAttendees: 10,
+  organizerId: 'org-1',
+} as Event;
+
+const ACTIVE_REGISTRATION = {
+  id: 'reg-1',
+  eventId: 'event-1',
+  userId: 'user-1',
+  status: RegistrationStatus.CONFIRMED,
+} as Registration;
+
+describe('RegistrationsService', () => {
+  let service: RegistrationsService;
+  let registrationRepo: ReturnType<typeof mockRepo>;
+  let eventsService: jest.Mocked<Pick<EventsService, 'getEventById'>>;
+  let refundService: jest.Mocked<Pick<RefundService, 'refundSinglePayment'>>;
+  let auditService: jest.Mocked<Pick<AuditService, 'log'>>;
+  let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
+
+  beforeEach(async () => {
+    registrationRepo = mockRepo();
+    eventsService = { getEventById: jest.fn() };
+    refundService = { refundSinglePayment: jest.fn() };
+    auditService = { log: jest.fn().mockResolvedValue({}) };
+    dataSource = { transaction: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RegistrationsService,
+        { provide: getRepositoryToken(Registration), useValue: registrationRepo },
+        { provide: EventsService, useValue: eventsService },
+        { provide: RefundService, useValue: refundService },
+        { provide: AuditService, useValue: auditService },
+        { provide: DataSource, useValue: dataSource },
+      ],
+    }).compile();
+
+    service = module.get(RegistrationsService);
+  });
+
+  // ─── register() ──────────────────────────────────────────────────────────
+
+  describe('register()', () => {
+    it('throws BadRequestException when event is not PUBLISHED', async () => {
+      eventsService.getEventById.mockResolvedValue({
+        ...PUBLISHED_EVENT,
+        status: EventStatus.DRAFT,
+      } as Event);
+
+      await expect(service.register('event-1', 'user-1')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws ConflictException when user already has an active registration', async () => {
+      eventsService.getEventById.mockResolvedValue(PUBLISHED_EVENT);
+      registrationRepo.findOne.mockResolvedValue(ACTIVE_REGISTRATION);
+
+      await expect(service.register('event-1', 'user-1')).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('creates WAITLISTED registration when event is at capacity', async () => {
+      eventsService.getEventById.mockResolvedValue(PUBLISHED_EVENT);
+      registrationRepo.findOne.mockResolvedValue(null); // no duplicate
+      registrationRepo.count.mockResolvedValue(10); // at capacity
+      const created = { ...ACTIVE_REGISTRATION, status: RegistrationStatus.WAITLISTED };
+      registrationRepo.create.mockReturnValue(created);
+      registrationRepo.save.mockResolvedValue(created);
+
+      const result = await service.register('event-1', 'user-1');
+
+      expect(result.registration.status).toBe(RegistrationStatus.WAITLISTED);
+    });
+
+    it('creates PENDING registration when event has capacity', async () => {
+      eventsService.getEventById.mockResolvedValue(PUBLISHED_EVENT);
+      registrationRepo.findOne.mockResolvedValue(null);
+      registrationRepo.count.mockResolvedValue(5); // under capacity
+      const created = { ...ACTIVE_REGISTRATION, status: RegistrationStatus.PENDING };
+      registrationRepo.create.mockReturnValue(created);
+      registrationRepo.save.mockResolvedValue(created);
+
+      const result = await service.register('event-1', 'user-1');
+
+      expect(result.registration.status).toBe(RegistrationStatus.PENDING);
+    });
+
+    it('creates PENDING registration when event has no maxAttendees (unlimited)', async () => {
+      eventsService.getEventById.mockResolvedValue({
+        ...PUBLISHED_EVENT,
+        maxAttendees: null,
+      } as any);
+      registrationRepo.findOne.mockResolvedValue(null);
+      const created = { ...ACTIVE_REGISTRATION, status: RegistrationStatus.PENDING };
+      registrationRepo.create.mockReturnValue(created);
+      registrationRepo.save.mockResolvedValue(created);
+
+      const result = await service.register('event-1', 'user-1');
+
+      expect(result.registration.status).toBe(RegistrationStatus.PENDING);
+    });
+  });
+
+  // ─── cancel() ────────────────────────────────────────────────────────────
+
+  describe('cancel()', () => {
+    it('throws NotFoundException when registration not found', async () => {
+      registrationRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.cancel('reg-missing', 'user-1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws ForbiddenException when caller does not own the registration', async () => {
+      registrationRepo.findOne.mockResolvedValue(ACTIVE_REGISTRATION);
+
+      await expect(service.cancel('reg-1', 'other-user')).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('throws BadRequestException when registration is not cancellable', async () => {
+      registrationRepo.findOne.mockResolvedValue({
+        ...ACTIVE_REGISTRATION,
+        status: RegistrationStatus.CANCELLED,
+      });
+
+      await expect(service.cancel('reg-1', 'user-1')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('cancels a CONFIRMED registration successfully', async () => {
+      registrationRepo.findOne.mockResolvedValue(ACTIVE_REGISTRATION);
+      const cancelled = { ...ACTIVE_REGISTRATION, status: RegistrationStatus.CANCELLED };
+      registrationRepo.save.mockResolvedValue(cancelled);
+
+      const result = await service.cancel('reg-1', 'user-1');
+
+      expect(result.status).toBe(RegistrationStatus.CANCELLED);
+    });
+  });
+});

--- a/backend/src/sponsors/sponsors.service.spec.ts
+++ b/backend/src/sponsors/sponsors.service.spec.ts
@@ -3,7 +3,14 @@ import { SponsorsService } from './sponsors.service';
 import { EventsService } from '../events/events.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { SponsorTier } from './entities/sponsor-tier.entity';
-import { NotFoundException, ForbiddenException } from '@nestjs/common';
+import { SponsorContribution } from './entities/sponsor-contribution.entity';
+import { Event, EventStatus } from '../events/entities/event.entity';
+import { User } from '../users/entities/user.entity';
+import { NotFoundException, ForbiddenException, BadRequestException } from '@nestjs/common';
+import { ContributionsService } from './contributions.service';
+import { EscrowService } from '../payments/services/escrow.service';
+import { StellarService } from '../stellar/stellar.service';
+import { AuditService } from '../audit/audit.service';
 
 describe('SponsorsService', () => {
   let service: SponsorsService;
@@ -112,6 +119,163 @@ describe('SponsorsService', () => {
       tierRepo.findOne.mockResolvedValue({ id: 't1' });
       const result = await service.getTierById('t1');
       expect(result).toEqual({ id: 't1' });
+    });
+  });
+});
+
+// ─── getFundingProgress and distributeEscrow — full provider setup ─────────
+
+describe('SponsorsService — funding progress and escrow distribution', () => {
+  let service: SponsorsService;
+  let eventsService: any;
+  let contributionRepo: any;
+  let eventRepo: any;
+  let usersRepo: any;
+  let escrowService: any;
+  let stellarService: any;
+  let auditService: any;
+
+  const mockQb = () => ({
+    innerJoin: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    getRawOne: jest.fn(),
+  });
+
+  beforeEach(async () => {
+    eventsService = { getEventById: jest.fn() };
+    contributionRepo = { createQueryBuilder: jest.fn(), findOne: jest.fn(), save: jest.fn() };
+    eventRepo = { findOne: jest.fn() };
+    usersRepo = { findOne: jest.fn() };
+    escrowService = { decryptEscrowSecret: jest.fn() };
+    stellarService = { sendPayment: jest.fn() };
+    auditService = { log: jest.fn().mockResolvedValue({}) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SponsorsService,
+        { provide: getRepositoryToken(SponsorTier), useValue: { findOne: jest.fn(), find: jest.fn(), create: jest.fn(), save: jest.fn(), remove: jest.fn() } },
+        { provide: getRepositoryToken(SponsorContribution), useValue: contributionRepo },
+        { provide: getRepositoryToken(Event), useValue: eventRepo },
+        { provide: getRepositoryToken(User), useValue: usersRepo },
+        { provide: EventsService, useValue: eventsService },
+        { provide: ContributionsService, useValue: { confirmContribution: jest.fn() } },
+        { provide: EscrowService, useValue: escrowService },
+        { provide: StellarService, useValue: stellarService },
+        { provide: AuditService, useValue: auditService },
+      ],
+    }).compile();
+
+    service = module.get(SponsorsService);
+  });
+
+  describe('getFundingProgress()', () => {
+    it('returns raised amount, percentage, and goalReached when fundingGoal is set', async () => {
+      eventsService.getEventById.mockResolvedValue({ id: 'e1', fundingGoal: 1000 });
+      const qb = mockQb();
+      qb.getRawOne
+        .mockResolvedValueOnce({ total: '500' })   // totalRaised
+        .mockResolvedValueOnce({ count: '3' });     // contributorCount
+      contributionRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getFundingProgress('e1');
+
+      expect(result.raised).toBe(500);
+      expect(result.goal).toBe(1000);
+      expect(result.percentage).toBe(50);
+      expect(result.goalReached).toBe(false);
+      expect(result.contributorCount).toBe(3);
+    });
+
+    it('returns goalReached: true when raised >= goal', async () => {
+      eventsService.getEventById.mockResolvedValue({ id: 'e1', fundingGoal: 500 });
+      const qb = mockQb();
+      qb.getRawOne
+        .mockResolvedValueOnce({ total: '600' })
+        .mockResolvedValueOnce({ count: '5' });
+      contributionRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getFundingProgress('e1');
+
+      expect(result.goalReached).toBe(true);
+      expect(result.percentage).toBe(100);
+    });
+
+    it('returns null goal and percentage when event has no fundingGoal', async () => {
+      eventsService.getEventById.mockResolvedValue({ id: 'e1', fundingGoal: null });
+      const qb = mockQb();
+      qb.getRawOne
+        .mockResolvedValueOnce({ total: '200' })
+        .mockResolvedValueOnce({ count: '2' });
+      contributionRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getFundingProgress('e1');
+
+      expect(result.goal).toBeNull();
+      expect(result.percentage).toBeNull();
+      expect(result.goalReached).toBe(false);
+    });
+  });
+
+  describe('distributeEscrow()', () => {
+    const COMPLETED_EVENT = {
+      id: 'e1',
+      organizerId: 'org-1',
+      status: EventStatus.COMPLETED,
+      escrowPublicKey: 'ESCROW_PUB',
+    };
+
+    it('throws ForbiddenException when caller is not organizer or admin', async () => {
+      eventsService.getEventById.mockResolvedValue(COMPLETED_EVENT);
+
+      await expect(
+        service.distributeEscrow('e1', 'other-user', 'event_goer' as any),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('throws BadRequestException when event is not COMPLETED', async () => {
+      eventsService.getEventById.mockResolvedValue({
+        ...COMPLETED_EVENT,
+        status: EventStatus.PUBLISHED,
+      });
+
+      await expect(
+        service.distributeEscrow('e1', 'org-1', 'organizer' as any),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when organizer has no Stellar wallet', async () => {
+      eventsService.getEventById.mockResolvedValue(COMPLETED_EVENT);
+      eventRepo.findOne.mockResolvedValue({ ...COMPLETED_EVENT, escrowSecretEncrypted: 'iv:tag:cipher' });
+      usersRepo.findOne.mockResolvedValue({ id: 'org-1', stellarPublicKey: null });
+      const qb = mockQb();
+      qb.getRawOne.mockResolvedValue({ total: '100' });
+      contributionRepo.createQueryBuilder.mockReturnValue(qb);
+
+      await expect(
+        service.distributeEscrow('e1', 'org-1', 'organizer' as any),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('calls StellarService.sendPayment and logs audit on success', async () => {
+      eventsService.getEventById.mockResolvedValue(COMPLETED_EVENT);
+      eventRepo.findOne.mockResolvedValue({ ...COMPLETED_EVENT, escrowSecretEncrypted: 'iv:tag:cipher' });
+      usersRepo.findOne.mockResolvedValue({ id: 'org-1', stellarPublicKey: 'GORG_PUB' });
+      const qb = mockQb();
+      qb.getRawOne.mockResolvedValue({ total: '500' });
+      contributionRepo.createQueryBuilder.mockReturnValue(qb);
+      escrowService.decryptEscrowSecret.mockResolvedValue('raw-secret');
+      stellarService.sendPayment.mockResolvedValue({ hash: 'tx-distribute' });
+
+      const result = await service.distributeEscrow('e1', 'org-1', 'organizer' as any);
+
+      expect(stellarService.sendPayment).toHaveBeenCalledWith(
+        'raw-secret', 'GORG_PUB', '500', 'XLM',
+      );
+      expect(result.transactionHash).toBe('tx-distribute');
+      expect(auditService.log).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'ESCROW_RELEASED' }),
+      );
     });
   });
 });


### PR DESCRIPTION
Adds unit test coverage across four service modules.

- New RegistrationsService spec: register() and cancel() covering event status, duplicate detection, capacity/waitlist logic, ownership, and status transition guards
- Expanded EventsService spec: publishEvent, cancelEvent, completeEvent, getEventStats, and duplicateEvent describe blocks
- Expanded SponsorsService spec: getFundingProgress (percentage, goalReached, null goal) and distributeEscrow (auth, status, wallet, success path)
- Expanded AdminService spec: blockUser, approveEvent, suspendEvent, unblockUser with all guard checks

Closes #268
Closes #269
Closes #270
Closes #271