### PR TITLE
feat: Swagger docs, coverage threshold, event capacity, and webhook outbound delivery

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -110,6 +110,14 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80,
+        "statements": 80
+      }
+    }
   }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -37,6 +37,7 @@ import { VenuesModule } from './venues/venues.module';
 import { GamificationModule } from './gamification/gamification.module';
 import { SchedulingModule } from './scheduling/scheduling.module';
 import { CategoriesModule } from './categories/categories.module';
+import { WebhooksModule } from './webhooks/webhooks.module';
 
 
 @Module({
@@ -116,7 +117,7 @@ import { CategoriesModule } from './categories/categories.module';
     AnalyticsModule,
     SchedulingModule,
     CategoriesModule,
-
+    WebhooksModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/database/migrations/1711380000010-AddCapacityToEvents.ts
+++ b/backend/src/database/migrations/1711380000010-AddCapacityToEvents.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCapacityToEvents1711380000010 implements MigrationInterface {
+  name = 'AddCapacityToEvents1711380000010';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "events" ADD COLUMN IF NOT EXISTS "maxAttendees" integer NULL DEFAULT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "events" DROP COLUMN IF EXISTS "maxAttendees"`,
+    );
+  }
+}

--- a/backend/src/database/migrations/1711380000020-AddWebhookUrlToEvents.ts
+++ b/backend/src/database/migrations/1711380000020-AddWebhookUrlToEvents.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddWebhookUrlToEvents1711380000020 implements MigrationInterface {
+  name = 'AddWebhookUrlToEvents1711380000020';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "events" ADD COLUMN IF NOT EXISTS "webhookUrl" character varying NULL DEFAULT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "events" DROP COLUMN IF EXISTS "webhookUrl"`,
+    );
+  }
+}

--- a/backend/src/events/entities/event.entity.ts
+++ b/backend/src/events/entities/event.entity.ts
@@ -118,6 +118,13 @@ export class Event {
   @JoinTable({ name: 'event_categories' })
   categories: Category[];
 
+  /**
+   * Optional webhook URL for outbound payment status notifications.
+   * When set, a signed POST request is sent on each payment status transition.
+   */
+  @Column({ type: 'varchar', nullable: true, default: null })
+  webhookUrl: string | null;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/backend/src/events/events.controller.ts
+++ b/backend/src/events/events.controller.ts
@@ -1,5 +1,6 @@
 import {
   Controller,
+  ForbiddenException,
   Get,
   Post,
   Put,
@@ -20,6 +21,7 @@ import {
   ApiTags,
   ApiBearerAuth,
   ApiOperation,
+  ApiParam,
   ApiResponse,
   ApiBody,
 } from '@nestjs/swagger';
@@ -36,6 +38,7 @@ import { RolesGuard } from '../common/guards/roles.guard';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { AuthenticatedRequest } from '../common/interfaces/authenticated-request.interface';
 import { TicketsService } from '../tickets/tickets.service';
+import { WebhooksService } from '../webhooks/webhooks.service';
 import { Event } from './entities/event.entity';
 
 @ApiTags('Events')
@@ -48,6 +51,7 @@ export class EventsController {
     private readonly eventsService: EventsService,
     @Inject(forwardRef(() => TicketsService))
     private readonly ticketsService: TicketsService,
+    private readonly webhooksService: WebhooksService,
   ) {}
 
   @Post()
@@ -94,8 +98,9 @@ export class EventsController {
   @ApiOperation({
     summary: 'Get an event by ID',
     description:
-      'Retrieves full details including soldTickets and remainingCapacity.',
+      'Retrieves full details including soldTickets and availableSpots.',
   })
+  @ApiParam({ name: 'id', description: 'Event UUID' })
   @ApiResponse({ status: 200, description: 'Event found', type: Event })
   @ApiResponse({ status: 404, description: 'Event not found' })
   getById(@Param('id', ParseUUIDPipe) id: string) {
@@ -108,6 +113,8 @@ export class EventsController {
     summary: 'Update an event',
     description: 'Organizer-only. Allows updating event details.',
   })
+  @ApiParam({ name: 'id', description: 'Event UUID' })
+  @ApiBody({ type: UpdateEventDto })
   @ApiResponse({ status: 200, description: 'Event updated', type: Event })
   @ApiResponse({ status: 403, description: 'Forbidden' })
   @ApiResponse({ status: 404, description: 'Event not found' })
@@ -184,6 +191,7 @@ export class EventsController {
     summary: 'Delete an event',
     description: 'Organizer-only. Soft deletes an event if no tickets sold.',
   })
+  @ApiParam({ name: 'id', description: 'Event UUID' })
   @ApiResponse({ status: 204, description: 'Event deleted' })
   @ApiResponse({ status: 403, description: 'Forbidden' })
   @ApiResponse({ status: 404, description: 'Event not found' })
@@ -201,6 +209,7 @@ export class EventsController {
     description:
       'Organizer-only. Transitions DRAFT → PUBLISHED and sets up escrow.',
   })
+  @ApiParam({ name: 'id', description: 'Event UUID' })
   @ApiResponse({ status: 201, description: 'Event published', type: Event })
   @ApiResponse({ status: 400, description: 'Invalid state transition' })
   @ApiResponse({ status: 403, description: 'Forbidden' })
@@ -219,6 +228,7 @@ export class EventsController {
     description:
       'Organizer-only. Transitions PUBLISHED → COMPLETED. Only allowed after endDate.',
   })
+  @ApiParam({ name: 'id', description: 'Event UUID' })
   @ApiResponse({ status: 201, description: 'Event completed', type: Event })
   @ApiResponse({
     status: 400,
@@ -240,6 +250,7 @@ export class EventsController {
     description:
       'Organizer-only. Cancels the event and automatically triggers refunds.',
   })
+  @ApiParam({ name: 'id', description: 'Event UUID' })
   @ApiResponse({ status: 201, description: 'Event cancelled' })
   @ApiResponse({ status: 403, description: 'Forbidden' })
   @ApiResponse({ status: 404, description: 'Event not found' })
@@ -257,6 +268,7 @@ export class EventsController {
     description:
       'Organizer-only. Returns revenue, ticket counts, sponsorship totals.',
   })
+  @ApiParam({ name: 'id', description: 'Event UUID' })
   @ApiResponse({
     status: 200,
     description: 'Event stats',
@@ -302,6 +314,12 @@ export class EventsController {
 
   @Post(':id/duplicate')
   @Roles(Role.ORGANIZER)
+  @ApiOperation({ summary: 'Duplicate an event', description: 'Organizer-only. Creates a DRAFT copy of an existing event.' })
+  @ApiParam({ name: 'id', description: 'Event UUID to duplicate' })
+  @ApiBody({ type: DuplicateEventDto })
+  @ApiResponse({ status: 201, description: 'Event duplicated', type: Event })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  @ApiResponse({ status: 404, description: 'Event not found' })
   duplicate(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: DuplicateEventDto,
@@ -345,5 +363,25 @@ export class EventsController {
     @Req() req: AuthenticatedRequest,
   ) {
     return this.eventsService.deleteEventImage(id, imageId, req.user.id);
+
+  @Get(':id/webhooks/deliveries')
+  @Roles(Role.ORGANIZER)
+  @ApiOperation({
+    summary: 'Get webhook delivery history',
+    description: 'Organizer-only. Returns the last 50 outbound webhook deliveries for this event.',
+  })
+  @ApiParam({ name: 'id', description: 'Event UUID' })
+  @ApiResponse({ status: 200, description: 'Webhook delivery records' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  @ApiResponse({ status: 404, description: 'Event not found' })
+  async getWebhookDeliveries(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    const event = await this.eventsService.getEventById(id);
+    if (event.organizerId !== req.user.id) {
+      throw new ForbiddenException();
+    }
+    return this.webhooksService.getDeliveries(id);
   }
 }

--- a/backend/src/events/events.module.ts
+++ b/backend/src/events/events.module.ts
@@ -14,6 +14,7 @@ import { Payment } from '../payments/entities/payment.entity';
 import { SponsorContribution } from '../sponsors/entities/sponsor-contribution.entity';
 import { RefundModule } from '../payments/refunds/refund.module';
 import { EventImage } from './entities/event-image.entity';
+import { WebhooksModule } from '../webhooks/webhooks.module';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { EventImage } from './entities/event-image.entity';
     EscrowModule,
     AuditModule,
     forwardRef(() => RefundModule),
+    WebhooksModule,
   ],
   controllers: [EventsController],
   providers: [EventsService, EventStateService],

--- a/backend/src/events/events.service.ts
+++ b/backend/src/events/events.service.ts
@@ -44,6 +44,7 @@ export interface PaginatedResult<T> {
 export type EventWithCapacity = Event & {
   soldTickets: number;
   remainingCapacity: number | null;
+  availableSpots: number | null;
 };
 
 @Injectable()
@@ -254,11 +255,14 @@ export class EventsService {
       where: { eventId: id, status: 'valid' },
     });
 
+    const remainingCapacity =
+      event.maxAttendees !== null ? event.maxAttendees - soldTickets : null;
+
     return {
       ...event,
       soldTickets,
-      remainingCapacity:
-        event.maxAttendees !== null ? event.maxAttendees - soldTickets : null,
+      remainingCapacity,
+      availableSpots: remainingCapacity,
     };
   }
 
@@ -321,11 +325,13 @@ export class EventsService {
 
     const data: EventWithCapacity[] = rawEvents.entities.map((event, i) => {
       const soldTickets = Number(rawEvents.raw[i]?.soldTickets ?? 0);
+      const remainingCapacity =
+        event.maxAttendees !== null ? event.maxAttendees - soldTickets : null;
       return {
         ...event,
         soldTickets,
-        remainingCapacity:
-          event.maxAttendees !== null ? event.maxAttendees - soldTickets : null,
+        remainingCapacity,
+        availableSpots: remainingCapacity,
       };
     });
 

--- a/backend/src/payments/payments.module.ts
+++ b/backend/src/payments/payments.module.ts
@@ -5,6 +5,7 @@ import { PaymentsController } from './payments.controller';
 import { PaymentsService } from './payments.service';
 import { PaymentExpiryJob } from './jobs/payment-expiry.job';
 import { Payment } from './entities/payment.entity';
+import { User } from '../users/entities/user.entity';
 import { CurrenciesModule } from '../currencies/currencies.module';
 import { EventsModule } from '../events/events.module';
 import { StellarModule } from '../stellar/stellar.module';
@@ -16,12 +17,16 @@ import { PaymentAnalyticsService } from './services/payment-analytics.service';
 @Module({
   imports: [
     TypeOrmModule.forFeature([Payment]),
+import { WebhooksModule } from '../webhooks/webhooks.module';
+
+    TypeOrmModule.forFeature([Payment, User]),
     ScheduleModule,
     CurrenciesModule,
     EventsModule,
     StellarModule,
     AuditModule,
     NotificationModule,
+    WebhooksModule,
   ],
   controllers: [PaymentsController, PaymentAnalyticsController],
   providers: [

--- a/backend/src/payments/payments.service.ts
+++ b/backend/src/payments/payments.service.ts
@@ -7,10 +7,6 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, LessThan } from 'typeorm';
-import { Payment, PaymentStatus } from './entities/payment.entity';
-import { PaginationDto } from '../common/pagination/dto/pagination.dto';
-import { paginate } from '../common/pagination/pagination.helper';
-import { LessThan, Repository } from 'typeorm';
 import { AuditAction } from '../audit/entities/audit-log.entity';
 import { AuditService } from '../audit/audit.service';
 import { PaginationDto } from '../common/pagination/pagination.dto';
@@ -20,11 +16,10 @@ import { EventStatus } from '../events/entities/event.entity';
 import { EventsService } from '../events/events.service';
 import { NotificationService } from '../notifications/notification.service';
 import { StellarService } from '../stellar/stellar.service';
-import { AuditService } from '../audit/audit.service';
-import { NotificationService } from '../notifications/notification.service';
 import { User } from '../users/entities/user.entity';
 import { ConfirmPaymentDto } from './dto/confirm-payment.dto';
 import { Payment, PaymentStatus } from './entities/payment.entity';
+import { WebhooksService } from '../webhooks/webhooks.service';
 
 @Injectable()
 export class PaymentsService {
@@ -37,6 +32,8 @@ export class PaymentsService {
     private readonly stellarService: StellarService,
     private readonly auditService: AuditService,
     private readonly notificationService: NotificationService,
+    private readonly webhooksService: WebhooksService,
+    private readonly currenciesService: CurrenciesService,
   ) {}
 
   async getPaymentById(id: string): Promise<Payment> {
@@ -330,6 +327,8 @@ export class PaymentsService {
       },
     });
 
+    this.webhooksService.queueDelivery(event, confirmed).catch(() => undefined);
+
     return confirmed;
   }
 
@@ -396,7 +395,7 @@ export class PaymentsService {
 
   private async markFailed(payment: Payment, reason: string): Promise<void> {
     payment.status = PaymentStatus.FAILED;
-    await this.paymentsRepository.save(payment);
+    const saved = await this.paymentsRepository.save(payment);
 
     await this.auditService.log({
       action: AuditAction.PAYMENT_FAILED,
@@ -415,6 +414,7 @@ export class PaymentsService {
         currency: payment.currency,
         reason,
       });
+      this.webhooksService.queueDelivery(event, saved).catch(() => undefined);
     } catch (error) {
       console.error(
         `Failed to queue payment failure email for ${payment.id}:`,

--- a/backend/src/sponsors/sponsors.controller.ts
+++ b/backend/src/sponsors/sponsors.controller.ts
@@ -17,7 +17,9 @@ import {
 import {
   ApiTags,
   ApiBearerAuth,
+  ApiBody,
   ApiOperation,
+  ApiParam,
   ApiResponse,
 } from '@nestjs/swagger';
 import { SponsorsService } from './sponsors.service';
@@ -47,7 +49,10 @@ export class SponsorsController {
   @Roles(Role.ORGANIZER)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Create sponsor tier', description: 'Organizer-only. Creates a new sponsorship tier for an event.' })
+  @ApiParam({ name: 'eventId', description: 'Event UUID' })
+  @ApiBody({ type: CreateSponsorTierDto })
   @ApiResponse({ status: 201, description: 'Tier created' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 403, description: 'Forbidden' })
   create(
     @Param('eventId', ParseUUIDPipe) eventId: string,
@@ -59,7 +64,9 @@ export class SponsorsController {
 
   @Get()
   @ApiOperation({ summary: 'List sponsor tiers', description: 'Public. Shows available sponsorship tiers for an event.' })
+  @ApiParam({ name: 'eventId', description: 'Event UUID' })
   @ApiResponse({ status: 200, description: 'List of tiers' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   list(@Param('eventId', ParseUUIDPipe) eventId: string) {
     return this.sponsorsService.listTiers(eventId);
   }
@@ -79,7 +86,11 @@ export class SponsorsController {
   @Roles(Role.ORGANIZER)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Update sponsor tier', description: 'Organizer-only. Updates tier details.' })
+  @ApiParam({ name: 'eventId', description: 'Event UUID' })
+  @ApiParam({ name: 'id', description: 'Tier UUID' })
+  @ApiBody({ type: UpdateSponsorTierDto })
   @ApiResponse({ status: 200, description: 'Tier updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 403, description: 'Forbidden' })
   update(
     @Param('id', ParseUUIDPipe) id: string,
@@ -94,7 +105,10 @@ export class SponsorsController {
   @ApiBearerAuth()
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Delete sponsor tier', description: 'Organizer-only. Removes a tier if no contributions exist.' })
+  @ApiParam({ name: 'eventId', description: 'Event UUID' })
+  @ApiParam({ name: 'id', description: 'Tier UUID' })
   @ApiResponse({ status: 204, description: 'Tier deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 403, description: 'Forbidden' })
   delete(
     @Param('id', ParseUUIDPipe) id: string,

--- a/backend/src/users/dto/request-role.dto.ts
+++ b/backend/src/users/dto/request-role.dto.ts
@@ -1,12 +1,19 @@
 import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { UserRole } from '../enums/user-role.enum';
 
 export class RequestRoleDto {
+  @ApiProperty({
+    enum: [UserRole.ORGANIZER, UserRole.SPONSOR],
+    description: 'The role being requested',
+    example: UserRole.ORGANIZER,
+  })
   @IsEnum([UserRole.ORGANIZER, UserRole.SPONSOR], {
     message: 'requestedRole must be ORGANIZER or SPONSOR',
   })
   requestedRole: UserRole.ORGANIZER | UserRole.SPONSOR;
 
+  @ApiPropertyOptional({ description: 'Optional reason for the role request', example: 'I want to host events' })
   @IsOptional()
   @IsString()
   reason?: string;

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -14,7 +14,9 @@ import {
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
+  ApiBody,
   ApiOperation,
+  ApiParam,
   ApiQuery,
   ApiResponse,
   ApiTags,
@@ -53,6 +55,8 @@ export class UsersController {
   @Get('me')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get current user profile' })
+  @ApiResponse({ status: 200, description: 'User profile returned' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getProfile(@Req() req: AuthenticatedRequest) {
     return this.usersService.findById(req.user.id);
   }
@@ -60,6 +64,10 @@ export class UsersController {
   @Patch('me')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Update current user profile' })
+  @ApiBody({ type: UpdateProfileDto })
+  @ApiResponse({ status: 200, description: 'Profile updated' })
+  @ApiResponse({ status: 400, description: 'Bad request' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async updateProfile(
     @Req() req: AuthenticatedRequest,
     @Body() dto: UpdateProfileDto,
@@ -71,6 +79,8 @@ export class UsersController {
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Soft delete current user account' })
+  @ApiResponse({ status: 204, description: 'Account deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async deleteProfile(@Req() req: AuthenticatedRequest) {
     await this.usersService.deleteMyAccount(req.user.id);
     return;
@@ -79,6 +89,9 @@ export class UsersController {
   @Patch('me/notification-preferences')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Update notification preferences' })
+  @ApiBody({ type: UpdateNotificationPreferencesDto })
+  @ApiResponse({ status: 200, description: 'Notification preferences updated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async updateNotificationPreferences(
     @Req() req: AuthenticatedRequest,
     @Body() updateDto: UpdateNotificationPreferencesDto,
@@ -133,7 +146,9 @@ export class UsersController {
     summary: 'Find a user by ID',
     description: 'Retrieves user details.',
   })
+  @ApiParam({ name: 'id', description: 'User UUID' })
   @ApiResponse({ status: 200, description: 'User found.' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'User not found.' })
   async findOne(@Param('id') id: string) {
     return this.usersService.findById(id);

--- a/backend/src/webhooks/entities/webhook-delivery.entity.ts
+++ b/backend/src/webhooks/entities/webhook-delivery.entity.ts
@@ -1,0 +1,36 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Index(['eventId'])
+@Index(['paymentId'])
+@Entity('webhook_deliveries')
+export class WebhookDelivery {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  eventId: string;
+
+  @Column({ type: 'uuid' })
+  paymentId: string;
+
+  @Column({ type: 'varchar' })
+  url: string;
+
+  @Column({ type: 'int', nullable: true, default: null })
+  statusCode: number | null;
+
+  @Column({ type: 'text', nullable: true, default: null })
+  responseBody: string | null;
+
+  @Column({ type: 'int', default: 0 })
+  attempt: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/webhooks/jobs/webhook-delivery.job.ts
+++ b/backend/src/webhooks/jobs/webhook-delivery.job.ts
@@ -1,0 +1,117 @@
+import { Processor, Process } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Job } from 'bull';
+import * as crypto from 'crypto';
+import * as https from 'https';
+import * as http from 'http';
+import { WebhookDelivery } from '../entities/webhook-delivery.entity';
+
+export const WEBHOOK_QUEUE = 'webhook-delivery';
+
+export interface WebhookJobData {
+  deliveryId: string;
+  url: string;
+  payload: Record<string, unknown>;
+  secret: string;
+  attempt: number;
+}
+
+@Processor(WEBHOOK_QUEUE)
+export class WebhookDeliveryJob {
+  private readonly logger = new Logger(WebhookDeliveryJob.name);
+
+  constructor(
+    @InjectRepository(WebhookDelivery)
+    private readonly deliveryRepo: Repository<WebhookDelivery>,
+  ) {}
+
+  @Process('deliver')
+  async deliver(job: Job<WebhookJobData>): Promise<void> {
+    const { deliveryId, url, payload, secret, attempt } = job.data;
+
+    const body = JSON.stringify(payload);
+    const signature = crypto
+      .createHmac('sha256', secret)
+      .update(body)
+      .digest('hex');
+
+    let statusCode: number | null = null;
+    let responseBody: string | null = null;
+
+    try {
+      const result = await this.postRequest(url, body, signature);
+      statusCode = result.statusCode;
+      responseBody = result.body;
+    } catch (err) {
+      this.logger.warn(`Webhook delivery attempt ${attempt} failed for ${deliveryId}: ${err}`);
+
+      const backoffDelays = [1000, 2000, 4000, 8000, 16000];
+      if (attempt < 5) {
+        const delay = backoffDelays[attempt] ?? 16000;
+        await job.queue.add(
+          'deliver',
+          { ...job.data, attempt: attempt + 1 },
+          { delay },
+        );
+      }
+
+      await this.deliveryRepo.update(deliveryId, {
+        attempt,
+        statusCode: null,
+        responseBody: String(err),
+      });
+      return;
+    }
+
+    await this.deliveryRepo.update(deliveryId, {
+      attempt,
+      statusCode,
+      responseBody,
+    });
+
+    this.logger.log(
+      `Webhook delivered to ${url} — status ${statusCode} (attempt ${attempt})`,
+    );
+  }
+
+  private postRequest(
+    url: string,
+    body: string,
+    signature: string,
+  ): Promise<{ statusCode: number; body: string }> {
+    return new Promise((resolve, reject) => {
+      const parsedUrl = new URL(url);
+      const lib = parsedUrl.protocol === 'https:' ? https : http;
+      const options = {
+        hostname: parsedUrl.hostname,
+        port: parsedUrl.port || (parsedUrl.protocol === 'https:' ? 443 : 80),
+        path: parsedUrl.pathname + parsedUrl.search,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+          'X-Lumentix-Signature': `sha256=${signature}`,
+        },
+      };
+
+      const req = lib.request(options, (res) => {
+        let data = '';
+        res.on('data', (chunk) => (data += chunk));
+        res.on('end', () =>
+          resolve({ statusCode: res.statusCode ?? 0, body: data }),
+        );
+      });
+
+      req.on('error', reject);
+      req.setTimeout(10000, () => {
+        req.destroy();
+        reject(new Error('Webhook request timed out'));
+      });
+
+      req.write(body);
+      req.end();
+    });
+  }
+}

--- a/backend/src/webhooks/webhooks.module.ts
+++ b/backend/src/webhooks/webhooks.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BullModule } from '@nestjs/bull';
+import { WebhookDelivery } from './entities/webhook-delivery.entity';
+import { WebhooksService } from './webhooks.service';
+import { WebhookDeliveryJob, WEBHOOK_QUEUE } from './jobs/webhook-delivery.job';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([WebhookDelivery]),
+    BullModule.registerQueue({ name: WEBHOOK_QUEUE }),
+  ],
+  providers: [WebhooksService, WebhookDeliveryJob],
+  exports: [WebhooksService],
+})
+export class WebhooksModule {}

--- a/backend/src/webhooks/webhooks.service.ts
+++ b/backend/src/webhooks/webhooks.service.ts
@@ -1,0 +1,71 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { InjectQueue } from '@nestjs/bull';
+import { Queue } from 'bull';
+import { ConfigService } from '@nestjs/config';
+import { WebhookDelivery } from './entities/webhook-delivery.entity';
+import { WEBHOOK_QUEUE, WebhookJobData } from './jobs/webhook-delivery.job';
+import { Event } from '../events/entities/event.entity';
+import { Payment } from '../payments/entities/payment.entity';
+
+@Injectable()
+export class WebhooksService {
+  private readonly logger = new Logger(WebhooksService.name);
+
+  constructor(
+    @InjectRepository(WebhookDelivery)
+    private readonly deliveryRepo: Repository<WebhookDelivery>,
+    @InjectQueue(WEBHOOK_QUEUE)
+    private readonly webhookQueue: Queue<WebhookJobData>,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async queueDelivery(event: Event, payment: Payment): Promise<void> {
+    if (!event.webhookUrl) {
+      return;
+    }
+
+    const delivery = this.deliveryRepo.create({
+      eventId: event.id,
+      paymentId: payment.id,
+      url: event.webhookUrl,
+      attempt: 0,
+    });
+
+    const saved = await this.deliveryRepo.save(delivery);
+
+    const secret =
+      this.configService.get<string>('WEBHOOK_SECRET') ?? 'lumentix-webhook-secret';
+
+    const payload: Record<string, unknown> = {
+      event: 'payment.status_changed',
+      eventId: event.id,
+      paymentId: payment.id,
+      status: payment.status,
+      currency: payment.currency,
+      amount: payment.amount,
+      timestamp: new Date().toISOString(),
+    };
+
+    await this.webhookQueue.add('deliver', {
+      deliveryId: saved.id,
+      url: event.webhookUrl,
+      payload,
+      secret,
+      attempt: 1,
+    });
+
+    this.logger.log(
+      `Queued webhook delivery ${saved.id} for payment ${payment.id} to ${event.webhookUrl}`,
+    );
+  }
+
+  async getDeliveries(eventId: string): Promise<WebhookDelivery[]> {
+    return this.deliveryRepo.find({
+      where: { eventId },
+      order: { createdAt: 'DESC' },
+      take: 50,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `@ApiOperation`, `@ApiResponse`, `@ApiParam`, `@ApiBody` decorators to all controller endpoints
- Adds `@ApiProperty` to DTO classes for complete OpenAPI spec
- Adds 80% coverage threshold to Jest config (`branches`, `functions`, `lines`, `statements`)
- Adds migrations for `maxAttendees` capacity and `webhookUrl` on events
- Implements outbound webhook delivery with HMAC-SHA256 signing and exponential-backoff retry (up to 5 attempts)
- Adds `GET /events/:id/webhooks/deliveries` endpoint for organizer review

Closes #472
Closes #473
Closes #474
Closes #475