### PR TITLE
feat(analytics): add event analytics dashboard with sales, demographics, and attendance tracking (#561)

### DIFF
--- a/backend/src/analytics/analytics.controller.ts
+++ b/backend/src/analytics/analytics.controller.ts
@@ -1,0 +1,127 @@
+import {
+  Controller,
+  Get,
+  Param,
+  UseGuards,
+  Req,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+} from '@nestjs/swagger';
+import { AnalyticsService } from './analytics.service';
+import { SalesReportDto } from './dto/sales-report.dto';
+import { DemographicsReportDto } from './dto/demographic-report.dto';
+import { AttendancePatternDto } from './dto/attendance-pattern.dto';
+import { AnalyticsDashboardDto } from './dto/analytics-dashboard.dto';
+import { Roles, Role } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AuthenticatedRequest } from '../common/interfaces/authenticated-request.interface';
+
+@ApiTags('Analytics')
+@ApiBearerAuth()
+@Controller('analytics')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@ApiResponse({ status: 429, description: 'Too Many Requests' })
+export class AnalyticsController {
+  constructor(private readonly analyticsService: AnalyticsService) {}
+
+  @Get('events/:eventId/dashboard')
+  @Roles(Role.ORGANIZER)
+  @ApiOperation({
+    summary: 'Get comprehensive analytics dashboard',
+    description:
+      'Organizer-only. Returns complete analytics including sales, demographics, attendance, and refunds.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Analytics dashboard data',
+    type: AnalyticsDashboardDto,
+  })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  @ApiResponse({ status: 404, description: 'Event not found' })
+  async getDashboard(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<AnalyticsDashboardDto> {
+    return this.analyticsService.generateAnalyticsDashboard(
+      eventId,
+      req.user.id,
+    );
+  }
+
+  @Get('events/:eventId/sales-report')
+  @Roles(Role.ORGANIZER)
+  @ApiOperation({
+    summary: 'Generate sales velocity report',
+    description:
+      'Organizer-only. Provides sales data over time, velocity metrics, and trends.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Sales report with velocity metrics',
+    type: SalesReportDto,
+  })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  @ApiResponse({ status: 404, description: 'Event not found' })
+  async generateSalesReport(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<SalesReportDto> {
+    return this.analyticsService.generateSalesReport(eventId, req.user.id);
+  }
+
+  @Get('events/:eventId/demographics')
+  @Roles(Role.ORGANIZER)
+  @ApiOperation({
+    summary: 'Get demographic analytics',
+    description:
+      'Organizer-only. Provides age distribution, currency breakdown, and repeat attendee data.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Demographic report',
+    type: DemographicsReportDto,
+  })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  @ApiResponse({ status: 404, description: 'Event not found' })
+  async trackDemographicData(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<DemographicsReportDto> {
+    return this.analyticsService.trackDemographicData(eventId, req.user.id);
+  }
+
+  @Get('events/:eventId/attendance')
+  @Roles(Role.ORGANIZER)
+  @ApiOperation({
+    summary: 'Analyze attendance patterns',
+    description:
+      'Organizer-only. Provides check-in data, peak hours, and attendance metrics.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Attendance pattern data',
+    type: AttendancePatternDto,
+    isArray: false,
+  })
+  @ApiResponse({
+    status: 204,
+    description: 'No check-in data available yet',
+  })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  @ApiResponse({ status: 404, description: 'Event not found' })
+  async analyzeAttendancePatterns(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<AttendancePatternDto | null> {
+    return this.analyticsService.analyzeAttendancePatterns(
+      eventId,
+      req.user.id,
+    );
+  }
+}

--- a/backend/src/analytics/analytics.module.ts
+++ b/backend/src/analytics/analytics.module.ts
@@ -1,0 +1,27 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AnalyticsService } from './analytics.service';
+import { AnalyticsController } from './analytics.controller';
+import { Event } from '../events/entities/event.entity';
+import { TicketEntity } from '../tickets/entities/ticket.entity';
+import { Payment } from '../payments/entities/payment.entity';
+import { Registration } from '../registrations/entities/registration.entity';
+import { AgeVerification } from '../age-verification/entities/age-verification.entity';
+import { User } from '../users/entities/user.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      Event,
+      TicketEntity,
+      Payment,
+      Registration,
+      AgeVerification,
+      User,
+    ]),
+  ],
+  controllers: [AnalyticsController],
+  providers: [AnalyticsService],
+  exports: [AnalyticsService],
+})
+export class AnalyticsModule {}

--- a/backend/src/analytics/analytics.service.spec.ts
+++ b/backend/src/analytics/analytics.service.spec.ts
@@ -1,0 +1,135 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AnalyticsService } from './analytics.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Event } from '../events/entities/event.entity';
+import { TicketEntity } from '../tickets/entities/ticket.entity';
+import { Payment, PaymentStatus } from '../payments/entities/payment.entity';
+import { Registration, RegistrationStatus } from '../registrations/entities/registration.entity';
+import { AgeVerification } from '../age-verification/entities/age-verification.entity';
+import { User } from '../users/entities/user.entity';
+
+describe('AnalyticsService', () => {
+	let service: AnalyticsService;
+	let eventRepo: any;
+	let ticketRepo: any;
+	let paymentRepo: any;
+	let registrationRepo: any;
+	let ageVerificationRepo: any;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				AnalyticsService,
+				{
+					provide: getRepositoryToken(Event),
+					useValue: { findOne: jest.fn() },
+				},
+				{
+					provide: getRepositoryToken(TicketEntity),
+					useValue: { find: jest.fn() },
+				},
+				{
+					provide: getRepositoryToken(Payment),
+					useValue: { find: jest.fn() },
+				},
+				{
+					provide: getRepositoryToken(Registration),
+					useValue: { find: jest.fn(), createQueryBuilder: jest.fn() },
+				},
+				{
+					provide: getRepositoryToken(AgeVerification),
+					useValue: { find: jest.fn() },
+				},
+				{
+					provide: getRepositoryToken(User),
+					useValue: {},
+				},
+			],
+		}).compile();
+
+		service = module.get<AnalyticsService>(AnalyticsService);
+		eventRepo = module.get(getRepositoryToken(Event));
+		ticketRepo = module.get(getRepositoryToken(TicketEntity));
+		paymentRepo = module.get(getRepositoryToken(Payment));
+		registrationRepo = module.get(getRepositoryToken(Registration));
+		ageVerificationRepo = module.get(getRepositoryToken(AgeVerification));
+	});
+
+	it('generates a sales report for an organizer event', async () => {
+		eventRepo.findOne.mockResolvedValue({
+			id: 'event-1',
+			organizerId: 'org-1',
+			createdAt: new Date('2026-04-01T00:00:00.000Z'),
+		});
+
+		paymentRepo.find.mockResolvedValue([
+			{ id: 'p1', amount: 100, createdAt: new Date('2026-04-01T01:00:00.000Z'), status: PaymentStatus.CONFIRMED },
+			{ id: 'p2', amount: 200, createdAt: new Date('2026-04-02T01:00:00.000Z'), status: PaymentStatus.CONFIRMED },
+		]);
+
+		const report = await service.generateSalesReport('event-1', 'org-1');
+
+		expect(report.totalTicketsSold).toBe(2);
+		expect(report.totalRevenue).toBe(300);
+		expect(report.avgTicketPrice).toBe(150);
+		expect(report.salesData.length).toBe(2);
+		expect(report.metrics.ticketsLast24Hours).toBeDefined();
+	});
+
+	it('calculates demographic statistics for event attendees', async () => {
+		eventRepo.findOne.mockResolvedValue({
+			id: 'event-1',
+			organizerId: 'org-1',
+		});
+
+		registrationRepo.find.mockResolvedValue([
+			{ userId: 'user-1', eventId: 'event-1', status: RegistrationStatus.CONFIRMED },
+			{ userId: 'user-2', eventId: 'event-1', status: RegistrationStatus.PENDING },
+		]);
+
+		const mockQueryBuilder = {
+			select: jest.fn().mockReturnThis(),
+			addSelect: jest.fn().mockReturnThis(),
+			where: jest.fn().mockReturnThis(),
+			andWhere: jest.fn().mockReturnThis(),
+			groupBy: jest.fn().mockReturnThis(),
+			having: jest.fn().mockReturnThis(),
+			getRawMany: jest.fn().mockResolvedValue([]),
+		};
+		registrationRepo.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+
+		ageVerificationRepo.find.mockResolvedValue([
+			{ status: 'verified', dateOfBirth: '2000-01-01', eventId: 'event-1' },
+			{ status: 'failed', dateOfBirth: '2010-01-01', eventId: 'event-1' },
+		]);
+
+		paymentRepo.find.mockResolvedValue([
+			{ amount: 100, currency: 'USD', status: PaymentStatus.CONFIRMED },
+			{ amount: 10, currency: 'XLM', status: PaymentStatus.CONFIRMED },
+		]);
+
+		const demographics = await service.trackDemographicData('event-1', 'org-1');
+
+		expect(demographics.totalAttendees).toBe(2);
+		expect(demographics.currencyBreakdown).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ currency: 'USD', ticketCount: 1 }),
+				expect.objectContaining({ currency: 'XLM', ticketCount: 1 }),
+			]),
+		);
+	});
+
+	it('returns null when no attendance check-ins have occurred', async () => {
+		eventRepo.findOne.mockResolvedValue({
+			id: 'event-1',
+			organizerId: 'org-1',
+			startDate: new Date('2026-04-01T10:00:00.000Z'),
+		});
+
+		ticketRepo.find.mockResolvedValueOnce([]);
+
+		const attendance = await service.analyzeAttendancePatterns('event-1', 'org-1');
+
+		expect(attendance).toBeNull();
+	});
+});

--- a/backend/src/analytics/analytics.service.ts
+++ b/backend/src/analytics/analytics.service.ts
@@ -1,0 +1,696 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ForbiddenException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between, In } from 'typeorm';
+import { Event } from '../events/entities/event.entity';
+import { TicketEntity } from '../tickets/entities/ticket.entity';
+import { Payment, PaymentStatus } from '../payments/entities/payment.entity';
+import { Registration, RegistrationStatus } from '../registrations/entities/registration.entity';
+import { AgeVerification } from '../age-verification/entities/age-verification.entity';
+import { User } from '../users/entities/user.entity';
+
+import {
+  SalesReportDto,
+  SalesDataPoint,
+  SalesVelocityMetrics,
+} from './dto/sales-report.dto';
+import {
+  DemographicsReportDto,
+  DemographicBreakdown,
+  AgeDistributionBucket,
+  CurrencyBreakdown,
+} from './dto/demographic-report.dto';
+import {
+  AttendancePatternDto,
+  AttendanceDataPoint,
+  AttendanceMetrics,
+} from './dto/attendance-pattern.dto';
+import {
+  AnalyticsDashboardDto,
+  QuickStats,
+  RefundMetrics,
+} from './dto/analytics-dashboard.dto';
+
+@Injectable()
+export class AnalyticsService {
+  private readonly logger = new Logger(AnalyticsService.name);
+
+  constructor(
+    @InjectRepository(Event)
+    private readonly eventRepository: Repository<Event>,
+    @InjectRepository(TicketEntity)
+    private readonly ticketRepository: Repository<TicketEntity>,
+    @InjectRepository(Payment)
+    private readonly paymentRepository: Repository<Payment>,
+    @InjectRepository(Registration)
+    private readonly registrationRepository: Repository<Registration>,
+    @InjectRepository(AgeVerification)
+    private readonly ageVerificationRepository: Repository<AgeVerification>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  async generateSalesReport(
+    eventId: string,
+    organizerId: string,
+  ): Promise<SalesReportDto> {
+    // Verify event and ownership
+    const event = await this.eventRepository.findOne({ where: { id: eventId } });
+    if (!event) {
+      throw new NotFoundException(`Event with id "${eventId}" not found`);
+    }
+    if (event.organizerId !== organizerId) {
+      throw new ForbiddenException('You are not the organizer of this event.');
+    }
+
+    // Fetch all confirmed payments for the event
+    const payments = await this.paymentRepository.find({
+      where: {
+        eventId,
+        status: PaymentStatus.CONFIRMED,
+      },
+      order: { createdAt: 'ASC' },
+    });
+
+    // Generate sales data points aggregated by hour
+    const salesDataMap = new Map<string, SalesDataPoint>();
+    let cumulativeTickets = 0;
+    let cumulativeRevenue = 0;
+
+    for (const payment of payments) {
+      const hour = new Date(payment.createdAt);
+      hour.setMinutes(0, 0, 0);
+      const key = hour.toISOString();
+
+      const existing = salesDataMap.get(key) || {
+        timestamp: hour,
+        ticketsSold: 0,
+        revenue: 0,
+        cumulativeTickets: 0,
+        cumulativeRevenue: 0,
+      };
+
+      existing.ticketsSold += 1;
+      existing.revenue += Number(payment.amount);
+      cumulativeTickets += 1;
+      cumulativeRevenue += Number(payment.amount);
+      existing.cumulativeTickets = cumulativeTickets;
+      existing.cumulativeRevenue = cumulativeRevenue;
+
+      salesDataMap.set(key, existing);
+    }
+
+    const salesData = Array.from(salesDataMap.values());
+
+    // Calculate metrics
+    const metrics = this.calculateSalesVelocityMetrics(payments, event);
+
+    const totalTicketsSold = payments.length;
+    const totalRevenue = payments.reduce(
+      (sum, p) => sum + Number(p.amount),
+      0,
+    );
+    const avgTicketPrice = totalTicketsSold > 0 ? totalRevenue / totalTicketsSold : 0;
+
+    // Calculate days active
+    const now = new Date();
+    const daysActive = Math.ceil(
+      (now.getTime() - event.createdAt.getTime()) / (1000 * 60 * 60 * 24),
+    );
+
+    return {
+      salesData,
+      metrics,
+      totalTicketsSold,
+      totalRevenue,
+      avgTicketPrice,
+      daysActive,
+    };
+  }
+
+  private calculateSalesVelocityMetrics(
+    payments: Payment[],
+    event: Event,
+  ): SalesVelocityMetrics {
+    const now = new Date();
+    const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+    const ticketsLast7Days = payments.filter((p) =>
+      p.createdAt >= sevenDaysAgo,
+    ).length;
+
+    const ticketsLast24Hours = payments.filter((p) =>
+      p.createdAt >= oneDayAgo,
+    ).length;
+
+    // Calculate average tickets per day
+    const eventAgeDays = Math.max(
+      1,
+      Math.ceil(
+        (now.getTime() - event.createdAt.getTime()) / (1000 * 60 * 60 * 24),
+      ),
+    );
+    const avgTicketsPerDay = payments.length / eventAgeDays;
+
+    // Calculate total revenue and average per day
+    const totalRevenue = payments.reduce(
+      (sum, p) => sum + Number(p.amount),
+      0,
+    );
+    const avgRevenuePerDay = totalRevenue / eventAgeDays;
+
+    // Find peak sales hour
+    const hourCounts = new Map<number, number>();
+    const dayCounts = new Map<number, number>();
+
+    for (const payment of payments) {
+      const date = new Date(payment.createdAt);
+      const hour = date.getHours();
+      const day = date.getDay();
+      hourCounts.set(hour, (hourCounts.get(hour) ?? 0) + 1);
+      dayCounts.set(day, (dayCounts.get(day) ?? 0) + 1);
+    }
+
+    let peakSalesHour: number | null = null;
+    let peakHourCount = 0;
+    for (const [hour, count] of hourCounts) {
+      if (count > peakHourCount) {
+        peakHourCount = count;
+        peakSalesHour = hour;
+      }
+    }
+
+    let peakSalesDayOfWeek: number | null = null;
+    let peakDayCount = 0;
+    for (const [day, count] of dayCounts) {
+      if (count > peakDayCount) {
+        peakDayCount = count;
+        peakSalesDayOfWeek = day;
+      }
+    }
+
+    // Determine trend
+    let trend: 'increasing' | 'decreasing' | 'stable' = 'stable';
+    if (ticketsLast24Hours > avgTicketsPerDay * 1.2) {
+      trend = 'increasing';
+    } else if (ticketsLast24Hours < avgTicketsPerDay * 0.8) {
+      trend = 'decreasing';
+    }
+
+    return {
+      avgTicketsPerDay,
+      avgRevenuePerDay,
+      ticketsLast7Days,
+      ticketsLast24Hours,
+      peakSalesHour,
+      peakSalesDayOfWeek,
+      trend,
+    };
+  }
+
+  async trackDemographicData(
+    eventId: string,
+    organizerId: string,
+  ): Promise<DemographicsReportDto> {
+    // Verify event and ownership
+    const event = await this.eventRepository.findOne({ where: { id: eventId } });
+    if (!event) {
+      throw new NotFoundException(`Event with id "${eventId}" not found`);
+    }
+    if (event.organizerId !== organizerId) {
+      throw new ForbiddenException('You are not the organizer of this event.');
+    }
+
+    // Get all registrations for the event
+    const registrations = await this.registrationRepository.find({
+      where: { eventId },
+    });
+
+    const confirmedRegistrations = registrations.filter(
+      (r) =>
+        r.status === RegistrationStatus.CONFIRMED ||
+        r.status === RegistrationStatus.PENDING,
+    );
+
+    // Get age verifications
+    const ageVerifications = await this.ageVerificationRepository.find({
+      where: { eventId },
+    });
+
+    const demographics = this.analyzeAgeDemographics(ageVerifications);
+
+    // Get currency breakdown
+    const payments = await this.paymentRepository.find({
+      where: {
+        eventId,
+        status: PaymentStatus.CONFIRMED,
+      },
+    });
+
+    const currencyBreakdown = this.analyzeCurrencyBreakdown(
+      payments,
+      event.ticketPrice,
+    );
+
+    // Calculate repeat attendees (users who attended other events)
+    const userIds = confirmedRegistrations.map((r) => r.userId);
+    let repeatAttendeeCount = 0;
+
+    if (userIds.length > 0) {
+      const userEventCounts = await this.registrationRepository
+        .createQueryBuilder('r')
+        .select('r.userId', 'userId')
+        .addSelect('COUNT(*)', 'eventCount')
+        .where('r.userId IN (:...userIds)', { userIds })
+        .andWhere('r.status = :status', { status: RegistrationStatus.CONFIRMED })
+        .groupBy('r.userId')
+        .having('COUNT(*) > 1')
+        .getRawMany();
+
+      repeatAttendeeCount = userEventCounts.length;
+    }
+
+    return {
+      demographics,
+      currencyBreakdown,
+      totalAttendees: confirmedRegistrations.length,
+      totalRegistrations: registrations.length,
+      repeatAttendeeCount,
+      repeatAttendeePercentage:
+        confirmedRegistrations.length > 0
+          ? (repeatAttendeeCount / confirmedRegistrations.length) * 100
+          : 0,
+    };
+  }
+
+  private analyzeAgeDemographics(
+    ageVerifications: AgeVerification[],
+  ): DemographicBreakdown {
+    const today = new Date();
+    const ages: number[] = [];
+    const ageBuckets = new Map<string, number>();
+
+    // Define age ranges
+    const ranges = [
+      { min: 0, max: 17, label: '0-17' },
+      { min: 18, max: 24, label: '18-24' },
+      { min: 25, max: 34, label: '25-34' },
+      { min: 35, max: 44, label: '35-44' },
+      { min: 45, max: 54, label: '45-54' },
+      { min: 55, max: 64, label: '55-64' },
+      { min: 65, max: 150, label: '65+' },
+    ];
+
+    // Initialize buckets
+    for (const range of ranges) {
+      ageBuckets.set(range.label, 0);
+    }
+
+    // Calculate ages and bucket them
+    for (const verification of ageVerifications) {
+      if (verification.dateOfBirth && verification.status === 'verified') {
+        const birthDate = new Date(verification.dateOfBirth);
+        let age = today.getFullYear() - birthDate.getFullYear();
+        const monthDiff = today.getMonth() - birthDate.getMonth();
+        if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birthDate.getDate())) {
+          age--;
+        }
+
+        ages.push(age);
+
+        // Find and increment the appropriate bucket
+        for (const range of ranges) {
+          if (age >= range.min && age <= range.max) {
+            ageBuckets.set(range.label, ageBuckets.get(range.label)! + 1);
+            break;
+          }
+        }
+      }
+    }
+
+    const totalVerified = ages.length;
+    const verifiedAges: AgeDistributionBucket[] = [];
+
+    for (const [label, count] of ageBuckets) {
+      verifiedAges.push({
+        ageRange: label,
+        count,
+        percentage: totalVerified > 0 ? (count / totalVerified) * 100 : 0,
+      });
+    }
+
+    // Sort by age range
+    verifiedAges.sort((a, b) => {
+      const aMin = parseInt(a.ageRange.split('-')[0]);
+      const bMin = parseInt(b.ageRange.split('-')[0]);
+      return aMin - bMin;
+    });
+
+    const averageAge = ages.length > 0 ? ages.reduce((a, b) => a + b, 0) / ages.length : null;
+    const minAge = ages.length > 0 ? Math.min(...ages) : null;
+    const maxAge = ages.length > 0 ? Math.max(...ages) : null;
+
+    return {
+      verifiedAges,
+      ageVerificationRate:
+        ageVerifications.length > 0
+          ? (totalVerified / ageVerifications.length) * 100
+          : 0,
+      averageAge: averageAge ? Math.round(averageAge * 10) / 10 : null,
+      minAge,
+      maxAge,
+    };
+  }
+
+  private analyzeCurrencyBreakdown(
+    payments: Payment[],
+    eventTicketPrice: number,
+  ): CurrencyBreakdown[] {
+    const currencyMap = new Map<string, { tickets: number; amount: number }>();
+
+    for (const payment of payments) {
+      const currency = payment.currency || 'XLM';
+      const existing = currencyMap.get(currency) || {
+        tickets: 0,
+        amount: 0,
+      };
+      existing.tickets += 1;
+      existing.amount += Number(payment.amount);
+      currencyMap.set(currency, existing);
+    }
+
+    const totalTickets = payments.length;
+    const result: CurrencyBreakdown[] = [];
+
+    for (const [currency, data] of currencyMap) {
+      result.push({
+        currency,
+        ticketCount: data.tickets,
+        totalAmount: data.amount,
+        percentage: totalTickets > 0 ? (data.tickets / totalTickets) * 100 : 0,
+      });
+    }
+
+    // Sort by ticket count descending
+    result.sort((a, b) => b.ticketCount - a.ticketCount);
+
+    return result;
+  }
+
+  async analyzeAttendancePatterns(
+    eventId: string,
+    organizerId: string,
+  ): Promise<AttendancePatternDto | null> {
+    // Verify event and ownership
+    const event = await this.eventRepository.findOne({ where: { id: eventId } });
+    if (!event) {
+      throw new NotFoundException(`Event with id "${eventId}" not found`);
+    }
+    if (event.organizerId !== organizerId) {
+      throw new ForbiddenException('You are not the organizer of this event.');
+    }
+
+    // Get all used tickets (check-ins)
+    const usedTickets = await this.ticketRepository.find({
+      where: {
+        eventId,
+        status: 'used',
+      },
+      order: { createdAt: 'ASC' },
+    });
+
+    // If no used tickets, return null (event hasn't started or no check-ins yet)
+    if (usedTickets.length === 0) {
+      return null;
+    }
+
+    // Get all tickets for the event
+    const allTickets = await this.ticketRepository.find({
+      where: { eventId },
+    });
+
+    // Generate hourly check-in data
+    const hourlyMap = new Map<number, AttendanceDataPoint>();
+    let cumulativeCheckIns = 0;
+
+    const eventStart = event.startDate;
+    const hours = new Map<number, number>();
+
+    for (const ticket of usedTickets) {
+      const checkInTime = new Date(ticket.createdAt);
+      const eventHour = Math.floor(
+        (checkInTime.getTime() - eventStart.getTime()) / (1000 * 60 * 60),
+      );
+      const clampedHour = Math.max(0, eventHour); // Don't go below hour 0
+
+      hours.set(clampedHour, (hours.get(clampedHour) ?? 0) + 1);
+    }
+
+    // Create hourly data points
+    const hourlyCheckIns: AttendanceDataPoint[] = [];
+    let maxHour = 0;
+
+    for (const [hour, count] of hours) {
+      cumulativeCheckIns += count;
+      hourlyCheckIns.push({
+        timestamp: new Date(
+          eventStart.getTime() + hour * 60 * 60 * 1000,
+        ),
+        checkInCount: count,
+        cumulativeCheckIns,
+        hour,
+      });
+      maxHour = Math.max(maxHour, hour);
+    }
+
+    // Fill in missing hours with 0 check-ins
+    for (let h = 0; h <= maxHour; h++) {
+      if (!hours.has(h)) {
+        const lastCumulative = hourlyCheckIns.find((d) => d.hour === h - 1)
+          ?.cumulativeCheckIns ?? 0;
+        hourlyCheckIns.push({
+          timestamp: new Date(
+            eventStart.getTime() + h * 60 * 60 * 1000,
+          ),
+          checkInCount: 0,
+          cumulativeCheckIns: lastCumulative,
+          hour: h,
+        });
+      }
+    }
+
+    // Sort by hour
+    hourlyCheckIns.sort((a, b) => a.hour - b.hour);
+
+    // Calculate metrics
+    const metrics = this.calculateAttendanceMetrics(
+      usedTickets,
+      hourlyCheckIns,
+      eventStart,
+    );
+
+    const eventDurationHours = maxHour + 1;
+    const ticketsUsed = usedTickets.length;
+    const ticketsUnused = allTickets.length - ticketsUsed;
+    const lastCheckInTime =
+      usedTickets.length > 0
+        ? new Date(usedTickets[usedTickets.length - 1].createdAt)
+        : null;
+
+    return {
+      eventDurationHours,
+      hourlyCheckIns,
+      metrics,
+      totalTicketsIssued: allTickets.length,
+      ticketsUsed,
+      ticketsUnused,
+      eventStartTime: eventStart,
+      lastCheckInTime,
+    };
+  }
+
+  private calculateAttendanceMetrics(
+    usedTickets: TicketEntity[],
+    hourlyCheckIns: AttendanceDataPoint[],
+    eventStart: Date,
+  ): AttendanceMetrics {
+    let peakCheckInHour: number | null = null;
+    let peakCheckInCount = 0;
+
+    for (const hour of hourlyCheckIns) {
+      if (hour.checkInCount > peakCheckInCount) {
+        peakCheckInCount = hour.checkInCount;
+        peakCheckInHour = hour.hour;
+      }
+    }
+
+    const totalCheckIns = usedTickets.length;
+
+    // Calculate average check-in interval
+    let avgCheckInInterval: number | null = null;
+    if (usedTickets.length > 1) {
+      const firstCheckIn = usedTickets[0].createdAt;
+      const lastCheckIn = usedTickets[usedTickets.length - 1].createdAt;
+      const totalMinutes = (lastCheckIn.getTime() - firstCheckIn.getTime()) / (1000 * 60);
+      avgCheckInInterval = totalMinutes / (usedTickets.length - 1);
+    }
+
+    // Calculate peak check-in rate (check-ins per minute)
+    let peakCheckInRate: number | null = null;
+    if (peakCheckInCount > 0) {
+      // Assume peak hour = 60 minutes
+      peakCheckInRate = peakCheckInCount / 60;
+    }
+
+    return {
+      peakCheckInHour,
+      peakCheckInCount,
+      totalCheckIns,
+      attendanceRate: usedTickets.length, // Will be calculated in dashboard
+      avgCheckInInterval,
+      peakCheckInRate,
+      estimatedCapacityFilled: null, // Will be set in dashboard
+    };
+  }
+
+  async generateAnalyticsDashboard(
+    eventId: string,
+    organizerId: string,
+  ): Promise<AnalyticsDashboardDto> {
+    // Verify event and ownership
+    const event = await this.eventRepository.findOne({ where: { id: eventId } });
+    if (!event) {
+      throw new NotFoundException(`Event with id "${eventId}" not found`);
+    }
+    if (event.organizerId !== organizerId) {
+      throw new ForbiddenException('You are not the organizer of this event.');
+    }
+
+    // Get all required data in parallel
+    const [salesReport, demographics, attendance, allPayments, allTickets, allRegistrations] = await Promise.all([
+      this.generateSalesReport(eventId, organizerId),
+      this.trackDemographicData(eventId, organizerId),
+      this.analyzeAttendancePatterns(eventId, organizerId),
+      this.paymentRepository.find({ where: { eventId } }),
+      this.ticketRepository.find({ where: { eventId } }),
+      this.registrationRepository.find({ where: { eventId } }),
+    ]);
+
+    // Calculate refund metrics
+    const refundedPayments = allPayments.filter((p) => p.status === PaymentStatus.REFUNDED);
+    const totalRefunds = refundedPayments.length;
+    const totalRefundAmount = refundedPayments.reduce(
+      (sum, p) => sum + Number(p.amount),
+      0,
+    );
+    const refundRate =
+      allPayments.length > 0 ? (totalRefunds / allPayments.length) * 100 : 0;
+
+    const avgRefundAmount = totalRefunds > 0 ? totalRefundAmount / totalRefunds : 0;
+
+    const now = new Date();
+    const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const refundsLast7Days = refundedPayments.filter((p) =>
+      p.updatedAt >= sevenDaysAgo,
+    ).length;
+
+    const refunds: RefundMetrics = {
+      totalRefunds,
+      totalRefundAmount,
+      refundRate,
+      avgRefundAmount,
+      mostCommonReason: null, // Could be enhanced with refund reason tracking
+      refundsLast7Days,
+    };
+
+    // Calculate quick stats
+    const confirmedPayments = allPayments.filter(
+      (p) => p.status === PaymentStatus.CONFIRMED,
+    );
+    const usedTickets = allTickets.filter((t) => t.status === 'used');
+    const confirmedRegistrations = allRegistrations.filter(
+      (r) =>
+        r.status === RegistrationStatus.CONFIRMED ||
+        r.status === RegistrationStatus.PENDING,
+    );
+
+    const totalRevenue = confirmedPayments.reduce(
+      (sum, p) => sum + Number(p.amount),
+      0,
+    );
+    const attendanceRate =
+      allTickets.length > 0 ? (usedTickets.length / allTickets.length) * 100 : 0;
+
+    // Determine trends
+    const last24HoursSales = confirmedPayments.filter((p) => {
+      const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+      return p.createdAt >= oneDayAgo;
+    }).length;
+
+    const last7DaysSales = confirmedPayments.filter((p) => {
+      const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+      return p.createdAt >= sevenDaysAgo;
+    }).length;
+
+    const avgDailySales = last7DaysSales / 7;
+    const salesTrend =
+      last24HoursSales > avgDailySales * 1.2
+        ? 'up'
+        : last24HoursSales < avgDailySales * 0.8
+          ? 'down'
+          : 'stable';
+
+    const last24HoursRevenue = confirmedPayments
+      .filter((p) => {
+        const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+        return p.createdAt >= oneDayAgo;
+      })
+      .reduce((sum, p) => sum + Number(p.amount), 0);
+
+    const last7DaysRevenue = confirmedPayments
+      .filter((p) => {
+        const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+        return p.createdAt >= sevenDaysAgo;
+      })
+      .reduce((sum, p) => sum + Number(p.amount), 0);
+
+    const avgDailyRevenue = last7DaysRevenue / 7;
+    const revenueTrend =
+      last24HoursRevenue > avgDailyRevenue * 1.2
+        ? 'up'
+        : last24HoursRevenue < avgDailyRevenue * 0.8
+          ? 'down'
+          : 'stable';
+
+    const quickStats: QuickStats = {
+      ticketsSold: confirmedPayments.length,
+      totalRevenue,
+      attendanceCount: usedTickets.length,
+      attendanceRate,
+      avgTicketPrice:
+        confirmedPayments.length > 0
+          ? totalRevenue / confirmedPayments.length
+          : 0,
+      totalRefunds,
+      refundRate,
+      revenueTrend,
+      salesTrend,
+    };
+
+    return {
+      eventId,
+      lastUpdated: new Date(),
+      quickStats,
+      salesReport,
+      demographics,
+      attendance,
+      refunds,
+    };
+  }
+}

--- a/backend/src/analytics/dto/analytics-dashboard.dto.ts
+++ b/backend/src/analytics/dto/analytics-dashboard.dto.ts
@@ -1,0 +1,79 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SalesReportDto } from './sales-report.dto';
+import { DemographicsReportDto } from './demographic-report.dto';
+import { AttendancePatternDto } from './attendance-pattern.dto';
+
+export class RefundMetrics {
+  @ApiProperty({ description: 'Total number of refunds' })
+  totalRefunds: number;
+
+  @ApiProperty({ description: 'Total refund amount' })
+  totalRefundAmount: number;
+
+  @ApiProperty({ description: 'Refund rate as percentage of total sales' })
+  refundRate: number;
+
+  @ApiProperty({ description: 'Average refund amount' })
+  avgRefundAmount: number;
+
+  @ApiProperty({
+    description: 'Most common reason for refunds',
+    nullable: true,
+  })
+  mostCommonReason: string | null;
+
+  @ApiProperty({ description: 'Refunds in last 7 days' })
+  refundsLast7Days: number;
+}
+
+export class QuickStats {
+  @ApiProperty({ description: 'Total tickets sold' })
+  ticketsSold: number;
+
+  @ApiProperty({ description: 'Total revenue' })
+  totalRevenue: number;
+
+  @ApiProperty({ description: 'Current attendance count' })
+  attendanceCount: number;
+
+  @ApiProperty({ description: 'Attendance rate percentage' })
+  attendanceRate: number;
+
+  @ApiProperty({ description: 'Average ticket price' })
+  avgTicketPrice: number;
+
+  @ApiProperty({ description: 'Total refunds' })
+  totalRefunds: number;
+
+  @ApiProperty({ description: 'Refund rate percentage' })
+  refundRate: number;
+
+  @ApiProperty({ description: 'Revenue trend (up, down, stable)' })
+  revenueTrend: 'up' | 'down' | 'stable';
+
+  @ApiProperty({ description: 'Sales trend (up, down, stable)' })
+  salesTrend: 'up' | 'down' | 'stable';
+}
+
+export class AnalyticsDashboardDto {
+  @ApiProperty({ description: 'Event ID' })
+  eventId: string;
+
+  @ApiProperty({ description: 'Dashboard last updated at' })
+  lastUpdated: Date;
+
+  @ApiProperty({ type: QuickStats })
+  quickStats: QuickStats;
+
+  @ApiProperty({ type: SalesReportDto })
+  salesReport: SalesReportDto;
+
+  @ApiProperty({ type: DemographicsReportDto })
+  demographics: DemographicsReportDto;
+
+  @ApiProperty({ type: AttendancePatternDto, nullable: true })
+  attendance: AttendancePatternDto | null;
+
+  @ApiProperty({ type: RefundMetrics })
+  refunds: RefundMetrics;
+}

--- a/backend/src/analytics/dto/attendance-pattern.dto.ts
+++ b/backend/src/analytics/dto/attendance-pattern.dto.ts
@@ -1,0 +1,66 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AttendanceDataPoint {
+  @ApiProperty({ description: 'Time of check-in' })
+  timestamp: Date;
+
+  @ApiProperty({ description: 'Number of attendees checked in at this time' })
+  checkInCount: number;
+
+  @ApiProperty({ description: 'Cumulative attendees checked in up to this time' })
+  cumulativeCheckIns: number;
+
+  @ApiProperty({ description: 'Hour of day (0-23)' })
+  hour: number;
+}
+
+export class AttendanceMetrics {
+  @ApiProperty({ description: 'Peak check-in hour (0-23)' })
+  peakCheckInHour: number | null;
+
+  @ApiProperty({ description: 'Number of attendees checked in during peak hour' })
+  peakCheckInCount: number;
+
+  @ApiProperty({ description: 'Total attendees checked in' })
+  totalCheckIns: number;
+
+  @ApiProperty({ description: 'Percentage of tickets that were used' })
+  attendanceRate: number;
+
+  @ApiProperty({ description: 'Average time between check-ins (in minutes)' })
+  avgCheckInInterval: number | null;
+
+  @ApiProperty({ description: 'Check-ins per minute at peak' })
+  peakCheckInRate: number | null;
+
+  @ApiProperty({
+    description: 'Estimated total attendance capacity filled',
+  })
+  estimatedCapacityFilled: number | null;
+}
+
+export class AttendancePatternDto {
+  @ApiProperty({ description: 'Time period covered (in hours)' })
+  eventDurationHours: number;
+
+  @ApiProperty({ type: [AttendanceDataPoint], description: 'Hourly check-in data' })
+  hourlyCheckIns: AttendanceDataPoint[];
+
+  @ApiProperty({ type: AttendanceMetrics })
+  metrics: AttendanceMetrics;
+
+  @ApiProperty({ description: 'Total tickets issued for the event' })
+  totalTicketsIssued: number;
+
+  @ApiProperty({ description: 'Number of tickets used/checked in' })
+  ticketsUsed: number;
+
+  @ApiProperty({ description: 'Number of tickets not used' })
+  ticketsUnused: number;
+
+  @ApiProperty({ description: 'Time event started' })
+  eventStartTime: Date;
+
+  @ApiProperty({ description: 'Time of last check-in' })
+  lastCheckInTime: Date | null;
+}

--- a/backend/src/analytics/dto/demographic-report.dto.ts
+++ b/backend/src/analytics/dto/demographic-report.dto.ts
@@ -1,0 +1,66 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AgeDistributionBucket {
+  @ApiProperty({ description: 'Age range label (e.g., "18-25")' })
+  ageRange: string;
+
+  @ApiProperty({ description: 'Count of attendees in this range' })
+  count: number;
+
+  @ApiProperty({ description: 'Percentage of total attendees' })
+  percentage: number;
+}
+
+export class DemographicBreakdown {
+  @ApiProperty({ description: 'Age ranges verified' })
+  verifiedAges: AgeDistributionBucket[];
+
+  @ApiProperty({ description: 'Percentage of attendees with age verification' })
+  ageVerificationRate: number;
+
+  @ApiProperty({ description: 'Average age of attendees (if available)' })
+  averageAge: number | null;
+
+  @ApiProperty({ description: 'Youngest attendee age (if available)' })
+  minAge: number | null;
+
+  @ApiProperty({ description: 'Oldest attendee age (if available)' })
+  maxAge: number | null;
+}
+
+export class CurrencyBreakdown {
+  @ApiProperty({ description: 'Currency code' })
+  currency: string;
+
+  @ApiProperty({ description: 'Number of tickets sold in this currency' })
+  ticketCount: number;
+
+  @ApiProperty({ description: 'Total revenue in this currency' })
+  totalAmount: number;
+
+  @ApiProperty({ description: 'Percentage of total tickets' })
+  percentage: number;
+}
+
+export class DemographicsReportDto {
+  @ApiProperty({ type: DemographicBreakdown })
+  demographics: DemographicBreakdown;
+
+  @ApiProperty({
+    type: [CurrencyBreakdown],
+    description: 'Breakdown by currency',
+  })
+  currencyBreakdown: CurrencyBreakdown[];
+
+  @ApiProperty({ description: 'Total unique attendees' })
+  totalAttendees: number;
+
+  @ApiProperty({ description: 'Total registrations (includes cancelled/refunded)' })
+  totalRegistrations: number;
+
+  @ApiProperty({ description: 'Repeat attendees (attended this event before)' })
+  repeatAttendeeCount: number;
+
+  @ApiProperty({ description: 'Percentage of repeat attendees' })
+  repeatAttendeePercentage: number;
+}

--- a/backend/src/analytics/dto/sales-report.dto.ts
+++ b/backend/src/analytics/dto/sales-report.dto.ts
@@ -1,0 +1,64 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SalesDataPoint {
+  @ApiProperty({ description: 'Timestamp for the data point' })
+  timestamp: Date;
+
+  @ApiProperty({ description: 'Number of tickets sold at this timestamp' })
+  ticketsSold: number;
+
+  @ApiProperty({ description: 'Revenue amount (in currency units)' })
+  revenue: number;
+
+  @ApiProperty({ description: 'Cumulative tickets sold up to this point' })
+  cumulativeTickets: number;
+
+  @ApiProperty({ description: 'Cumulative revenue up to this point' })
+  cumulativeRevenue: number;
+}
+
+export class SalesVelocityMetrics {
+  @ApiProperty({ description: 'Average tickets sold per day' })
+  avgTicketsPerDay: number;
+
+  @ApiProperty({ description: 'Average revenue per day' })
+  avgRevenuePerDay: number;
+
+  @ApiProperty({ description: 'Tickets sold in the last 7 days' })
+  ticketsLast7Days: number;
+
+  @ApiProperty({ description: 'Tickets sold in the last 24 hours' })
+  ticketsLast24Hours: number;
+
+  @ApiProperty({ description: 'Peak sales hour (0-23)' })
+  peakSalesHour: number | null;
+
+  @ApiProperty({ description: 'Peak sales day of week (0-6, Sunday-Saturday)' })
+  peakSalesDayOfWeek: number | null;
+
+  @ApiProperty({ description: 'Sales trend (increasing, decreasing, stable)' })
+  trend: 'increasing' | 'decreasing' | 'stable';
+}
+
+export class SalesReportDto {
+  @ApiProperty({
+    type: [SalesDataPoint],
+    description: 'Sales data points over time',
+  })
+  salesData: SalesDataPoint[];
+
+  @ApiProperty({ type: SalesVelocityMetrics })
+  metrics: SalesVelocityMetrics;
+
+  @ApiProperty({ description: 'Total tickets sold' })
+  totalTicketsSold: number;
+
+  @ApiProperty({ description: 'Total revenue' })
+  totalRevenue: number;
+
+  @ApiProperty({ description: 'Average ticket price' })
+  avgTicketPrice: number;
+
+  @ApiProperty({ description: 'Time period covered (in days)' })
+  daysActive: number;
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -28,6 +28,7 @@ import { TransactionsModule } from './transactions/transactions.module';
 import { TicketsModule } from './tickets/tickets.module';
 import { AdminModule } from './admin/admin.module';
 import { RegistrationsModule } from './registrations/registrations.module';
+import { AnalyticsModule } from './analytics/analytics.module';
 
 
 @Module({
@@ -104,6 +105,7 @@ import { RegistrationsModule } from './registrations/registrations.module';
     TicketsModule,
     AdminModule,
     RegistrationsModule,
+    AnalyticsModule,
 
   ],
   controllers: [AppController],

--- a/frontend/app/events/[id]/analytics/page.tsx
+++ b/frontend/app/events/[id]/analytics/page.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { apiClient } from "@/lib/api-client";
+import { AnalyticsDashboard } from "@/types/analytics";
+import { formatPrice } from "@/types/event";
+
+function formatPercent(value: number): string {
+	return `${value.toFixed(1)}%`;
+}
+
+function numberOrDash(value: number | null | undefined) {
+	return value !== null && value !== undefined ? value : "—";
+}
+
+export default function EventAnalyticsPage({ params }: { params: { id: string } }) {
+	const { id } = params;
+	const [dashboard, setDashboard] = useState<AnalyticsDashboard | null>(null);
+	const [isLoading, setIsLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	const loadDashboard = async (token: string) => {
+		try {
+			setError(null);
+			const data = await apiClient.getEventAnalyticsDashboard(id, token);
+			setDashboard(data);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Unable to fetch analytics data");
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	useEffect(() => {
+		const token = window.localStorage.getItem("lumentix_access_token");
+		if (!token) {
+			setError("Organizer access token not found. Please paste your bearer token in the event creation page.");
+			setIsLoading(false);
+			return;
+		}
+
+		void loadDashboard(token);
+		const intervalId = window.setInterval(() => void loadDashboard(token), 15000);
+		return () => window.clearInterval(intervalId);
+	}, [id]);
+
+	const summaryItems = useMemo(() => {
+		if (!dashboard) return [];
+		return [
+			{ label: "Tickets sold", value: dashboard.quickStats.ticketsSold },
+			{ label: "Revenue", value: formatPrice(dashboard.quickStats.totalRevenue, "USD") },
+			{ label: "Attendance rate", value: formatPercent(dashboard.quickStats.attendanceRate) },
+			{ label: "Refund rate", value: formatPercent(dashboard.quickStats.refundRate) },
+			{ label: "Avg ticket price", value: formatPrice(dashboard.quickStats.avgTicketPrice, "USD") },
+		];
+	}, [dashboard]);
+
+	return (
+		<div className="max-w-7xl mx-auto px-4 py-8">
+			<div className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+				<div>
+					<h1 className="text-3xl font-bold text-white">Organizer Analytics</h1>
+					<p className="mt-2 text-gray-400 max-w-2xl">
+						Live event analytics for organizers, updated automatically every 15 seconds.
+					</p>
+				</div>
+				<Link
+					href={`/events/${id}`}
+					className="inline-flex items-center rounded-full border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-200 transition hover:bg-blue-500/20"
+				>
+					Back to event
+				</Link>
+			</div>
+
+			<div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3 mb-8">
+				{dashboard ? (
+					summaryItems.map((item) => (
+						<div key={item.label} className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 shadow-lg shadow-black/10">
+							<p className="text-sm uppercase tracking-[0.2em] text-slate-400">{item.label}</p>
+							<p className="mt-3 text-3xl font-semibold text-white">{item.value}</p>
+						</div>
+					))
+				) : (
+					<div className="rounded-3xl border border-white/10 bg-slate-950/70 p-5 shadow-lg shadow-black/10 sm:col-span-2 xl:col-span-3">
+						<p className="text-sm text-slate-400">Loading analytics summary...</p>
+					</div>
+				)}
+			</div>
+
+			{error ? (
+				<div className="rounded-3xl border border-red-500/20 bg-red-500/10 p-6 text-red-100">
+					<p className="font-semibold">Unable to load analytics</p>
+					<p className="mt-2 text-sm text-red-100/80">{error}</p>
+				</div>
+			) : null}
+
+			{isLoading ? (
+				<div className="rounded-3xl border border-white/10 bg-slate-950/70 p-8 text-gray-400">
+					<p>Fetching analytics data...</p>
+				</div>
+			) : null}
+
+			{dashboard && (
+				<div className="space-y-8">
+					<section className="rounded-3xl border border-white/10 bg-slate-950/70 p-6">
+						<div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+							<div>
+								<h2 className="text-xl font-semibold text-white">Sales Velocity</h2>
+								<p className="mt-2 text-sm text-slate-400">Revenue and ticket momentum with hourly breakouts.</p>
+							</div>
+							<p className="text-sm text-slate-500">Updated {new Date(dashboard.lastUpdated).toLocaleString()}</p>
+						</div>
+
+						<div className="mt-6 grid gap-4 lg:grid-cols-3">
+							{[
+								{ label: "Avg tickets/day", value: dashboard.salesReport.metrics.avgTicketsPerDay.toFixed(1) },
+								{ label: "Avg revenue/day", value: formatPrice(dashboard.salesReport.metrics.avgRevenuePerDay, "USD") },
+								{ label: "Peak hour", value: dashboard.salesReport.metrics.peakSalesHour !== null ? `${dashboard.salesReport.metrics.peakSalesHour}:00` : "N/A" },
+							].map((item) => (
+								<div key={item.label} className="rounded-3xl border border-white/10 bg-slate-900/70 p-4">
+									<p className="text-sm text-slate-400">{item.label}</p>
+									<p className="mt-3 text-lg font-semibold text-white">{item.value}</p>
+								</div>
+							))}
+						</div>
+
+						<div className="mt-6 overflow-x-auto">
+							<table className="min-w-full divide-y divide-white/10 text-left text-sm">
+								<thead>
+									<tr>
+										<th className="pb-3 text-slate-400">Time</th>
+										<th className="pb-3 text-slate-400">Tickets</th>
+										<th className="pb-3 text-slate-400">Revenue</th>
+										<th className="pb-3 text-slate-400">Cumulative</th>
+									</tr>
+								</thead>
+								<tbody className="divide-y divide-white/10 text-slate-300">
+									{dashboard.salesReport.salesData.map((data) => (
+										<tr key={data.timestamp}>
+											<td className="py-3">{new Date(data.timestamp).toLocaleString()}</td>
+											<td className="py-3">{data.ticketsSold}</td>
+											<td className="py-3">{formatPrice(data.revenue, "USD")}</td>
+											<td className="py-3">{formatPrice(data.cumulativeRevenue, "USD")}</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+					</section>
+
+					<section className="rounded-3xl border border-white/10 bg-slate-950/70 p-6">
+						<h2 className="text-xl font-semibold text-white">Demographics</h2>
+						<p className="mt-2 text-sm text-slate-400">Age distribution, currency mix, and repeat attendee trends.</p>
+
+						<div className="mt-6 grid gap-4 lg:grid-cols-2">
+							<div className="rounded-3xl border border-white/10 bg-slate-900/70 p-4">
+								<p className="text-sm text-slate-400">Verified age distribution</p>
+								<ul className="mt-3 space-y-2 text-slate-300">
+									{dashboard.demographics.demographics.verifiedAges.map((age) => (
+										<li key={age.ageRange} className="flex justify-between gap-4">
+											<span>{age.ageRange}</span>
+											<span>{age.count} ({age.percentage.toFixed(1)}%)</span>
+										</li>
+									))}
+								</ul>
+							</div>
+
+							<div className="rounded-3xl border border-white/10 bg-slate-900/70 p-4">
+								<p className="text-sm text-slate-400">Currency breakdown</p>
+								<ul className="mt-3 space-y-2 text-slate-300">
+									{dashboard.demographics.currencyBreakdown.map((currency) => (
+										<li key={currency.currency} className="flex justify-between gap-4">
+											<span>{currency.currency}</span>
+											<span>{currency.ticketCount} tickets</span>
+										</li>
+									))}
+								</ul>
+							</div>
+						</div>
+					</section>
+
+					<section className="rounded-3xl border border-white/10 bg-slate-950/70 p-6">
+						<h2 className="text-xl font-semibold text-white">Attendance Patterns</h2>
+						<p className="mt-2 text-sm text-slate-400">Check-in velocity and ticket utilization across the event.</p>
+
+						{dashboard.attendance ? (
+							<div className="mt-6 space-y-4">
+								<div className="grid gap-4 md:grid-cols-3">
+									{[
+										{ label: "Tickets used", value: dashboard.attendance.ticketsUsed },
+										{ label: "Tickets unused", value: dashboard.attendance.ticketsUnused },
+										{ label: "Event hours", value: dashboard.attendance.eventDurationHours },
+									].map((item) => (
+										<div key={item.label} className="rounded-3xl border border-white/10 bg-slate-900/70 p-4">
+											<p className="text-sm text-slate-400">{item.label}</p>
+											<p className="mt-3 text-lg font-semibold text-white">{item.value}</p>
+										</div>
+									))}
+								</div>
+
+								<div className="overflow-x-auto rounded-3xl border border-white/10 bg-slate-900/70 p-4">
+									<table className="min-w-full divide-y divide-white/10 text-left text-sm text-slate-300">
+										<thead>
+											<tr>
+												<th className="pb-3">Hour</th>
+												<th className="pb-3">Check-ins</th>
+												<th className="pb-3">Cumulative</th>
+											</tr>
+										</thead>
+										<tbody className="divide-y divide-white/10">
+											{dashboard.attendance.hourlyCheckIns.map((point) => (
+												<tr key={`${point.hour}-${point.timestamp}`}>
+													<td className="py-3">{point.hour}:00</td>
+													<td className="py-3">{point.checkInCount}</td>
+													<td className="py-3">{point.cumulativeCheckIns}</td>
+												</tr>
+											))}
+										</tbody>
+									</table>
+								</div>
+								<div className="grid gap-4 md:grid-cols-3">
+									<div className="rounded-3xl border border-white/10 bg-slate-900/70 p-4">
+										<p className="text-sm text-slate-400">Peak hour</p>
+										<p className="mt-3 text-lg font-semibold text-white">{dashboard.attendance.metrics.peakCheckInHour ?? "N/A"}</p>
+									</div>
+									<div className="rounded-3xl border border-white/10 bg-slate-900/70 p-4">
+										<p className="text-sm text-slate-400">Avg check-in interval</p>
+										<p className="mt-3 text-lg font-semibold text-white">{numberOrDash(dashboard.attendance.metrics.avgCheckInInterval)} min</p>
+									</div>
+									<div className="rounded-3xl border border-white/10 bg-slate-900/70 p-4">
+										<p className="text-sm text-slate-400">Check-ins per min</p>
+										<p className="mt-3 text-lg font-semibold text-white">{numberOrDash(dashboard.attendance.metrics.peakCheckInRate)}</p>
+									</div>
+								</div>
+							</div>
+						) : (
+							<div className="mt-6 rounded-3xl border border-white/10 bg-slate-900/70 p-6 text-slate-300">
+								<p>No attendance check-ins have been recorded yet.</p>
+							</div>
+						)}
+					</section>
+
+					<section className="rounded-3xl border border-white/10 bg-slate-950/70 p-6">
+						<h2 className="text-xl font-semibold text-white">Refund Health</h2>
+						<p className="mt-2 text-sm text-slate-400">Refund counts, average refund size, and recent refund activity.</p>
+
+						<div className="mt-6 grid gap-4 md:grid-cols-4">
+							{[
+								{ label: "Refunds total", value: dashboard.refunds.totalRefunds },
+								{ label: "Refund amount", value: formatPrice(dashboard.refunds.totalRefundAmount, "USD") },
+								{ label: "Avg refund", value: formatPrice(dashboard.refunds.avgRefundAmount, "USD") },
+								{ label: "Recent refunds", value: dashboard.refunds.refundsLast7Days },
+							].map((item) => (
+								<div key={item.label} className="rounded-3xl border border-white/10 bg-slate-900/70 p-4">
+									<p className="text-sm text-slate-400">{item.label}</p>
+									<p className="mt-3 text-lg font-semibold text-white">{item.value}</p>
+								</div>
+							))}
+						</div>
+					</section>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/frontend/components/events/EventDetailClient.tsx
+++ b/frontend/components/events/EventDetailClient.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { Event, VipTier, SeatCategoryName } from "@/types/event";
 import { formatPrice } from "@/types/event";
 import SeatMap from "@/components/venues/SeatMap";
@@ -32,15 +33,25 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
     <div className="max-w-6xl mx-auto px-4 py-8">
       {/* Event Header */}
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-white mb-2">{event.title}</h1>
-        <div className="flex items-center gap-3 text-sm text-gray-400">
-          <span>{event.location}</span>
-          <span>·</span>
-          <span>{new Date(event.startDate).toLocaleDateString("en-US", { weekday: "long", month: "long", day: "numeric", year: "numeric" })}</span>
-          <span>·</span>
-          <span className="text-lg font-bold text-white">
-            {event.ticketPrice === 0 ? "Free" : formatPrice(event.ticketPrice, event.currency)}
-          </span>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-white mb-2">{event.title}</h1>
+            <div className="flex items-center gap-3 text-sm text-gray-400">
+              <span>{event.location}</span>
+              <span>·</span>
+              <span>{new Date(event.startDate).toLocaleDateString("en-US", { weekday: "long", month: "long", day: "numeric", year: "numeric" })}</span>
+              <span>·</span>
+              <span className="text-lg font-bold text-white">
+                {event.ticketPrice === 0 ? "Free" : formatPrice(event.ticketPrice, event.currency)}
+              </span>
+            </div>
+          </div>
+          <Link
+            href={`/events/${event.id}/analytics`}
+            className="inline-flex items-center rounded-full border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm font-medium text-blue-200 transition hover:bg-blue-500/20"
+          >
+            View analytics
+          </Link>
         </div>
       </div>
 

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -17,6 +17,10 @@ async function request<T>(
     throw new Error(`API error ${res.status}: ${errorBody}`);
   }
 
+  if (res.status === 204) {
+    return null as any;
+  }
+
   return res.json();
 }
 
@@ -105,6 +109,26 @@ export const apiClient = {
 
   getOrganizerResaleEarnings: (token: string) =>
     request('/resale/organizer/earnings', {
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+
+  getEventAnalyticsDashboard: (eventId: string, token: string) =>
+    request(`/analytics/events/${eventId}/dashboard`, {
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+
+  getEventSalesReport: (eventId: string, token: string) =>
+    request(`/analytics/events/${eventId}/sales-report`, {
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+
+  getEventDemographics: (eventId: string, token: string) =>
+    request(`/analytics/events/${eventId}/demographics`, {
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+
+  getEventAttendance: (eventId: string, token: string) =>
+    request(`/analytics/events/${eventId}/attendance`, {
       headers: { Authorization: `Bearer ${token}` },
     }),
 };

--- a/frontend/types/analytics.ts
+++ b/frontend/types/analytics.ts
@@ -1,0 +1,115 @@
+export interface SalesDataPoint {
+	timestamp: string;
+	ticketsSold: number;
+	revenue: number;
+	cumulativeTickets: number;
+	cumulativeRevenue: number;
+}
+
+export interface SalesVelocityMetrics {
+	avgTicketsPerDay: number;
+	avgRevenuePerDay: number;
+	ticketsLast7Days: number;
+	ticketsLast24Hours: number;
+	peakSalesHour: number | null;
+	peakSalesDayOfWeek: number | null;
+	trend: 'increasing' | 'decreasing' | 'stable';
+}
+
+export interface SalesReport {
+	salesData: SalesDataPoint[];
+	metrics: SalesVelocityMetrics;
+	totalTicketsSold: number;
+	totalRevenue: number;
+	avgTicketPrice: number;
+	daysActive: number;
+}
+
+export interface AgeDistributionBucket {
+	ageRange: string;
+	count: number;
+	percentage: number;
+}
+
+export interface DemographicBreakdown {
+	verifiedAges: AgeDistributionBucket[];
+	ageVerificationRate: number;
+	averageAge: number | null;
+	minAge: number | null;
+	maxAge: number | null;
+}
+
+export interface CurrencyBreakdown {
+	currency: string;
+	ticketCount: number;
+	totalAmount: number;
+	percentage: number;
+}
+
+export interface DemographicsReport {
+	demographics: DemographicBreakdown;
+	currencyBreakdown: CurrencyBreakdown[];
+	totalAttendees: number;
+	totalRegistrations: number;
+	repeatAttendeeCount: number;
+	repeatAttendeePercentage: number;
+}
+
+export interface AttendanceDataPoint {
+	timestamp: string;
+	checkInCount: number;
+	cumulativeCheckIns: number;
+	hour: number;
+}
+
+export interface AttendanceMetrics {
+	peakCheckInHour: number | null;
+	peakCheckInCount: number;
+	totalCheckIns: number;
+	attendanceRate: number;
+	avgCheckInInterval: number | null;
+	peakCheckInRate: number | null;
+	estimatedCapacityFilled: number | null;
+}
+
+export interface AttendancePattern {
+	eventDurationHours: number;
+	hourlyCheckIns: AttendanceDataPoint[];
+	metrics: AttendanceMetrics;
+	totalTicketsIssued: number;
+	ticketsUsed: number;
+	ticketsUnused: number;
+	eventStartTime: string;
+	lastCheckInTime: string | null;
+}
+
+export interface RefundMetrics {
+	totalRefunds: number;
+	totalRefundAmount: number;
+	refundRate: number;
+	avgRefundAmount: number;
+	mostCommonReason: string | null;
+	refundsLast7Days: number;
+}
+
+export interface QuickStats {
+	ticketsSold: number;
+	totalRevenue: number;
+	attendanceCount: number;
+	attendanceRate: number;
+	avgTicketPrice: number;
+	totalRefunds: number;
+	refundRate: number;
+	revenueTrend: 'up' | 'down' | 'stable';
+	salesTrend: 'up' | 'down' | 'stable';
+}
+
+export interface AnalyticsDashboard {
+	eventId: string;
+	lastUpdated: string;
+	quickStats: QuickStats;
+	salesReport: SalesReport;
+	 demographics: DemographicsReport;
+	attendance: AttendancePattern | null;
+	refunds: RefundMetrics;
+}


### PR DESCRIPTION
Closes #561

## 📊 Feat: Event Analytics Dashboard for Organizers

Implements a comprehensive analytics system for event organizers covering sales velocity, demographic data, refund rates, and attendance patterns — with a real-time frontend dashboard that refreshes every 15 seconds.

### Backend

**New/Updated Files**
- `AnalyticsModule`, `AnalyticsController`, expanded `AnalyticsService`
- Implemented service methods:
  - `generateSalesReport(eventId, organizerId)` — sales velocity and refund rates
  - `trackDemographicData(eventId, organizerId)` — attendee demographic breakdown
  - `analyzeAttendancePatterns(eventId, organizerId)` — attendance trend analysis
  - `generateAnalyticsDashboard(eventId, organizerId)` — aggregated dashboard view
- Organizer-only endpoints (auth-protected):
  - `GET /analytics/events/:eventId/dashboard`
  - `GET /analytics/events/:eventId/sales-report`
  - `GET /analytics/events/:eventId/demographics`
  - `GET /analytics/events/:eventId/attendance`
- Unit tests in `analytics.service.spec.ts` covering sales report, demographic analytics, and attendance fallback — all passing

### Frontend

- `page.tsx` — analytics dashboard page with real-time refresh every 15 seconds
- `api-client.ts` — added analytics API client methods
- `EventDetailClient.tsx` — added organizer dashboard access link on event detail page
- `analytics.ts` — added analytics TypeScript type definitions

### Validation
```
Backend Jest spec: analytics.service.spec.ts ✅ passed
```