### PR TITLE
feat: add dynamic pricing and waitlist queue flow

### DIFF
--- a/contract/src/error.rs
+++ b/contract/src/error.rs
@@ -109,4 +109,12 @@ pub enum LumentixError {
     OraclePriceNotFound = 44,
     /// Currency conversion error
     CurrencyConversionError = 45,
+
+    // Waitlist errors (46–49)
+    /// User is already present in the event waitlist
+    AlreadyOnWaitlist = 46,
+    /// User has no active waitlist offer
+    WaitlistOfferNotFound = 47,
+    /// Waitlist offer has expired
+    WaitlistOfferExpired = 48,
 }

--- a/contract/src/events/mod.rs
+++ b/contract/src/events/mod.rs
@@ -277,6 +277,30 @@ impl BatchTicketsUsed {
     }
 }
 
+/// Event emitted when a buyer joins an event waitlist.
+pub struct WaitlistJoined;
+
+impl WaitlistJoined {
+    pub fn emit(env: &Env, event_id: u64, buyer: Address, position: u32) {
+        env.events().publish(
+            (symbol_short!("wjoin"),),
+            (event_id, buyer, position),
+        );
+    }
+}
+
+/// Event emitted when waitlist members receive a reservation offer.
+pub struct WaitlistAvailabilityNotified;
+
+impl WaitlistAvailabilityNotified {
+    pub fn emit(env: &Env, event_id: u64, buyer: Address, quantity: u32, expires_at: u64) {
+        env.events().publish(
+            (symbol_short!("wnotify"),),
+            (event_id, buyer, quantity, expires_at),
+        );
+    }
+}
+
 /// Event emitted when a ticket is refunded
 pub struct TicketRefunded;
 

--- a/contract/src/lumentix_contract.rs
+++ b/contract/src/lumentix_contract.rs
@@ -9,12 +9,12 @@ use crate::events::{
     FundsWithdrawn, GenericEventStateTransition, OraclePriceUpdated, PlatformFeeRecipientUpdated,
     PlatformFeeUpdated, PlatformFeesWithdrawn, ProtocolFeeQueried, SeatHoldReleased, SeatSelected,
     TicketPurchased, TicketRefunded, TicketTransferred, TicketUsed, VenueLayoutCreated,
-    VipTierCreated, VipTicketAssigned,
+    VipTierCreated, VipTicketAssigned, WaitlistAvailabilityNotified, WaitlistJoined,
 };
 use crate::storage;
 use crate::types::{
     AccessibilityBooking, AccessibilityInventory, CurrencyConfig, Event, EventStatus, Seat,
-    Ticket, TicketTransferRecord, VenueLayout, VenueSection, VipTier,
+    Ticket, TicketTransferRecord, VenueLayout, VenueSection, VipTier, WaitlistOffer,
     PERSISTENT_LIFETIME,
 };
 use crate::validation;
@@ -22,6 +22,10 @@ use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec, Map};
 
 #[contract]
 pub struct LumentixContract;
+
+const ONE_DAY_SECONDS: u64 = 24 * 60 * 60;
+const SEVEN_DAYS_SECONDS: u64 = 7 * 24 * 60 * 60;
+const THIRTY_DAYS_SECONDS: u64 = 30 * 24 * 60 * 60;
 
 #[contractimpl]
 impl LumentixContract {
@@ -298,6 +302,11 @@ impl LumentixContract {
         event.max_tickets = new_capacity;
         storage::set_event(&env, event_id, &event);
 
+        if new_capacity > old_capacity && event.status == EventStatus::Published {
+            let newly_available = new_capacity - old_capacity;
+            let _ = Self::process_waitlist_queue_internal(&env, event_id, newly_available);
+        }
+
         // Emit EventCapacityChanged event
         EventCapacityChanged::emit(&env, event_id, old_capacity, new_capacity);
 
@@ -365,8 +374,21 @@ impl LumentixContract {
             return Err(LumentixError::EventPaused);
         }
 
-        // Check capacity — reject when sold out
-        if event.tickets_sold >= event.max_tickets {
+        let now = env.ledger().timestamp();
+        Self::cleanup_expired_waitlist_offers(&env, event_id, now);
+        let reserved_for_waitlist = storage::get_waitlist_reserved(&env, event_id);
+
+        let mut consume_waitlist_offer = false;
+        if let Some(offer) = storage::get_waitlist_offer(&env, event_id, &buyer) {
+            if offer.quantity > 0 && offer.expires_at > now {
+                consume_waitlist_offer = true;
+            }
+        }
+
+        // Check capacity, accounting for reserved waitlist offers.
+        if !consume_waitlist_offer
+            && event.tickets_sold.saturating_add(reserved_for_waitlist) >= event.max_tickets
+        {
             return Err(LumentixError::EventSoldOut);
         }
 
@@ -405,7 +427,7 @@ impl LumentixContract {
         let ticket = Ticket {
             id: ticket_id,
             event_id,
-            owner: buyer,
+            owner: buyer.clone(),
             purchase_time: env.ledger().timestamp(),
             used: false,
             refunded: false,
@@ -416,6 +438,22 @@ impl LumentixContract {
         };
 
         storage::set_ticket(&env, ticket_id, &ticket);
+
+        if consume_waitlist_offer {
+            if let Some(mut offer) = storage::get_waitlist_offer(&env, event_id, &buyer) {
+                if offer.quantity > 0 {
+                    offer.quantity -= 1;
+                    let reserved = storage::get_waitlist_reserved(&env, event_id);
+                    storage::set_waitlist_reserved(&env, event_id, reserved.saturating_sub(1));
+                }
+
+                if offer.quantity == 0 {
+                    storage::remove_waitlist_offer(&env, event_id, &buyer);
+                } else {
+                    storage::set_waitlist_offer(&env, event_id, &buyer, &offer);
+                }
+            }
+        }
 
         TicketPurchased::emit(
             &env,
@@ -461,8 +499,14 @@ impl LumentixContract {
             return Err(LumentixError::EventPaused);
         }
 
-        // Check availability for the requested quantity
-        let available = event.max_tickets.saturating_sub(event.tickets_sold);
+        let now = env.ledger().timestamp();
+        Self::cleanup_expired_waitlist_offers(&env, event_id, now);
+        let reserved_for_waitlist = storage::get_waitlist_reserved(&env, event_id);
+
+        // Check public availability for the requested quantity
+        let available = event
+            .max_tickets
+            .saturating_sub(event.tickets_sold.saturating_add(reserved_for_waitlist));
         if available < quantity {
             return Err(LumentixError::EventSoldOut);
         }
@@ -798,6 +842,12 @@ impl LumentixContract {
         event.tickets_sold = event.tickets_sold.saturating_sub(1);
         storage::set_event(&env, ticket.event_id, &event);
 
+        if event.status == EventStatus::Cancelled {
+            // Cancelled events do not issue waitlist offers.
+        } else {
+            let _ = Self::process_waitlist_queue_internal(&env, ticket.event_id, 1);
+        }
+
         // Emit TicketRefunded event
         TicketRefunded::emit(&env, ticket_id, ticket.event_id, buyer, event.ticket_price);
 
@@ -919,6 +969,168 @@ impl LumentixContract {
     /// Get event data by ID.
     pub fn get_event(env: Env, event_id: u64) -> Result<Event, LumentixError> {
         storage::get_event(&env, event_id)
+    }
+
+    /// Calculate dynamic ticket price from time window and demand velocity.
+    /// - Early bird: >30 days => -20%
+    /// - Normal: 7..=30 days => base price
+    /// - Last minute: <=24h => +50%
+    /// Additional demand multipliers are applied from purchase velocity metrics.
+    pub fn calculate_dynamic_price(
+        env: Env,
+        event_id: u64,
+        recent_purchases: u32,
+        window_seconds: u64,
+    ) -> Result<i128, LumentixError> {
+        let event = storage::get_event(&env, event_id)?;
+        let now = env.ledger().timestamp();
+        let time_remaining = event.end_time.saturating_sub(now);
+
+        let mut price = if time_remaining > THIRTY_DAYS_SECONDS {
+            // Early bird discount
+            (event.ticket_price * 80) / 100
+        } else if time_remaining >= SEVEN_DAYS_SECONDS {
+            // Normal window (7-30 days)
+            event.ticket_price
+        } else if time_remaining <= ONE_DAY_SECONDS {
+            // Last-minute premium
+            (event.ticket_price * 150) / 100
+        } else {
+            // Between 24h and 7 days: keep base price
+            event.ticket_price
+        };
+
+        // Demand metric: purchases per hour over a caller-supplied analysis window.
+        if recent_purchases > 0 {
+            let window = if window_seconds == 0 { 1 } else { window_seconds };
+            let velocity_per_hour = (recent_purchases as u64).saturating_mul(3600) / window;
+
+            let demand_multiplier_bps = if velocity_per_hour >= 50 {
+                13000 // +30%
+            } else if velocity_per_hour >= 20 {
+                11500 // +15%
+            } else if velocity_per_hour >= 10 {
+                10500 // +5%
+            } else {
+                10000
+            };
+
+            price = (price * demand_multiplier_bps as i128) / 10000;
+        }
+
+        if price <= 0 {
+            return Err(LumentixError::InvalidAmount);
+        }
+
+        Ok(price)
+    }
+
+    /// Join an event waitlist once capacity is exhausted.
+    pub fn join_waitlist(env: Env, event_id: u64, buyer: Address) -> Result<u32, LumentixError> {
+        buyer.require_auth();
+        let event = storage::get_event(&env, event_id)?;
+        if event.status != EventStatus::Published {
+            return Err(LumentixError::InvalidStatusTransition);
+        }
+
+        let now = env.ledger().timestamp();
+        Self::cleanup_expired_waitlist_offers(&env, event_id, now);
+
+        let reserved = storage::get_waitlist_reserved(&env, event_id);
+        let available = event
+            .max_tickets
+            .saturating_sub(event.tickets_sold.saturating_add(reserved));
+        if available > 0 {
+            return Err(LumentixError::InvalidStatusTransition);
+        }
+
+        if let Some(offer) = storage::get_waitlist_offer(&env, event_id, &buyer) {
+            if offer.quantity > 0 && offer.expires_at > now {
+                return Err(LumentixError::AlreadyOnWaitlist);
+            }
+        }
+
+        let mut queue = storage::get_waitlist_queue(&env, event_id);
+        for queued in queue.iter() {
+            if queued == buyer {
+                return Err(LumentixError::AlreadyOnWaitlist);
+            }
+        }
+        queue.push_back(buyer.clone());
+        let position = queue.len();
+        storage::set_waitlist_queue(&env, event_id, &queue);
+        WaitlistJoined::emit(&env, event_id, buyer, position);
+        Ok(position)
+    }
+
+    /// Organizer-triggered queue processing to issue FIFO waitlist offers.
+    pub fn process_waitlist_queue(
+        env: Env,
+        organizer: Address,
+        event_id: u64,
+    ) -> Result<u32, LumentixError> {
+        organizer.require_auth();
+        let event = storage::get_event(&env, event_id)?;
+        if event.organizer != organizer {
+            return Err(LumentixError::Unauthorized);
+        }
+
+        let now = env.ledger().timestamp();
+        Self::cleanup_expired_waitlist_offers(&env, event_id, now);
+        let reserved = storage::get_waitlist_reserved(&env, event_id);
+        let available = event
+            .max_tickets
+            .saturating_sub(event.tickets_sold.saturating_add(reserved));
+
+        Ok(Self::process_waitlist_queue_internal(&env, event_id, available))
+    }
+
+    /// Notify a specific waitlist member that tickets are available.
+    /// Creates a 24-hour reservation window.
+    pub fn notify_waitlist_availability(
+        env: Env,
+        organizer: Address,
+        event_id: u64,
+        buyer: Address,
+        quantity: u32,
+    ) -> Result<u64, LumentixError> {
+        organizer.require_auth();
+        if quantity == 0 {
+            return Err(LumentixError::InvalidAmount);
+        }
+
+        let event = storage::get_event(&env, event_id)?;
+        if event.organizer != organizer {
+            return Err(LumentixError::Unauthorized);
+        }
+        if event.status != EventStatus::Published {
+            return Err(LumentixError::InvalidStatusTransition);
+        }
+
+        let now = env.ledger().timestamp();
+        Self::cleanup_expired_waitlist_offers(&env, event_id, now);
+
+        let reserved = storage::get_waitlist_reserved(&env, event_id);
+        let available = event
+            .max_tickets
+            .saturating_sub(event.tickets_sold.saturating_add(reserved));
+        if available < quantity {
+            return Err(LumentixError::EventSoldOut);
+        }
+
+        let expires_at = now + ONE_DAY_SECONDS;
+        let offer = WaitlistOffer {
+            quantity,
+            expires_at,
+        };
+        storage::set_waitlist_offer(&env, event_id, &buyer, &offer);
+        Self::add_offer_recipient_if_missing(&env, event_id, &buyer);
+
+        let new_reserved = storage::get_waitlist_reserved(&env, event_id).saturating_add(quantity);
+        storage::set_waitlist_reserved(&env, event_id, new_reserved);
+        WaitlistAvailabilityNotified::emit(&env, event_id, buyer, quantity, expires_at);
+
+        Ok(expires_at)
     }
 
     /// Get the status of an event by ID.
@@ -2257,6 +2469,82 @@ impl LumentixContract {
     }
 
     // ── Internal helpers ─────────────────────────────────────────────────────
+
+    fn add_offer_recipient_if_missing(env: &Env, event_id: u64, buyer: &Address) {
+        let mut recipients = storage::get_waitlist_offer_recipients(env, event_id);
+        for existing in recipients.iter() {
+            if existing == *buyer {
+                return;
+            }
+        }
+        recipients.push_back(buyer.clone());
+        storage::set_waitlist_offer_recipients(env, event_id, &recipients);
+    }
+
+    fn cleanup_expired_waitlist_offers(env: &Env, event_id: u64, now: u64) {
+        let recipients = storage::get_waitlist_offer_recipients(env, event_id);
+        let mut active_recipients = Vec::<Address>::new(env);
+        let mut reserved = storage::get_waitlist_reserved(env, event_id);
+
+        for buyer in recipients.iter() {
+            if let Some(offer) = storage::get_waitlist_offer(env, event_id, &buyer) {
+                if offer.quantity == 0 || offer.expires_at <= now {
+                    reserved = reserved.saturating_sub(offer.quantity);
+                    storage::remove_waitlist_offer(env, event_id, &buyer);
+                } else {
+                    active_recipients.push_back(buyer);
+                }
+            }
+        }
+
+        storage::set_waitlist_offer_recipients(env, event_id, &active_recipients);
+        storage::set_waitlist_reserved(env, event_id, reserved);
+    }
+
+    fn process_waitlist_queue_internal(env: &Env, event_id: u64, mut available: u32) -> u32 {
+        if available == 0 {
+            return 0;
+        }
+
+        let event = match storage::get_event(env, event_id) {
+            Ok(event) => event,
+            Err(_) => return 0,
+        };
+        if event.status != EventStatus::Published {
+            return 0;
+        }
+
+        let mut queue = storage::get_waitlist_queue(env, event_id);
+        let mut next_queue = Vec::<Address>::new(env);
+        let mut processed: u32 = 0;
+        let now = env.ledger().timestamp();
+
+        for buyer in queue.iter() {
+            if available == 0 {
+                next_queue.push_back(buyer);
+                continue;
+            }
+
+            let expires_at = now + ONE_DAY_SECONDS;
+            let offer = WaitlistOffer {
+                quantity: 1,
+                expires_at,
+            };
+            storage::set_waitlist_offer(env, event_id, &buyer, &offer);
+            Self::add_offer_recipient_if_missing(env, event_id, &buyer);
+
+            let reserved = storage::get_waitlist_reserved(env, event_id);
+            storage::set_waitlist_reserved(env, event_id, reserved.saturating_add(1));
+
+            WaitlistAvailabilityNotified::emit(env, event_id, buyer, 1, expires_at);
+            available -= 1;
+            processed += 1;
+        }
+
+        queue = next_queue;
+        storage::set_waitlist_queue(env, event_id, &queue);
+        processed
+    }
 
     fn build_seat_id(env: &Env, section: &String, row: u32, number: u32) -> String {
         let sec = section.to_bytes();

--- a/contract/src/storage.rs
+++ b/contract/src/storage.rs
@@ -1,7 +1,8 @@
 use crate::error::LumentixError;
 use crate::types::{
     AccessibilityBooking, AccessibilityInventory, CurrencyConfig, Event, Seat, Ticket,
-    TicketTransferRecord, VenueLayout, VipTier, INSTANCE_LIFETIME, PERSISTENT_LIFETIME,
+    TicketTransferRecord, VenueLayout, VipTier, WaitlistOffer, INSTANCE_LIFETIME,
+    PERSISTENT_LIFETIME,
 };
 use soroban_sdk::{Address, Env, String, Vec};
 
@@ -24,6 +25,10 @@ const VENUE_LAYOUT_PREFIX: &str = "VENUE_";
 const SEAT_PREFIX: &str = "SEAT_";
 const CURRENCY_CONFIG_PREFIX: &str = "CURCFG_";
 const ACC_BOOKING_COUNTER: &str = "ACC_CTR";
+const WAITLIST_QUEUE_PREFIX: &str = "WQUEUE_";
+const WAITLIST_OFFER_PREFIX: &str = "WOFFER_";
+const WAITLIST_OFFER_RECIPIENTS_PREFIX: &str = "WOFRECS_";
+const WAITLIST_RESERVED_PREFIX: &str = "WRESV_";
 
 /// Check if contract is initialized
 pub fn is_initialized(env: &Env) -> bool {
@@ -466,4 +471,97 @@ pub fn get_currency_config(env: &Env, code: &String) -> Result<CurrencyConfig, L
 pub fn has_currency(env: &Env, code: &String) -> bool {
     let key = (CURRENCY_CONFIG_PREFIX, code.clone());
     env.storage().instance().has(&key)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// WAITLIST STORAGE
+// ═══════════════════════════════════════════════════════════════════════════
+
+pub fn get_waitlist_queue(env: &Env, event_id: u64) -> Vec<Address> {
+    let key = (WAITLIST_QUEUE_PREFIX, event_id);
+    let queue: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(env));
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+    }
+    queue
+}
+
+pub fn set_waitlist_queue(env: &Env, event_id: u64, queue: &Vec<Address>) {
+    let key = (WAITLIST_QUEUE_PREFIX, event_id);
+    env.storage().persistent().set(&key, queue);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+}
+
+pub fn get_waitlist_offer(env: &Env, event_id: u64, buyer: &Address) -> Option<WaitlistOffer> {
+    let key = (WAITLIST_OFFER_PREFIX, event_id, buyer.clone());
+    let offer: Option<WaitlistOffer> = env.storage().persistent().get(&key);
+    if offer.is_some() {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+    }
+    offer
+}
+
+pub fn set_waitlist_offer(env: &Env, event_id: u64, buyer: &Address, offer: &WaitlistOffer) {
+    let key = (WAITLIST_OFFER_PREFIX, event_id, buyer.clone());
+    env.storage().persistent().set(&key, offer);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+}
+
+pub fn remove_waitlist_offer(env: &Env, event_id: u64, buyer: &Address) {
+    let key = (WAITLIST_OFFER_PREFIX, event_id, buyer.clone());
+    env.storage().persistent().remove(&key);
+}
+
+pub fn get_waitlist_offer_recipients(env: &Env, event_id: u64) -> Vec<Address> {
+    let key = (WAITLIST_OFFER_RECIPIENTS_PREFIX, event_id);
+    let recipients: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(env));
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+    }
+    recipients
+}
+
+pub fn set_waitlist_offer_recipients(env: &Env, event_id: u64, recipients: &Vec<Address>) {
+    let key = (WAITLIST_OFFER_RECIPIENTS_PREFIX, event_id);
+    env.storage().persistent().set(&key, recipients);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+}
+
+pub fn get_waitlist_reserved(env: &Env, event_id: u64) -> u32 {
+    let key = (WAITLIST_RESERVED_PREFIX, event_id);
+    let reserved: u32 = env.storage().persistent().get(&key).unwrap_or(0);
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+    }
+    reserved
+}
+
+pub fn set_waitlist_reserved(env: &Env, event_id: u64, reserved: u32) {
+    let key = (WAITLIST_RESERVED_PREFIX, event_id);
+    env.storage().persistent().set(&key, &reserved);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
 }

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -5240,3 +5240,78 @@ fn test_set_event_capacity() {
     // Decrease to 50 should succeed
     assert!(client.try_set_event_capacity(&organizer, &event_id, &50u32).is_ok());
 }
+
+#[test]
+fn test_calculate_dynamic_price_time_tiers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+    let event_id = client.create_event(
+        &organizer,
+        &String::from_str(&env, "Dynamic"),
+        &String::from_str(&env, "Pricing"),
+        &String::from_str(&env, "Venue"),
+        &2_000u64,
+        &(1_000 + (31 * 24 * 60 * 60)),
+        &100i128,
+        &100u32,
+    );
+    client.update_event_status(&event_id, &EventStatus::Published, &organizer);
+
+    let early = client.calculate_dynamic_price(&event_id, &0u32, &3600u64);
+    assert_eq!(early, 80i128);
+
+    env.ledger()
+        .with_mut(|li| li.timestamp = 1_000 + (10 * 24 * 60 * 60));
+    let normal = client.calculate_dynamic_price(&event_id, &0u32, &3600u64);
+    assert_eq!(normal, 100i128);
+
+    env.ledger()
+        .with_mut(|li| li.timestamp = (1_000 + (31 * 24 * 60 * 60)) - (12 * 60 * 60));
+    let last_minute = client.calculate_dynamic_price(&event_id, &0u32, &3600u64);
+    assert_eq!(last_minute, 150i128);
+}
+
+#[test]
+fn test_waitlist_fifo_offer_and_reserved_capacity() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+    let buyer_a = Address::generate(&env);
+    let buyer_b = Address::generate(&env);
+    let buyer_c = Address::generate(&env);
+
+    let event_id = client.create_event(
+        &organizer,
+        &String::from_str(&env, "Waitlist Event"),
+        &String::from_str(&env, "Desc"),
+        &String::from_str(&env, "Loc"),
+        &1000u64,
+        &2000u64,
+        &100i128,
+        &1u32,
+    );
+    client.update_event_status(&event_id, &EventStatus::Published, &organizer);
+
+    client.purchase_ticket(&buyer_a, &event_id, &100i128);
+    let position = client.join_waitlist(&event_id, &buyer_b);
+    assert_eq!(position, 1u32);
+
+    // Increasing capacity auto-processes queue and reserves the new slot for buyer_b.
+    assert!(client
+        .try_set_event_capacity(&organizer, &event_id, &2u32)
+        .is_ok());
+
+    // Public buyer cannot consume the reserved waitlist slot.
+    let c_result = client.try_purchase_ticket(&buyer_c, &event_id, &100i128);
+    assert_eq!(c_result, Err(Ok(LumentixError::EventSoldOut)));
+
+    // Waitlisted buyer can purchase during their reservation window.
+    assert!(client
+        .try_purchase_ticket(&buyer_b, &event_id, &100i128)
+        .is_ok());
+}

--- a/contract/src/types.rs
+++ b/contract/src/types.rs
@@ -65,18 +65,6 @@ pub struct TicketTransferRecord {
     pub timestamp: u64,
 }
 
-/// A single record in a ticket's transfer history
-#[contracttype]
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TicketTransferRecord {
-    /// Address that sent the ticket
-    pub from: Address,
-    /// Address that received the ticket
-    pub to: Address,
-    /// Ledger timestamp when the transfer occurred
-    pub timestamp: u64,
-}
-
 /// Fee collected event for tracking platform fees
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -171,4 +159,13 @@ pub struct CurrencyConfig {
     pub decimals: u32,
     pub oracle_price: i128,
     pub last_updated: u64,
+}
+
+// ── Waitlist ───────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WaitlistOffer {
+    pub quantity: u32,
+    pub expires_at: u64,
 }


### PR DESCRIPTION
## Summary
- Implements issue #550 with `calculate_dynamic_price` using time-aware pricing bands and purchase-velocity demand metrics.
- Implements issue #552 with FIFO waitlist support via `join_waitlist`, `process_waitlist_queue`, and `notify_waitlist_availability`, including 24-hour reservation windows.
- Verifies issues #544 and #545 in the contract flow: `BatchTicketsPurchased` and `BatchTicketsUsed` are used to avoid per-ticket event bloat for indexers.
- Adds/updates storage, events, errors, and contract tests to cover dynamic pricing tiers and waitlist reservation behavior.

## Issues Addressed
- #544: To save indexer processing, provide one combined emit instead of looping independent purchases. Define `BatchTicketsPurchased` exposing `event_id`, `buyer`, `quantity`, `total_price`, and `starting_ticket_id`. This prevents event bloat across the Stellar network.
- #545: As organizers scan groups, emitting individual check-in events clogs up logs. Consolidate via `BatchTicketsUsed` emitting `event_id`, `quantity`, and a `Vec<u64>` of `ticket_ids`. Enables rapid updating of active headcounts on live venue dashboards.
- #550: Implement surge pricing algorithm that adjusts ticket prices based on purchase velocity and time remaining until event. Early bird discounts (30 days before: -20%), normal pricing (7-30 days), and last-minute premium (+50% within 24 hours). Include `calculate_dynamic_price` function with demand metrics.
- #552: When events reach capacity, allow users to join a waitlist. If tickets become available (refunds, cancellations), automatically offer them to waitlist members in FIFO order. Add `join_waitlist`, `process_waitlist_queue`, and `notify_waitlist_availability` functions with 24-hour purchase windows.

## Test Plan
- [x] `cargo test` in `contract/`
- [x] Validate dynamic price tiers via unit test (`test_calculate_dynamic_price_time_tiers`)
- [x] Validate waitlist reservation and FIFO behavior via unit test (`test_waitlist_fifo_offer_and_reserved_capacity`)

Closes #544
Closes #545
Closes #550
Closes #552