### PR TITLE
feat: stream max-retry cap, idempotency keys, internal signing, ticket transfer

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -52,3 +52,8 @@ AUDIT_RETENTION_DAYS=90
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 GOOGLE_CALLBACK_URL=http://localhost:8000/auth/google/callback
+
+# ─── Internal Service Signing ────────────────────────────────────────────────
+# Shared secret used to sign inter-service HTTP requests (HMAC-SHA256).
+# MUST be changed in production. See docs/internal-api.md for the signing protocol.
+INTERNAL_SECRET=change_me_in_production

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -1,9 +1,12 @@
 import {
   Controller,
   Get,
+  HttpCode,
+  HttpStatus,
   Param,
   ParseUUIDPipe,
   Patch,
+  Post,
   Query,
   UseGuards,
 } from '@nestjs/common';
@@ -26,6 +29,7 @@ import { PaginationDto } from '../common/pagination/dto/pagination.dto';
 import { RoleRequestStatus } from '../users/entities/role-request.entity';
 import { UserRole } from '../users/enums/user-role.enum';
 import { StellarService } from '../stellar/stellar.service';
+import { StellarWebhookService } from '../stellar/stellar-webhook.service';
 
 @ApiTags('Admin')
 @ApiBearerAuth()
@@ -37,7 +41,26 @@ export class AdminController {
     private readonly adminService: AdminService,
     private readonly bruteForceService: BruteForceService,
     private readonly stellarService: StellarService,
+    private readonly stellarWebhookService: StellarWebhookService,
   ) {}
+
+  // ─── Stellar Stream Management ────────────────────────────────────────────
+
+  @Post('stellar/reconnect')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Manually reconnect the Stellar payment stream',
+    description:
+      'Admin-only endpoint. Restarts the Horizon SSE stream and resets the ' +
+      'consecutive-failure counter. Use after a STELLAR_STREAM_DEAD event.',
+  })
+  @ApiResponse({ status: 200, description: 'Stream reconnect initiated' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  reconnectStellarStream(): { message: string } {
+    this.stellarWebhookService.reconnect();
+    return { message: 'Stellar stream reconnect initiated' };
+  }
 
   @Patch('security/unlock-ip/:ip')
   @ApiOperation({

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -11,6 +11,14 @@ import { StellarModule } from '../stellar/stellar.module';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Event, User, RoleRequest]), AuthModule, StellarModule],
+import { StellarWebhookModule } from '../stellar/stellar-webhook.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Event, User, RoleRequest]),
+    AuthModule,
+    StellarWebhookModule,
+  ],
   controllers: [AdminController],
   providers: [AdminService, RolesGuard],
   exports: [RolesGuard],

--- a/backend/src/common/guards/internal-signature.guard.ts
+++ b/backend/src/common/guards/internal-signature.guard.ts
@@ -1,0 +1,92 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { createHmac } from 'crypto';
+import { Request } from 'express';
+
+/** Maximum age of a signed request before it is considered stale (30 seconds). */
+const MAX_TIMESTAMP_AGE_MS = 30_000;
+
+/**
+ * Guards routes under `/internal/*` by verifying an HMAC-SHA256 signature.
+ *
+ * Expected request headers:
+ *   X-Timestamp         — Unix epoch in milliseconds (string)
+ *   X-Internal-Signature — hex(HMAC-SHA256(`${timestamp}:${rawBody}`, INTERNAL_SECRET))
+ *
+ * Apply this guard at the controller level on any `@Controller('internal/...')`
+ * controller, or register it globally for the `/internal` prefix only.
+ */
+@Injectable()
+export class InternalSignatureGuard implements CanActivate {
+  private readonly logger = new Logger(InternalSignatureGuard.name);
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request>();
+
+    const timestamp = request.headers['x-timestamp'] as string | undefined;
+    const signature = request.headers['x-internal-signature'] as
+      | string
+      | undefined;
+
+    if (!timestamp || !signature) {
+      this.logger.warn(
+        `InternalSignatureGuard: missing header(s) on ${request.method} ${request.path}`,
+      );
+      throw new UnauthorizedException('Missing internal signature headers');
+    }
+
+    // Reject stale requests
+    const requestTime = parseInt(timestamp, 10);
+    if (isNaN(requestTime) || Date.now() - requestTime > MAX_TIMESTAMP_AGE_MS) {
+      this.logger.warn(
+        `InternalSignatureGuard: stale timestamp ${timestamp} on ${request.path}`,
+      );
+      throw new UnauthorizedException('Request timestamp is stale');
+    }
+
+    const secret = process.env.INTERNAL_SECRET;
+    if (!secret) {
+      this.logger.error(
+        'InternalSignatureGuard: INTERNAL_SECRET env var is not set',
+      );
+      throw new UnauthorizedException('Internal signing is misconfigured');
+    }
+
+    // Raw body is expected to have been captured by a body parser as a Buffer
+    // on `request.rawBody`. Fall back to empty string for GET / DELETE requests.
+    const rawBody =
+      (request as unknown as { rawBody?: Buffer }).rawBody?.toString('utf8') ??
+      '';
+
+    const expected = createHmac('sha256', secret)
+      .update(`${timestamp}:${rawBody}`)
+      .digest('hex');
+
+    if (!timingSafeEqual(expected, signature)) {
+      this.logger.warn(
+        `InternalSignatureGuard: invalid signature on ${request.method} ${request.path}`,
+      );
+      throw new UnauthorizedException('Invalid internal signature');
+    }
+
+    return true;
+  }
+}
+
+/**
+ * Constant-time string comparison to prevent timing attacks.
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  return (
+    bufA.length === bufB.length &&
+    require('crypto').timingSafeEqual(bufA, bufB)
+  );
+}

--- a/backend/src/common/http/internal-http-client.service.ts
+++ b/backend/src/common/http/internal-http-client.service.ts
@@ -1,0 +1,111 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { createHmac } from 'crypto';
+
+/**
+ * A lightweight HTTP client for calls between internal LumenTix services.
+ *
+ * Every outbound request is automatically signed with:
+ *   X-Timestamp            — current Unix epoch in milliseconds (string)
+ *   X-Internal-Signature   — hex(HMAC-SHA256(`${timestamp}:${body}`, INTERNAL_SECRET))
+ *
+ * The receiving service should validate these headers using InternalSignatureGuard.
+ */
+@Injectable()
+export class InternalHttpClientService {
+  private readonly logger = new Logger(InternalHttpClientService.name);
+
+  // ─── GET ─────────────────────────────────────────────────────────────────
+
+  async get<T = unknown>(url: string, extraHeaders?: Record<string, string>): Promise<T> {
+    const headers = this.buildHeaders('', extraHeaders);
+
+    this.logger.debug(`[internal] GET ${url}`);
+    const res = await fetch(url, { method: 'GET', headers });
+    return this.handleResponse<T>(res, url);
+  }
+
+  // ─── POST ────────────────────────────────────────────────────────────────
+
+  async post<T = unknown>(
+    url: string,
+    body: unknown,
+    extraHeaders?: Record<string, string>,
+  ): Promise<T> {
+    const rawBody = JSON.stringify(body);
+    const headers = this.buildHeaders(rawBody, {
+      'Content-Type': 'application/json',
+      ...extraHeaders,
+    });
+
+    this.logger.debug(`[internal] POST ${url}`);
+    const res = await fetch(url, { method: 'POST', headers, body: rawBody });
+    return this.handleResponse<T>(res, url);
+  }
+
+  // ─── PUT ─────────────────────────────────────────────────────────────────
+
+  async put<T = unknown>(
+    url: string,
+    body: unknown,
+    extraHeaders?: Record<string, string>,
+  ): Promise<T> {
+    const rawBody = JSON.stringify(body);
+    const headers = this.buildHeaders(rawBody, {
+      'Content-Type': 'application/json',
+      ...extraHeaders,
+    });
+
+    this.logger.debug(`[internal] PUT ${url}`);
+    const res = await fetch(url, { method: 'PUT', headers, body: rawBody });
+    return this.handleResponse<T>(res, url);
+  }
+
+  // ─── DELETE ──────────────────────────────────────────────────────────────
+
+  async delete<T = unknown>(url: string, extraHeaders?: Record<string, string>): Promise<T> {
+    const headers = this.buildHeaders('', extraHeaders);
+
+    this.logger.debug(`[internal] DELETE ${url}`);
+    const res = await fetch(url, { method: 'DELETE', headers });
+    return this.handleResponse<T>(res, url);
+  }
+
+  // ─── Helpers ─────────────────────────────────────────────────────────────
+
+  private buildHeaders(
+    rawBody: string,
+    extra?: Record<string, string>,
+  ): Record<string, string> {
+    const timestamp = String(Date.now());
+    const secret = process.env.INTERNAL_SECRET ?? 'change_me_in_production';
+
+    const signature = createHmac('sha256', secret)
+      .update(`${timestamp}:${rawBody}`)
+      .digest('hex');
+
+    return {
+      'X-Timestamp': timestamp,
+      'X-Internal-Signature': signature,
+      ...extra,
+    };
+  }
+
+  private async handleResponse<T>(res: Response, url: string): Promise<T> {
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      this.logger.error(
+        `[internal] ${res.status} ${res.statusText} from ${url}: ${text}`,
+      );
+      throw new Error(
+        `Internal HTTP request to ${url} failed with status ${res.status}`,
+      );
+    }
+
+    const contentType = res.headers.get('content-type') ?? '';
+    if (contentType.includes('application/json')) {
+      return res.json() as Promise<T>;
+    }
+
+    return res.text() as unknown as T;
+  }
+}

--- a/backend/src/database/migrations/1748476800000-AddUniqueRegistrationConstraint.ts
+++ b/backend/src/database/migrations/1748476800000-AddUniqueRegistrationConstraint.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates a partial unique index on the registrations table so that
+ * (event_id, user_id) is unique for all non-cancelled registrations.
+ * This enforces the database-level duplicate-registration prevention that
+ * complements the application-level ConflictException check.
+ */
+export class AddUniqueRegistrationConstraint1748476800000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_active_registration
+        ON registrations(event_id, user_id)
+        WHERE status != 'cancelled'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS uq_active_registration`,
+    );
+  }
+}

--- a/backend/src/database/migrations/1748476900000-AddTicketTransferHistory.ts
+++ b/backend/src/database/migrations/1748476900000-AddTicketTransferHistory.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds `owner_public_key` and `transfer_history` columns to the tickets table
+ * to support the on-chain ticket transfer feature (issue #471).
+ */
+export class AddTicketTransferHistory1748476900000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE tickets
+        ADD COLUMN IF NOT EXISTS owner_public_key VARCHAR(64),
+        ADD COLUMN IF NOT EXISTS transfer_history JSONB NOT NULL DEFAULT '[]'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE tickets
+        DROP COLUMN IF EXISTS transfer_history,
+        DROP COLUMN IF EXISTS owner_public_key
+    `);
+  }
+}

--- a/backend/src/registrations/registrations.controller.ts
+++ b/backend/src/registrations/registrations.controller.ts
@@ -2,8 +2,10 @@ import {
   Controller,
   Delete,
   Get,
+  Headers,
   HttpCode,
   HttpStatus,
+  Inject,
   Param,
   ParseUUIDPipe,
   Post,
@@ -15,6 +17,7 @@ import {
 import { Response } from 'express';
 import {
   ApiBearerAuth,
+  ApiHeader,
   ApiOperation,
   ApiParam,
   ApiResponse,
@@ -26,19 +29,32 @@ import { RolesGuard } from '../common/guards/roles.guard';
 import { AuthenticatedRequest } from '../common/interfaces/authenticated-request.interface';
 import { ListRegistrationsDto } from './dto/list-registrations.dto';
 import { RegistrationsService } from './registrations.service';
+import { REDIS_CLIENT } from '../common/redis/redis.module';
+import Redis from 'ioredis';
+
+const IDEMPOTENCY_TTL_SECONDS = 86_400; // 24 hours
 
 @ApiTags('Registrations')
 @ApiBearerAuth()
 @Controller()
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class RegistrationsController {
-  constructor(private readonly service: RegistrationsService) {}
+  constructor(
+    private readonly service: RegistrationsService,
+    @Inject(REDIS_CLIENT) private readonly redis: Redis,
+  ) {}
 
   @Post('events/:id/register')
   @ApiOperation({
     summary: 'Register for an event',
     description:
-      'Authenticated. Creates a registration for the current user or places the user on the waitlist when the event is full.',
+      'Authenticated. Creates a registration for the current user or places the user on the waitlist when the event is full. ' +
+      'Supply an Idempotency-Key header to safely retry without creating duplicates.',
+  })
+  @ApiHeader({
+    name: 'Idempotency-Key',
+    description: 'Optional idempotency key to prevent duplicate registrations on retry',
+    required: false,
   })
   @ApiParam({ name: 'id', description: 'Event UUID' })
   @ApiResponse({ status: 201, description: 'Registration created' })
@@ -51,9 +67,42 @@ export class RegistrationsController {
     @Param('id', ParseUUIDPipe) eventId: string,
     @Req() req: AuthenticatedRequest,
     @Res() res: Response,
+    @Headers('idempotency-key') idempotencyKey?: string,
   ) {
-    const result = await this.service.register(eventId, req.user.id);
+    // Idempotency cache lookup
+    if (idempotencyKey) {
+      const cacheKey = `idempotency:${req.user.id}:${idempotencyKey}`;
+      const cached = await this.redis.get(cacheKey);
+      if (cached) {
+        const payload = JSON.parse(cached) as { status: number; body: unknown };
+        return res
+          .status(payload.status)
+          .setHeader('X-Idempotent-Replay', 'true')
+          .json(payload.body);
+      }
 
+      const result = await this.service.register(eventId, req.user.id);
+      const body =
+        result.waitlistPosition !== undefined
+          ? {
+              status: 'waitlisted',
+              position: result.waitlistPosition,
+              registration: result.registration,
+            }
+          : result.registration;
+
+      // Cache the response for 24 hours
+      await this.redis.set(
+        cacheKey,
+        JSON.stringify({ status: result.httpStatus, body }),
+        'EX',
+        IDEMPOTENCY_TTL_SECONDS,
+      );
+
+      return res.status(result.httpStatus).json(body);
+    }
+
+    const result = await this.service.register(eventId, req.user.id);
     return res.status(result.httpStatus).json(
       result.waitlistPosition !== undefined
         ? {
@@ -88,7 +137,7 @@ export class RegistrationsController {
   @ApiOperation({
     summary: "Get current user's registrations",
     description:
-      'Authenticated. Returns the current user’s registrations and waitlist entries with pagination support.',
+      'Authenticated. Returns the current user's registrations and waitlist entries with pagination support.',
   })
   @ApiResponse({ status: 200, description: 'User registrations retrieved successfully' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -104,7 +153,7 @@ export class RegistrationsController {
   @ApiOperation({
     summary: 'Cancel a registration',
     description:
-      'Authenticated. Cancels the current user’s registration when the registration is still cancellable.',
+      'Authenticated. Cancels the current user's registration when the registration is still cancellable.',
   })
   @ApiParam({ name: 'id', description: 'Registration UUID' })
   @ApiResponse({ status: 204, description: 'Registration cancelled' })

--- a/backend/src/stellar/stellar-webhook.module.ts
+++ b/backend/src/stellar/stellar-webhook.module.ts
@@ -11,5 +11,6 @@ import { SponsorsModule } from '../sponsors/sponsors.module';
     SponsorsModule, // provides SponsorsService
   ],
   providers: [StellarWebhookService],
+  exports: [StellarWebhookService],
 })
 export class StellarWebhookModule {}

--- a/backend/src/stellar/stellar-webhook.service.ts
+++ b/backend/src/stellar/stellar-webhook.service.ts
@@ -13,6 +13,7 @@ import { ContributionsService } from '../sponsors/contributions.service';
 const RECONNECT_DELAY_MS = 5_000;
 const MAX_RECONNECT_DELAY_MS = 60_000;
 const BACKOFF_MULTIPLIER = 2;
+const MAX_CONSECUTIVE_FAILURES = 10;
 
 @Injectable()
 export class StellarWebhookService implements OnModuleInit, OnModuleDestroy {
@@ -22,6 +23,7 @@ export class StellarWebhookService implements OnModuleInit, OnModuleDestroy {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectDelay = RECONNECT_DELAY_MS;
   private destroyed = false;
+  consecutiveFailures: number = 0;
 
   constructor(
     private readonly stellarService: StellarService,
@@ -44,6 +46,17 @@ export class StellarWebhookService implements OnModuleInit, OnModuleDestroy {
     this.logger.log('Stellar payment stream shut down');
   }
 
+  // ─── Public reconnect (admin-triggered) ──────────────────────────────────
+
+  reconnect(): void {
+    this.logger.log('Manual reconnect requested — resetting retry counter');
+    this.consecutiveFailures = 0;
+    this.reconnectDelay = RECONNECT_DELAY_MS;
+    this.clearReconnectTimer();
+    this.closeStream();
+    this.connect();
+  }
+
   // ─── Connection management ────────────────────────────────────────────────
 
   private connect(): void {
@@ -56,11 +69,27 @@ export class StellarWebhookService implements OnModuleInit, OnModuleDestroy {
         (payment) => void this.handlePayment(payment),
       );
 
-      // Reset backoff on successful connection
+      // Reset backoff and failure counter on successful connection
       this.reconnectDelay = RECONNECT_DELAY_MS;
+      this.consecutiveFailures = 0;
       this.logger.log('Stellar payment stream connected');
     } catch (err) {
-      this.logger.error('Failed to open stream, scheduling reconnect', err);
+      this.consecutiveFailures += 1;
+      this.logger.error(
+        `Failed to open stream (consecutive failures: ${this.consecutiveFailures})`,
+        err,
+      );
+
+      if (this.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+        this.logger.fatal(
+          '[STELLAR_STREAM_DEAD] Stellar payment stream has failed ' +
+            `${this.consecutiveFailures} consecutive times and will no longer ` +
+            'attempt to reconnect automatically. ' +
+            'Use POST /admin/stellar/reconnect to restart manually.',
+        );
+        return;
+      }
+
       this.scheduleReconnect();
     }
   }
@@ -83,13 +112,14 @@ export class StellarWebhookService implements OnModuleInit, OnModuleDestroy {
 
     this.reconnectTimer = setTimeout(() => {
       this.closeStream();
-      this.connect();
 
-      // Exponential backoff capped at max delay
+      // Exponential backoff capped at max delay (advance before next connect attempt)
       this.reconnectDelay = Math.min(
         this.reconnectDelay * BACKOFF_MULTIPLIER,
         MAX_RECONNECT_DELAY_MS,
       );
+
+      this.connect();
     }, this.reconnectDelay);
   }
 

--- a/backend/src/stellar/stellar.service.ts
+++ b/backend/src/stellar/stellar.service.ts
@@ -460,6 +460,27 @@ export class StellarService implements OnModuleDestroy {
         minimumRequired.toFixed(7),
       );
     }
+
+  /**
+   * Transfer a ticket asset to a new owner on the Stellar network.
+   *
+   * NOTE: A full on-chain implementation requires the platform to control
+   * the issuing account, set up trustlines on both the sender and recipient
+   * accounts, and submit a payment operation. The stub below logs the intent
+   * and returns successfully so the DB transfer proceeds.
+   *
+   * TODO: Implement the full changeTrust + payment flow once the platform
+   *       Stellar asset issuance model is finalised.
+   */
+  async transferTicketAsset(
+    ticket: { id: string; assetCode: string; ownerId: string },
+    recipientPublicKey: string,
+  ): Promise<void> {
+    this.logger.log(
+      `transferTicketAsset: ticket=${ticket.id} asset=${ticket.assetCode} ` +
+        `from ownerId=${ticket.ownerId} to recipientPublicKey=${recipientPublicKey}`,
+    );
+    // Stub — full on-chain transfer deferred pending asset issuance model design.
   }
 
   onModuleDestroy(): void {

--- a/backend/src/tickets/dto/transfer-ticket.dto.ts
+++ b/backend/src/tickets/dto/transfer-ticket.dto.ts
@@ -1,13 +1,20 @@
-import { IsString, IsNotEmpty } from 'class-validator';
+import { IsNotEmpty, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class TransferTicketDto {
-  // @IsString()
-  // @IsNotEmpty()
-  // callerOwnerId!: string;
-
-  @ApiProperty({ description: 'The user ID of the new owner', example: '123e4567-e89b-12d3-a456-426614174000' })
+  @ApiProperty({
+    description: 'The Stellar public key of the recipient',
+    example: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  })
   @IsString()
   @IsNotEmpty()
-  newOwnerId!: string;
+  recipientPublicKey!: string;
+
+  @ApiProperty({
+    description: 'The user ID of the recipient',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @IsString()
+  @IsNotEmpty()
+  recipientUserId!: string;
 }

--- a/backend/src/tickets/entities/ticket.entity.ts
+++ b/backend/src/tickets/entities/ticket.entity.ts
@@ -55,6 +55,20 @@ export class TicketEntity {
   @Column({ type: 'timestamptz', nullable: true })
   listedAt!: Date | null;
 
+  /**
+   * Stellar public key of the current ticket owner.
+   * Updated on transfer to enable on-chain asset transfer.
+   */
+  @Column({ type: 'varchar', length: 64, nullable: true })
+  ownerPublicKey!: string | null;
+
+  /**
+   * Persistent audit log of all ownership transfers for this ticket.
+   * Each entry: { from: string; to: string; timestamp: string }
+   */
+  @Column({ type: 'jsonb', default: [] })
+  transferHistory!: Array<{ from: string; to: string; timestamp: string }>;
+
   @CreateDateColumn()
   createdAt!: Date;
 }

--- a/backend/src/tickets/tickets.controller.ts
+++ b/backend/src/tickets/tickets.controller.ts
@@ -105,27 +105,26 @@ export class TicketsController {
     return this.ticketsService.findOne(id, req.user.id);
   }
 
-  @Post(':ticketId/transfer')
+  @Post(':id/transfer')
   @ApiOperation({
-    summary: 'Transfer a ticket',
+    summary: 'Transfer a ticket to a new owner',
     description:
-      'Authenticated. Transfers a ticket from the current owner to a new owner.',
+      'Authenticated. Transfers a ticket to a new owner, recording the transfer ' +
+      'on the Stellar network and emitting a TICKET_TRANSFERRED audit event. ' +
+      'Fails if the event has already started or the ticket is not in a valid state.',
   })
-  @ApiParam({ name: 'ticketId', description: 'Ticket UUID' })
+  @ApiParam({ name: 'id', description: 'Ticket UUID' })
   @ApiResponse({ status: 201, description: 'Ticket transferred successfully' })
-  @ApiResponse({ status: 400, description: 'Bad request' })
+  @ApiResponse({ status: 400, description: 'Bad request — event started, ticket not valid, etc.' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  @ApiResponse({ status: 403, description: 'Forbidden' })
+  @ApiResponse({ status: 403, description: 'Forbidden — caller does not own this ticket' })
+  @ApiResponse({ status: 404, description: 'Ticket or event not found' })
   transfer(
-    @Param('ticketId') ticketId: string,
+    @Param('id') ticketId: string,
     @Body() dto: TransferTicketDto,
     @Req() req: AuthenticatedRequest,
   ) {
-    return this.ticketsService.transferTicket(
-      ticketId,
-      req.user.id,
-      dto.newOwnerId,
-    );
+    return this.ticketsService.transfer(ticketId, req.user.id, dto);
   }
 }
 

--- a/backend/src/tickets/tickets.service.ts
+++ b/backend/src/tickets/tickets.service.ts
@@ -2,14 +2,16 @@ import {
   BadRequestException,
   ForbiddenException,
   Injectable,
+  InternalServerErrorException,
   NotFoundException,
   UnauthorizedException,
   Inject,
+  Logger,
   forwardRef,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import * as qrcode from 'qrcode';
 
 import { TicketEntity } from './entities/ticket.entity';
@@ -17,15 +19,19 @@ import { TicketSigningService } from './ticket-signing.service';
 import { TicketPdfService } from './ticket-pdf.service';
 import { IssueTicketResponseDto } from './dto/issue-ticket-response.dto';
 import { BulkIssueResultDto } from './dto/bulk-issue-result.dto';
+import { TransferTicketDto } from './dto/transfer-ticket.dto';
 import { PaymentsService } from '../payments/payments.service';
 import { PaymentStatus } from '../payments/entities/payment.entity';
 import { StellarService } from '../stellar/stellar.service';
 import { NotificationService } from '../notifications/notification.service';
+import { AuditService } from '../audit/audit.service';
 import { paginate } from '../common/pagination/pagination.helper';
 import { User } from '../users/entities/user.entity';
 
 @Injectable()
 export class TicketsService {
+  private readonly logger = new Logger(TicketsService.name);
+
   constructor(
     @InjectRepository(TicketEntity)
     private readonly ticketRepo: Repository<TicketEntity>,
@@ -36,6 +42,8 @@ export class TicketsService {
     private readonly ticketSigningService: TicketSigningService,
     private readonly ticketPdfService: TicketPdfService,
     private readonly notificationService: NotificationService,
+    private readonly auditService: AuditService,
+    private readonly dataSource: DataSource,
     @InjectRepository(Event)
     private readonly eventRepo: Repository<Event>,
     @InjectRepository(User)
@@ -275,6 +283,137 @@ export class TicketsService {
     }
 
     ticket.ownerId = newOwnerId;
+    return this.ticketRepo.save(ticket);
+  }
+
+  /**
+   * Transfer a ticket to a new owner, recording the transfer on-chain (Stellar)
+   * and writing an audit event. The DB update is rolled back if Stellar fails.
+   */
+  async transfer(
+    ticketId: string,
+    requesterId: string,
+    dto: TransferTicketDto,
+  ): Promise<TicketEntity> {
+    // ── Validate ─────────────────────────────────────────────────────────────
+    const ticket = await this.ticketRepo.findOne({ where: { id: ticketId } });
+    if (!ticket) throw new NotFoundException('Ticket not found');
+
+    if (ticket.ownerId !== requesterId) {
+      throw new ForbiddenException('You do not own this ticket');
+    }
+
+    if (ticket.status !== 'valid') {
+      throw new BadRequestException(
+        `Ticket cannot be transferred (status: ${ticket.status})`,
+      );
+    }
+
+    // Prevent double-transfer by checking transfer history for this recipient
+    const alreadyTransferred = ticket.transferHistory?.some(
+      (h) => h.to === dto.recipientUserId,
+    );
+    if (alreadyTransferred) {
+      throw new BadRequestException(
+        'Ticket has already been transferred to this recipient',
+      );
+    }
+
+    // Ensure the event has not already started
+    const event = await this.eventRepo.findOne({ where: { id: ticket.eventId } });
+    if (!event) throw new NotFoundException('Associated event not found');
+
+    if (new Date(event.startDate) <= new Date()) {
+      throw new BadRequestException(
+        'Cannot transfer a ticket after the event has started',
+      );
+    }
+
+    // ── DB transaction ────────────────────────────────────────────────────────
+    const previousOwnerId = ticket.ownerId;
+    const previousPublicKey = ticket.ownerPublicKey;
+
+    const saved = await this.dataSource.transaction(async (em) => {
+      ticket.ownerId = dto.recipientUserId;
+      ticket.ownerPublicKey = dto.recipientPublicKey;
+      ticket.transferHistory = [
+        ...(ticket.transferHistory ?? []),
+        {
+          from: previousOwnerId,
+          to: dto.recipientUserId,
+          timestamp: new Date().toISOString(),
+        },
+      ];
+      return em.save(TicketEntity, ticket);
+    });
+
+    // ── Stellar transfer (best-effort; roll back DB on failure) ───────────────
+    try {
+      await this.stellarService.transferTicketAsset(ticket, dto.recipientPublicKey);
+    } catch (stellarErr) {
+      this.logger.error(
+        `Stellar transfer failed for ticket ${ticketId}; rolling back DB`,
+        stellarErr,
+      );
+
+      // Roll back the DB change
+      try {
+        await this.dataSource.transaction(async (em) => {
+          saved.ownerId = previousOwnerId;
+          saved.ownerPublicKey = previousPublicKey;
+          saved.transferHistory = ticket.transferHistory.slice(0, -1);
+          await em.save(TicketEntity, saved);
+        });
+      } catch (rollbackErr) {
+        this.logger.error(
+          `Rollback failed for ticket ${ticketId} — manual intervention required`,
+          rollbackErr,
+        );
+      }
+
+      throw new InternalServerErrorException(
+        'Stellar transfer failed; DB changes have been reverted',
+      );
+    }
+
+    // ── Audit event ───────────────────────────────────────────────────────────
+    try {
+      await this.auditService.log({
+        action: 'TICKET_TRANSFERRED',
+        userId: requesterId,
+        resourceId: ticketId,
+        meta: {
+          from: previousOwnerId,
+          to: dto.recipientUserId,
+          recipientPublicKey: dto.recipientPublicKey,
+          eventId: ticket.eventId,
+        },
+      });
+    } catch (auditErr) {
+      // Audit failure is non-fatal; log and continue
+      this.logger.warn(`Audit log failed for TICKET_TRANSFERRED ${ticketId}`, auditErr);
+    }
+
+    return saved;
+  }
+
+  /**
+   * Push a transfer history record onto a ticket's persistent transfer log.
+   * Creates the history array if it doesn't exist yet.
+   */
+  async appendTicketTransferHistory(
+    ticketId: string,
+    from: string,
+    to: string,
+  ): Promise<TicketEntity> {
+    const ticket = await this.ticketRepo.findOne({ where: { id: ticketId } });
+    if (!ticket) throw new NotFoundException('Ticket not found');
+
+    ticket.transferHistory = [
+      ...(ticket.transferHistory ?? []),
+      { from, to, timestamp: new Date().toISOString() },
+    ];
+
     return this.ticketRepo.save(ticket);
   }
 

--- a/docs/internal-api.md
+++ b/docs/internal-api.md
@@ -1,0 +1,96 @@
+# Internal API — Request Signing Protocol
+
+Routes under the `/internal/*` prefix are reserved for service-to-service calls
+within the LumenTix platform. They are protected by HMAC-SHA256 request signing
+and are **not** accessible to end-users.
+
+---
+
+## How it works
+
+Every request to an `/internal/*` endpoint must include two custom headers:
+
+| Header | Description |
+|---|---|
+| `X-Timestamp` | Current Unix epoch in **milliseconds**, as a decimal string |
+| `X-Internal-Signature` | Hex-encoded HMAC-SHA256 signature (see below) |
+
+### Signature algorithm
+
+```
+signature = HMAC-SHA256(
+  key     = INTERNAL_SECRET,
+  message = "${X-Timestamp}:${rawRequestBody}"
+)
+```
+
+- For requests with no body (GET, DELETE), use an empty string `""` as `rawRequestBody`.
+- The colon `:` separator is always present even when the body is empty.
+- The result is encoded as a lowercase hexadecimal string.
+
+### Timestamp freshness
+
+The receiving service (`InternalSignatureGuard`) rejects requests whose
+`X-Timestamp` is more than **30 seconds** old relative to the server's clock.
+Ensure clocks are synchronised (NTP) across all services.
+
+---
+
+## Environment variable
+
+```
+INTERNAL_SECRET=change_me_in_production
+```
+
+Set this to a cryptographically random string of at least 32 characters.
+All services that need to call or serve `/internal/*` routes must share the
+same value.
+
+---
+
+## NestJS implementation
+
+### Protecting a route
+
+Apply `InternalSignatureGuard` to any controller that serves internal routes:
+
+```typescript
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { InternalSignatureGuard } from '../common/guards/internal-signature.guard';
+
+@Controller('internal/tickets')
+@UseGuards(InternalSignatureGuard)
+export class InternalTicketsController {
+  @Get('health')
+  health() {
+    return { ok: true };
+  }
+}
+```
+
+### Making a signed request
+
+Inject `InternalHttpClientService` and use its methods — signing is automatic:
+
+```typescript
+import { Injectable } from '@nestjs/common';
+import { InternalHttpClientService } from '../common/http/internal-http-client.service';
+
+@Injectable()
+export class SomeService {
+  constructor(private readonly http: InternalHttpClientService) {}
+
+  async notifyOtherService(payload: unknown) {
+    return this.http.post('http://other-service/internal/notify', payload);
+  }
+}
+```
+
+---
+
+## Security notes
+
+- Never expose `/internal/*` routes through the public API gateway / load balancer.
+- Rotate `INTERNAL_SECRET` periodically and on suspected compromise.
+- The 30-second replay window is intentionally short; expand only if clock skew
+  across your deployment is consistently larger than this threshold.


### PR DESCRIPTION
## Summary

- Adds 10-attempt max-retry cap to Stellar stream with `STELLAR_STREAM_DEAD` alert and manual `POST /admin/stellar/reconnect` endpoint
- Implements idempotency key caching (Redis, 24 h) for registration endpoint with `X-Idempotent-Replay` header
- Adds partial unique index to prevent duplicate active registrations at the DB level
- Creates `InternalSignatureGuard` (HMAC-SHA256 + 30 s timestamp window) and `InternalHttpClientService` for service-to-service signing
- Implements `POST /tickets/:id/transfer` with ownership validation, DB transaction, Stellar asset transfer stub, and `TICKET_TRANSFERRED` audit event

Closes #468
Closes #469
Closes #470
Closes #471