### PR TITLE
feat: Add merchandise integration and NFT collectibles

### DIFF
--- a/contract/src/error.rs
+++ b/contract/src/error.rs
@@ -219,4 +219,26 @@ pub enum LumentixError {
     CrossChainTransferExpired = 88,
     /// Bridge is currently paused
     BridgePaused = 89,
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Merchandise & NFT Collectible errors (90–99)
+    // ═══════════════════════════════════════════════════════════════════════
+    /// Merchandise item not found
+    MerchandiseNotFound = 90,
+    /// Merchandise item is sold out
+    MerchandiseSoldOut = 91,
+    /// Merchandise item is not active
+    MerchandiseNotActive = 92,
+    /// NFT collectible not found
+    NftNotFound = 93,
+    /// NFT collectible is not transferable
+    NftNotTransferable = 94,
+    /// Collectible inventory not configured for event
+    CollectibleInventoryNotFound = 95,
+    /// Collectible max supply reached
+    CollectibleMaxSupplyReached = 96,
+    /// Rarity tier supply exhausted
+    RarityTierExhausted = 97,
+    /// Caller is not the NFT owner
+    NftNotOwned = 98,
 }

--- a/contract/src/events/mod.rs
+++ b/contract/src/events/mod.rs
@@ -1005,3 +1005,107 @@ impl CrossChainTransferCompleted {
         );
     }
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// MERCHANDISE & NFT COLLECTIBLE EVENTS
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Emitted when event merchandise is created
+pub struct MerchandiseCreated;
+
+impl MerchandiseCreated {
+    pub fn emit(
+        env: &Env,
+        merchandise_id: u64,
+        event_id: u64,
+        organizer: Address,
+        name: String,
+        price: i128,
+        total_supply: u32,
+    ) {
+        env.events().publish(
+            (symbol_short!("merccreate"),),
+            (
+                merchandise_id,
+                event_id,
+                organizer,
+                name,
+                price,
+                total_supply,
+            ),
+        );
+    }
+}
+
+/// Emitted when a merchandise item is purchased
+pub struct MerchandisePurchased;
+
+impl MerchandisePurchased {
+    pub fn emit(
+        env: &Env,
+        merchandise_id: u64,
+        event_id: u64,
+        buyer: Address,
+        price: i128,
+        remaining_supply: u32,
+    ) {
+        env.events().publish(
+            (symbol_short!("mercbuy"),),
+            (
+                merchandise_id,
+                event_id,
+                buyer,
+                price,
+                remaining_supply,
+            ),
+        );
+    }
+}
+
+/// Emitted when a commemorative NFT is minted
+pub struct NftMinted;
+
+impl NftMinted {
+    pub fn emit(
+        env: &Env,
+        nft_id: u64,
+        event_id: u64,
+        owner: Address,
+        rarity: crate::types::RarityTier,
+        minted_at: u64,
+    ) {
+        env.events().publish(
+            (symbol_short!("nftmint"),),
+            (nft_id, event_id, owner, rarity, minted_at),
+        );
+    }
+}
+
+/// Emitted when an NFT collectible is traded/transferred
+pub struct NftTraded;
+
+impl NftTraded {
+    pub fn emit(env: &Env, nft_id: u64, event_id: u64, from: Address, to: Address) {
+        env.events().publish(
+            (symbol_short!("nfttrade"),),
+            (nft_id, event_id, from, to),
+        );
+    }
+}
+
+/// Emitted when collectible inventory is configured or updated
+pub struct CollectibleInventoryUpdated;
+
+impl CollectibleInventoryUpdated {
+    pub fn emit(
+        env: &Env,
+        event_id: u64,
+        max_supply: u32,
+        total_minted: u32,
+    ) {
+        env.events().publish(
+            (symbol_short!("colinvup"),),
+            (event_id, max_supply, total_minted),
+        );
+    }
+}

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -247,23 +247,28 @@ pub mod vip_accessibility_currency_seat_tests;
 #[cfg(test)]
 mod upgrade_carbon_identity_crosschain_tests;
 
+#[cfg(test)]
+mod merchandise_nft_tests;
+
 pub use contract::TicketContract;
 pub use error::LumentixError;
 pub use events::{
     AttendanceVerificationFailed, AttendanceVerified, BlockchainIdentityVerified,
-    BridgeTransactionValidated, CarbonFootprintCalculated, CarbonOffsetPurchased, CheckInEvent,
-    CrossChainTransferCompleted, CrossChainTransferInitiated, EnvironmentalImpactUpdated,
-    EventCancelled, EventMetadataUpdated, EventSalesPaused, EventSalesResumed,
-    IdentityCredentialIssued, IdentityCredentialRevoked, InsuranceClaimProcessed,
-    InsurancePoolUpdated, InsurancePurchased, ReputationUpdated, ReviewSubmitted, TransferEvent,
+    BridgeTransactionValidated, CarbonFootprintCalculated, CarbonOffsetPurchased,
+    CheckInEvent, CollectibleInventoryUpdated, CrossChainTransferCompleted,
+    CrossChainTransferInitiated, EnvironmentalImpactUpdated, EventCancelled, EventMetadataUpdated,
+    EventSalesPaused, EventSalesResumed, IdentityCredentialIssued, IdentityCredentialRevoked,
+    InsuranceClaimProcessed, InsurancePoolUpdated, InsurancePurchased, MerchandiseCreated,
+    MerchandisePurchased, NftMinted, NftTraded, ReputationUpdated, ReviewSubmitted, TransferEvent,
     UpgradeExecuted, UpgradeGovernanceConfigUpdated, UpgradeProposed, UpgradeVoteCast,
 };
 pub use lumentix_contract::LumentixContract;
 pub use models::{DataKey, EscrowConfig, EventAuth, Ticket as TicketModel, ValidatorKey};
 pub use types::{
     BridgeTransaction, CancellationReason, CarbonFootprint, CarbonOffsetPurchase,
-    CrossChainTransfer, CrossChainTransferStatus, EnvironmentalImpact, Event, EventReview,
-    EventStatus, IdentityCredential, IdentityProof, IdentityProvider, InsurancePolicy,
-    InsurancePool, OrganizerReputation, Ticket as LumentixTicket, UpgradeGovernanceConfig,
-    UpgradeProposal, UpgradeState, UpgradeVote,
+    CollectibleInventory, CrossChainTransfer, CrossChainTransferStatus, EnvironmentalImpact,
+    Event, EventMerchandise, EventReview, EventStatus, IdentityCredential, IdentityProof,
+    IdentityProvider, InsurancePolicy, InsurancePool, NftCollectible, OrganizerReputation,
+    RarityTier, Ticket as LumentixTicket, UpgradeGovernanceConfig, UpgradeProposal, UpgradeState,
+    UpgradeVote,
 };

--- a/contract/src/lumentix_contract.rs
+++ b/contract/src/lumentix_contract.rs
@@ -5,26 +5,28 @@ use crate::events::{
     AccessibilityBooked, AccessibilityInventoryUpdated, AdminChanged, AttendanceVerificationFailed,
     AttendanceVerified, BatchTicketsPurchased, BatchTicketsTransferred, BatchTicketsUsed,
     BlockchainIdentityVerified, BridgeTransactionValidated, CarbonFootprintCalculated,
-    CarbonOffsetPurchased, CrossChainTransferCompleted, CrossChainTransferInitiated,
-    EnvironmentalImpactUpdated, EscrowReleased, EventCancelled, EventCapacityChanged,
-    EventCompleted, EventCreated, EventCurrencySet, EventMetadataUpdated, EventSalesPaused,
-    EventSalesResumed, EventStatusChanged, EventTimeExtended, EventUpdated, FundsDeposited,
-    FundsWithdrawn, GenericEventStateTransition, IdentityCredentialIssued,
+    CarbonOffsetPurchased, CollectibleInventoryUpdated, CrossChainTransferCompleted,
+    CrossChainTransferInitiated, EnvironmentalImpactUpdated, EscrowReleased, EventCancelled,
+    EventCapacityChanged, EventCompleted, EventCreated, EventCurrencySet, EventMetadataUpdated,
+    EventSalesPaused, EventSalesResumed, EventStatusChanged, EventTimeExtended, EventUpdated,
+    FundsDeposited, FundsWithdrawn, GenericEventStateTransition, IdentityCredentialIssued,
     IdentityCredentialRevoked, InsuranceClaimProcessed, InsurancePoolUpdated, InsurancePurchased,
-    OraclePriceUpdated, PlatformFeeRecipientUpdated, PlatformFeeUpdated, PlatformFeesWithdrawn,
-    ProtocolFeeQueried, ReputationUpdated, ReviewSubmitted, SeatHoldReleased, SeatSelected,
-    TicketPurchased, TicketRefunded, TicketRevoked, TicketTransferred, TicketUsed, UpgradeExecuted,
+    MerchandiseCreated, MerchandisePurchased, NftMinted, NftTraded, OraclePriceUpdated,
+    PlatformFeeRecipientUpdated, PlatformFeeUpdated, PlatformFeesWithdrawn, ProtocolFeeQueried,
+    ReputationUpdated, ReviewSubmitted, SeatHoldReleased, SeatSelected, TicketPurchased,
+    TicketRefunded, TicketRevoked, TicketTransferred, TicketUsed, UpgradeExecuted,
     UpgradeGovernanceConfigUpdated, UpgradeProposed, UpgradeVoteCast, VenueLayoutCreated,
     VipTicketAssigned, VipTierCreated, WaitlistAvailabilityNotified, WaitlistJoined,
 };
 use crate::storage;
 use crate::types::{
     AccessibilityBooking, AccessibilityInventory, BridgeTransaction, CancellationReason,
-    CarbonFootprint, CarbonOffsetPurchase, CrossChainTransfer, CrossChainTransferStatus,
-    CurrencyConfig, EnvironmentalImpact, Event, EventReview, EventStatus, IdentityCredential,
-    IdentityProof, IdentityProvider, InsurancePolicy, OrganizerReputation, Seat, Ticket,
-    TicketTransferRecord, UpgradeGovernanceConfig, UpgradeProposal, UpgradeState, UpgradeVote,
-    VenueLayout, VenueSection, VipTier, WaitlistOffer, PERSISTENT_LIFETIME,
+    CarbonFootprint, CarbonOffsetPurchase, CollectibleInventory, CrossChainTransfer,
+    CrossChainTransferStatus, CurrencyConfig, EnvironmentalImpact, Event, EventMerchandise,
+    EventReview, EventStatus, IdentityCredential, IdentityProof, IdentityProvider, InsurancePolicy,
+    NftCollectible, OrganizerReputation, RarityTier, Seat, Ticket, TicketTransferRecord,
+    UpgradeGovernanceConfig, UpgradeProposal, UpgradeState, UpgradeVote, VenueLayout, VenueSection,
+    VipTier, WaitlistOffer, PERSISTENT_LIFETIME,
 };
 use crate::validation;
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Map, String, Vec};
@@ -4127,5 +4129,330 @@ impl LumentixContract {
     /// Check if a chain is supported
     pub fn is_chain_supported(env: Env, chain: String) -> bool {
         storage::is_chain_supported(&env, &chain)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // MERCHANDISE & NFT COLLECTIBLES
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// Create event merchandise for sale.
+    /// Only the event organizer can create merchandise.
+    /// The event must exist and not be cancelled.
+    /// Emits MerchandiseCreated event.
+    pub fn create_event_merchandise(
+        env: Env,
+        organizer: Address,
+        event_id: u64,
+        name: String,
+        description: String,
+        price: i128,
+        total_supply: u32,
+    ) -> Result<u64, LumentixError> {
+        organizer.require_auth();
+
+        let event = storage::get_event(&env, event_id)?;
+
+        if event.organizer != organizer {
+            return Err(LumentixError::Unauthorized);
+        }
+
+        if event.status == EventStatus::Cancelled {
+            return Err(LumentixError::InvalidStatusTransition);
+        }
+
+        validation::validate_string_not_empty(&name)?;
+        validation::validate_string_not_empty(&description)?;
+        validation::validate_positive_amount(price)?;
+        validation::validate_positive_capacity(total_supply)?;
+
+        let merchandise_id = storage::get_next_merchandise_id(&env);
+        storage::increment_merchandise_id(&env);
+
+        let item = EventMerchandise {
+            id: merchandise_id,
+            event_id,
+            name: name.clone(),
+            description,
+            price,
+            total_supply,
+            remaining_supply: total_supply,
+            organizer: organizer.clone(),
+            active: true,
+        };
+
+        storage::set_merchandise(&env, merchandise_id, &item);
+
+        MerchandiseCreated::emit(
+            &env,
+            merchandise_id,
+            event_id,
+            organizer,
+            name,
+            price,
+            total_supply,
+        );
+
+        Ok(merchandise_id)
+    }
+
+    /// Purchase a merchandise item for an event.
+    /// Buyer must pay the listed price.
+    /// Decrements remaining_supply on success.
+    /// Emits MerchandisePurchased event.
+    pub fn purchase_merchandise(
+        env: Env,
+        buyer: Address,
+        merchandise_id: u64,
+    ) -> Result<(), LumentixError> {
+        buyer.require_auth();
+
+        let mut item = storage::get_merchandise(&env, merchandise_id)?;
+
+        if !item.active {
+            return Err(LumentixError::MerchandiseNotActive);
+        }
+
+        if item.remaining_supply == 0 {
+            return Err(LumentixError::MerchandiseSoldOut);
+        }
+
+        let event = storage::get_event(&env, item.event_id)?;
+        if event.status == EventStatus::Cancelled {
+            return Err(LumentixError::InvalidStatusTransition);
+        }
+
+        // Process token transfer if token is set
+        if let Ok(token_address) = storage::get_token_result(&env) {
+            let token_client = soroban_sdk::token::Client::new(&env, &token_address);
+            token_client.transfer(&buyer, &env.current_contract_address(), &item.price);
+        }
+
+        // Add proceeds to event escrow
+        storage::add_escrow(&env, item.event_id, item.price);
+
+        item.remaining_supply -= 1;
+        storage::set_merchandise(&env, merchandise_id, &item);
+
+        MerchandisePurchased::emit(
+            &env,
+            merchandise_id,
+            item.event_id,
+            buyer,
+            item.price,
+            item.remaining_supply,
+        );
+
+        Ok(())
+    }
+
+    /// Get merchandise item by ID.
+    pub fn get_merchandise(
+        env: Env,
+        merchandise_id: u64,
+    ) -> Result<EventMerchandise, LumentixError> {
+        storage::get_merchandise(&env, merchandise_id)
+    }
+
+    /// Mint a commemorative NFT collectible for a special event.
+    /// Only the event organizer can mint NFTs.
+    /// Requires a collectible inventory to be configured first via manage_collectible_inventory.
+    /// Rarity tiers have limited supply tracked in the inventory.
+    /// Emits NftMinted event.
+    pub fn mint_commemorative_nft(
+        env: Env,
+        organizer: Address,
+        event_id: u64,
+        recipient: Address,
+        name: String,
+        description: String,
+        rarity: RarityTier,
+        transferable: bool,
+        metadata_hash: soroban_sdk::BytesN<32>,
+    ) -> Result<u64, LumentixError> {
+        organizer.require_auth();
+
+        let event = storage::get_event(&env, event_id)?;
+
+        if event.organizer != organizer {
+            return Err(LumentixError::Unauthorized);
+        }
+
+        if event.status == EventStatus::Cancelled {
+            return Err(LumentixError::InvalidStatusTransition);
+        }
+
+        validation::validate_string_not_empty(&name)?;
+        validation::validate_string_not_empty(&description)?;
+
+        // Collectible inventory must be configured
+        let mut inv = storage::get_collectible_inventory(&env, event_id)?;
+
+        if inv.total_minted >= inv.max_supply {
+            return Err(LumentixError::CollectibleMaxSupplyReached);
+        }
+
+        // Enforce per-rarity supply caps derived from max_supply:
+        // Legendary ≤ 1% of max_supply (min 1), Epic ≤ 5%, Rare ≤ 15%,
+        // Uncommon ≤ 30%, Common = remainder.
+        let max_supply = inv.max_supply;
+        let legendary_cap = (max_supply / 100).max(1);
+        let epic_cap = (max_supply * 5 / 100).max(1);
+        let rare_cap = (max_supply * 15 / 100).max(1);
+        let uncommon_cap = (max_supply * 30 / 100).max(1);
+
+        match &rarity {
+            RarityTier::Legendary => {
+                if inv.legendary_minted >= legendary_cap {
+                    return Err(LumentixError::RarityTierExhausted);
+                }
+                inv.legendary_minted += 1;
+            }
+            RarityTier::Epic => {
+                if inv.epic_minted >= epic_cap {
+                    return Err(LumentixError::RarityTierExhausted);
+                }
+                inv.epic_minted += 1;
+            }
+            RarityTier::Rare => {
+                if inv.rare_minted >= rare_cap {
+                    return Err(LumentixError::RarityTierExhausted);
+                }
+                inv.rare_minted += 1;
+            }
+            RarityTier::Uncommon => {
+                if inv.uncommon_minted >= uncommon_cap {
+                    return Err(LumentixError::RarityTierExhausted);
+                }
+                inv.uncommon_minted += 1;
+            }
+            RarityTier::Common => {
+                inv.common_minted += 1;
+            }
+        }
+
+        inv.total_minted += 1;
+        storage::set_collectible_inventory(&env, event_id, &inv);
+
+        let nft_id = storage::get_next_nft_id(&env);
+        storage::increment_nft_id(&env);
+
+        let minted_at = env.ledger().timestamp();
+
+        let nft = NftCollectible {
+            id: nft_id,
+            event_id,
+            name,
+            description,
+            rarity: rarity.clone(),
+            owner: recipient.clone(),
+            minted_at,
+            transferable,
+            metadata_hash,
+        };
+
+        storage::set_nft(&env, nft_id, &nft);
+
+        NftMinted::emit(&env, nft_id, event_id, recipient, rarity, minted_at);
+
+        CollectibleInventoryUpdated::emit(&env, event_id, inv.max_supply, inv.total_minted);
+
+        Ok(nft_id)
+    }
+
+    /// Trade (transfer) an NFT collectible to another address.
+    /// Only the current owner can trade their NFT.
+    /// The NFT must have transferable = true.
+    /// Emits NftTraded event.
+    pub fn trade_nft(
+        env: Env,
+        from: Address,
+        to: Address,
+        nft_id: u64,
+    ) -> Result<(), LumentixError> {
+        from.require_auth();
+
+        let mut nft = storage::get_nft(&env, nft_id)?;
+
+        if nft.owner != from {
+            return Err(LumentixError::NftNotOwned);
+        }
+
+        if !nft.transferable {
+            return Err(LumentixError::NftNotTransferable);
+        }
+
+        let event_id = nft.event_id;
+        nft.owner = to.clone();
+        storage::set_nft(&env, nft_id, &nft);
+
+        NftTraded::emit(&env, nft_id, event_id, from, to);
+
+        Ok(())
+    }
+
+    /// Get an NFT collectible by ID.
+    pub fn get_nft(env: Env, nft_id: u64) -> Result<NftCollectible, LumentixError> {
+        storage::get_nft(&env, nft_id)
+    }
+
+    /// Configure or update the collectible inventory for an event.
+    /// Only the event organizer can call this.
+    /// Sets the maximum supply of NFT collectibles for the event.
+    /// Can be called before minting begins to initialise, or to increase max_supply.
+    /// Emits CollectibleInventoryUpdated event.
+    pub fn manage_collectible_inventory(
+        env: Env,
+        organizer: Address,
+        event_id: u64,
+        max_supply: u32,
+    ) -> Result<(), LumentixError> {
+        organizer.require_auth();
+
+        let event = storage::get_event(&env, event_id)?;
+
+        if event.organizer != organizer {
+            return Err(LumentixError::Unauthorized);
+        }
+
+        if event.status == EventStatus::Cancelled {
+            return Err(LumentixError::InvalidStatusTransition);
+        }
+
+        validation::validate_positive_capacity(max_supply)?;
+
+        if storage::has_collectible_inventory(&env, event_id) {
+            // Update existing inventory — max_supply cannot be reduced below total_minted
+            let mut inv = storage::get_collectible_inventory(&env, event_id)?;
+            if max_supply < inv.total_minted {
+                return Err(LumentixError::CapacityExceeded);
+            }
+            inv.max_supply = max_supply;
+            storage::set_collectible_inventory(&env, event_id, &inv);
+            CollectibleInventoryUpdated::emit(&env, event_id, max_supply, inv.total_minted);
+        } else {
+            // Create new inventory
+            let inv = CollectibleInventory {
+                event_id,
+                total_minted: 0,
+                max_supply,
+                common_minted: 0,
+                uncommon_minted: 0,
+                rare_minted: 0,
+                epic_minted: 0,
+                legendary_minted: 0,
+            };
+            storage::set_collectible_inventory(&env, event_id, &inv);
+            CollectibleInventoryUpdated::emit(&env, event_id, max_supply, 0);
+        }
+
+        Ok(())
+    }
+
+    /// Get the collectible inventory for an event.
+    pub fn get_collectible_inventory(
+        env: Env,
+        event_id: u64,
+    ) -> Result<CollectibleInventory, LumentixError> {
+        storage::get_collectible_inventory(&env, event_id)
     }
 }

--- a/contract/src/merchandise_nft_tests.rs
+++ b/contract/src/merchandise_nft_tests.rs
@@ -1,0 +1,470 @@
+#![allow(warnings)]
+
+use crate::error::LumentixError;
+use crate::lumentix_contract::{LumentixContract, LumentixContractClient};
+use crate::types::{EventStatus, RarityTier};
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String};
+
+fn setup(env: &Env) -> (Address, LumentixContractClient<'_>) {
+    let contract_id = env.register(LumentixContract, ());
+    let client = LumentixContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+    (admin, client)
+}
+
+fn create_and_publish_event(
+    env: &Env,
+    client: &LumentixContractClient,
+    organizer: &Address,
+) -> u64 {
+    let event_id = client.create_event(
+        organizer,
+        &String::from_str(env, "Test Event"),
+        &String::from_str(env, "A great event"),
+        &String::from_str(env, "Venue"),
+        &1000u64,
+        &9000u64,
+        &100i128,
+        &100u32,
+    );
+    client.update_event_status(&event_id, &EventStatus::Published, organizer);
+    event_id
+}
+
+// ─── Merchandise Tests ────────────────────────────────────────────────────────
+
+#[test]
+fn test_create_event_merchandise_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let organizer = Address::generate(&env);
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    let merch_id = client.create_event_merchandise(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "T-Shirt"),
+        &String::from_str(&env, "Official event T-Shirt"),
+        &50i128,
+        &200u32,
+    );
+
+    assert_eq!(merch_id, 1u64);
+
+    let item = client.get_merchandise(&merch_id);
+    assert_eq!(item.event_id, event_id);
+    assert_eq!(item.price, 50i128);
+    assert_eq!(item.total_supply, 200u32);
+    assert_eq!(item.remaining_supply, 200u32);
+    assert!(item.active);
+}
+
+#[test]
+fn test_create_merchandise_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let organizer = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    let result = client.try_create_event_merchandise(
+        &attacker,
+        &event_id,
+        &String::from_str(&env, "Fake Merch"),
+        &String::from_str(&env, "desc"),
+        &10i128,
+        &10u32,
+    );
+    assert_eq!(result, Err(Ok(LumentixError::Unauthorized)));
+}
+
+#[test]
+fn test_create_merchandise_cancelled_event_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let organizer = Address::generate(&env);
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+    client.cancel_event(&organizer, &event_id);
+
+    let result = client.try_create_event_merchandise(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "Merch"),
+        &String::from_str(&env, "desc"),
+        &10i128,
+        &10u32,
+    );
+    assert_eq!(result, Err(Ok(LumentixError::InvalidStatusTransition)));
+}
+
+#[test]
+fn test_purchase_merchandise_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let organizer = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    let merch_id = client.create_event_merchandise(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "Cap"),
+        &String::from_str(&env, "Event cap"),
+        &25i128,
+        &50u32,
+    );
+
+    client.purchase_merchandise(&buyer, &merch_id);
+
+    let item = client.get_merchandise(&merch_id);
+    assert_eq!(item.remaining_supply, 49u32);
+}
+
+#[test]
+fn test_purchase_merchandise_sold_out() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let organizer = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    let merch_id = client.create_event_merchandise(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "Poster"),
+        &String::from_str(&env, "Limited poster"),
+        &10i128,
+        &1u32,
+    );
+
+    client.purchase_merchandise(&buyer, &merch_id);
+
+    let result = client.try_purchase_merchandise(&buyer, &merch_id);
+    assert_eq!(result, Err(Ok(LumentixError::MerchandiseSoldOut)));
+}
+
+// ─── Collectible Inventory Tests ──────────────────────────────────────────────
+
+#[test]
+fn test_manage_collectible_inventory_create() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let organizer = Address::generate(&env);
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    client.manage_collectible_inventory(&organizer, &event_id, &100u32);
+
+    let inv = client.get_collectible_inventory(&event_id);
+    assert_eq!(inv.max_supply, 100u32);
+    assert_eq!(inv.total_minted, 0u32);
+}
+
+#[test]
+fn test_manage_collectible_inventory_update() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let organizer = Address::generate(&env);
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    client.manage_collectible_inventory(&organizer, &event_id, &50u32);
+    // Increase supply
+    client.manage_collectible_inventory(&organizer, &event_id, &200u32);
+
+    let inv = client.get_collectible_inventory(&event_id);
+    assert_eq!(inv.max_supply, 200u32);
+}
+
+#[test]
+fn test_manage_collectible_inventory_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let organizer = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    let result =
+        client.try_manage_collectible_inventory(&attacker, &event_id, &100u32);
+    assert_eq!(result, Err(Ok(LumentixError::Unauthorized)));
+}
+
+// ─── NFT Minting Tests ────────────────────────────────────────────────────────
+
+#[test]
+fn test_mint_commemorative_nft_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let organizer = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    client.manage_collectible_inventory(&organizer, &event_id, &100u32);
+
+    let metadata_hash = BytesN::from_array(&env, &[1u8; 32]);
+
+    let nft_id = client.mint_commemorative_nft(
+        &organizer,
+        &event_id,
+        &recipient,
+        &String::from_str(&env, "Gold Pass"),
+        &String::from_str(&env, "Exclusive commemorative NFT"),
+        &RarityTier::Rare,
+        &true,
+        &metadata_hash,
+    );
+
+    assert_eq!(nft_id, 1u64);
+
+    let nft = client.get_nft(&nft_id);
+    assert_eq!(nft.event_id, event_id);
+    assert_eq!(nft.owner, recipient);
+    assert_eq!(nft.rarity, RarityTier::Rare);
+    assert!(nft.transferable);
+}
+
+#[test]
+fn test_mint_nft_without_inventory_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let organizer = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    let metadata_hash = BytesN::from_array(&env, &[2u8; 32]);
+
+    let result = client.try_mint_commemorative_nft(
+        &organizer,
+        &event_id,
+        &recipient,
+        &String::from_str(&env, "NFT"),
+        &String::from_str(&env, "desc"),
+        &RarityTier::Common,
+        &true,
+        &metadata_hash,
+    );
+    assert_eq!(result, Err(Ok(LumentixError::CollectibleInventoryNotFound)));
+}
+
+#[test]
+fn test_mint_nft_max_supply_reached() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let organizer = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    // Set max supply to 1
+    client.manage_collectible_inventory(&organizer, &event_id, &1u32);
+
+    let metadata_hash = BytesN::from_array(&env, &[3u8; 32]);
+
+    client.mint_commemorative_nft(
+        &organizer,
+        &event_id,
+        &recipient,
+        &String::from_str(&env, "NFT 1"),
+        &String::from_str(&env, "desc"),
+        &RarityTier::Common,
+        &true,
+        &metadata_hash,
+    );
+
+    let result = client.try_mint_commemorative_nft(
+        &organizer,
+        &event_id,
+        &recipient,
+        &String::from_str(&env, "NFT 2"),
+        &String::from_str(&env, "desc"),
+        &RarityTier::Common,
+        &true,
+        &metadata_hash,
+    );
+    assert_eq!(result, Err(Ok(LumentixError::CollectibleMaxSupplyReached)));
+}
+
+#[test]
+fn test_mint_legendary_rarity_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let organizer = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    // max_supply = 100, legendary cap = max(100/100, 1) = 1
+    client.manage_collectible_inventory(&organizer, &event_id, &100u32);
+
+    let metadata_hash = BytesN::from_array(&env, &[4u8; 32]);
+
+    // First legendary should succeed
+    client.mint_commemorative_nft(
+        &organizer,
+        &event_id,
+        &recipient,
+        &String::from_str(&env, "Legendary 1"),
+        &String::from_str(&env, "desc"),
+        &RarityTier::Legendary,
+        &false,
+        &metadata_hash,
+    );
+
+    // Second legendary should fail (cap = 1)
+    let result = client.try_mint_commemorative_nft(
+        &organizer,
+        &event_id,
+        &recipient,
+        &String::from_str(&env, "Legendary 2"),
+        &String::from_str(&env, "desc"),
+        &RarityTier::Legendary,
+        &false,
+        &metadata_hash,
+    );
+    assert_eq!(result, Err(Ok(LumentixError::RarityTierExhausted)));
+}
+
+// ─── NFT Trading Tests ────────────────────────────────────────────────────────
+
+#[test]
+fn test_trade_nft_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let organizer = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    client.manage_collectible_inventory(&organizer, &event_id, &50u32);
+
+    let metadata_hash = BytesN::from_array(&env, &[5u8; 32]);
+
+    let nft_id = client.mint_commemorative_nft(
+        &organizer,
+        &event_id,
+        &owner,
+        &String::from_str(&env, "Tradeable NFT"),
+        &String::from_str(&env, "desc"),
+        &RarityTier::Uncommon,
+        &true,
+        &metadata_hash,
+    );
+
+    client.trade_nft(&owner, &buyer, &nft_id);
+
+    let nft = client.get_nft(&nft_id);
+    assert_eq!(nft.owner, buyer);
+}
+
+#[test]
+fn test_trade_nft_not_transferable() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let organizer = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    client.manage_collectible_inventory(&organizer, &event_id, &50u32);
+
+    let metadata_hash = BytesN::from_array(&env, &[6u8; 32]);
+
+    let nft_id = client.mint_commemorative_nft(
+        &organizer,
+        &event_id,
+        &owner,
+        &String::from_str(&env, "Soulbound NFT"),
+        &String::from_str(&env, "desc"),
+        &RarityTier::Epic,
+        &false, // not transferable
+        &metadata_hash,
+    );
+
+    let result = client.try_trade_nft(&owner, &buyer, &nft_id);
+    assert_eq!(result, Err(Ok(LumentixError::NftNotTransferable)));
+}
+
+#[test]
+fn test_trade_nft_not_owner() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let organizer = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    client.manage_collectible_inventory(&organizer, &event_id, &50u32);
+
+    let metadata_hash = BytesN::from_array(&env, &[7u8; 32]);
+
+    let nft_id = client.mint_commemorative_nft(
+        &organizer,
+        &event_id,
+        &owner,
+        &String::from_str(&env, "NFT"),
+        &String::from_str(&env, "desc"),
+        &RarityTier::Common,
+        &true,
+        &metadata_hash,
+    );
+
+    let result = client.try_trade_nft(&attacker, &buyer, &nft_id);
+    assert_eq!(result, Err(Ok(LumentixError::NftNotOwned)));
+}
+
+#[test]
+fn test_collectible_inventory_tracks_rarity_counts() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let organizer = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+
+    client.manage_collectible_inventory(&organizer, &event_id, &200u32);
+
+    let metadata_hash = BytesN::from_array(&env, &[8u8; 32]);
+
+    client.mint_commemorative_nft(
+        &organizer,
+        &event_id,
+        &recipient,
+        &String::from_str(&env, "Common 1"),
+        &String::from_str(&env, "desc"),
+        &RarityTier::Common,
+        &true,
+        &metadata_hash,
+    );
+
+    client.mint_commemorative_nft(
+        &organizer,
+        &event_id,
+        &recipient,
+        &String::from_str(&env, "Rare 1"),
+        &String::from_str(&env, "desc"),
+        &RarityTier::Rare,
+        &true,
+        &metadata_hash,
+    );
+
+    let inv = client.get_collectible_inventory(&event_id);
+    assert_eq!(inv.total_minted, 2u32);
+    assert_eq!(inv.common_minted, 1u32);
+    assert_eq!(inv.rare_minted, 1u32);
+    assert_eq!(inv.uncommon_minted, 0u32);
+    assert_eq!(inv.epic_minted, 0u32);
+    assert_eq!(inv.legendary_minted, 0u32);
+}

--- a/contract/src/storage.rs
+++ b/contract/src/storage.rs
@@ -1,11 +1,11 @@
 use crate::error::LumentixError;
 use crate::types::{
     AccessibilityBooking, AccessibilityInventory, BridgeTransaction, CarbonFootprint,
-    CarbonOffsetPurchase, CrossChainTransfer, CurrencyConfig, EnvironmentalImpact, Event,
-    EventReview, IdentityCredential, IdentityProvider, InsurancePolicy, InsurancePool,
-    OrganizerReputation, Seat, Ticket, TicketTransferRecord, UpgradeGovernanceConfig,
-    UpgradeProposal, UpgradeVote, VenueLayout, VipTier, WaitlistOffer, INSTANCE_LIFETIME,
-    PERSISTENT_LIFETIME,
+    CarbonOffsetPurchase, CollectibleInventory, CrossChainTransfer, CurrencyConfig,
+    EnvironmentalImpact, Event, EventMerchandise, EventReview, IdentityCredential,
+    IdentityProvider, InsurancePolicy, InsurancePool, NftCollectible, OrganizerReputation, Seat,
+    Ticket, TicketTransferRecord, UpgradeGovernanceConfig, UpgradeProposal, UpgradeVote,
+    VenueLayout, VipTier, WaitlistOffer, INSTANCE_LIFETIME, PERSISTENT_LIFETIME,
 };
 use soroban_sdk::{Address, BytesN, Env, String, Vec};
 
@@ -1231,4 +1231,141 @@ pub fn register_supported_chain(env: &Env, chain: &String, supported: bool) {
 pub fn is_chain_supported(env: &Env, chain: &String) -> bool {
     let key = (SUPPORTED_CHAIN_PREFIX, chain.clone());
     env.storage().instance().get(&key).unwrap_or(false)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// MERCHANDISE & NFT COLLECTIBLE STORAGE
+// ═══════════════════════════════════════════════════════════════════════════
+
+const MERCHANDISE_PREFIX: &str = "MERCH_";
+const MERCHANDISE_COUNTER: &str = "MERCH_CTR";
+const NFT_PREFIX: &str = "NFT_";
+const NFT_COUNTER: &str = "NFT_CTR";
+const COLLECTIBLE_INVENTORY_PREFIX: &str = "COLINV_";
+
+/// Get next merchandise ID
+pub fn get_next_merchandise_id(env: &Env) -> u64 {
+    let id = env
+        .storage()
+        .instance()
+        .get(&MERCHANDISE_COUNTER)
+        .unwrap_or(1);
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME, INSTANCE_LIFETIME);
+    id
+}
+
+/// Increment merchandise ID counter
+pub fn increment_merchandise_id(env: &Env) {
+    let next_id = get_next_merchandise_id(env) + 1;
+    env.storage()
+        .instance()
+        .set(&MERCHANDISE_COUNTER, &next_id);
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME, INSTANCE_LIFETIME);
+}
+
+/// Set merchandise item
+pub fn set_merchandise(env: &Env, merchandise_id: u64, item: &EventMerchandise) {
+    let key = (MERCHANDISE_PREFIX, merchandise_id);
+    env.storage().persistent().set(&key, item);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+}
+
+/// Get merchandise item
+pub fn get_merchandise(
+    env: &Env,
+    merchandise_id: u64,
+) -> Result<EventMerchandise, LumentixError> {
+    let key = (MERCHANDISE_PREFIX, merchandise_id);
+    let item = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .ok_or(LumentixError::MerchandiseNotFound)?;
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+    Ok(item)
+}
+
+/// Get next NFT ID
+pub fn get_next_nft_id(env: &Env) -> u64 {
+    let id = env
+        .storage()
+        .instance()
+        .get(&NFT_COUNTER)
+        .unwrap_or(1);
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME, INSTANCE_LIFETIME);
+    id
+}
+
+/// Increment NFT ID counter
+pub fn increment_nft_id(env: &Env) {
+    let next_id = get_next_nft_id(env) + 1;
+    env.storage().instance().set(&NFT_COUNTER, &next_id);
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME, INSTANCE_LIFETIME);
+}
+
+/// Set NFT collectible
+pub fn set_nft(env: &Env, nft_id: u64, nft: &NftCollectible) {
+    let key = (NFT_PREFIX, nft_id);
+    env.storage().persistent().set(&key, nft);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+}
+
+/// Get NFT collectible
+pub fn get_nft(env: &Env, nft_id: u64) -> Result<NftCollectible, LumentixError> {
+    let key = (NFT_PREFIX, nft_id);
+    let nft = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .ok_or(LumentixError::NftNotFound)?;
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+    Ok(nft)
+}
+
+/// Set collectible inventory for an event
+pub fn set_collectible_inventory(env: &Env, event_id: u64, inv: &CollectibleInventory) {
+    let key = (COLLECTIBLE_INVENTORY_PREFIX, event_id);
+    env.storage().persistent().set(&key, inv);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+}
+
+/// Get collectible inventory for an event
+pub fn get_collectible_inventory(
+    env: &Env,
+    event_id: u64,
+) -> Result<CollectibleInventory, LumentixError> {
+    let key = (COLLECTIBLE_INVENTORY_PREFIX, event_id);
+    let inv = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .ok_or(LumentixError::CollectibleInventoryNotFound)?;
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+    Ok(inv)
+}
+
+/// Check if collectible inventory exists for an event
+pub fn has_collectible_inventory(env: &Env, event_id: u64) -> bool {
+    let key = (COLLECTIBLE_INVENTORY_PREFIX, event_id);
+    env.storage().persistent().has(&key)
 }

--- a/contract/src/types.rs
+++ b/contract/src/types.rs
@@ -418,3 +418,62 @@ pub struct BridgeTransaction {
     pub validation_time: u64,
     pub block_number: u64,
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Merchandise & NFT Collectibles
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Rarity tier for NFT collectibles
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RarityTier {
+    Common,
+    Uncommon,
+    Rare,
+    Epic,
+    Legendary,
+}
+
+/// Event merchandise item
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EventMerchandise {
+    pub id: u64,
+    pub event_id: u64,
+    pub name: String,
+    pub description: String,
+    pub price: i128,
+    pub total_supply: u32,
+    pub remaining_supply: u32,
+    pub organizer: Address,
+    pub active: bool,
+}
+
+/// A commemorative NFT collectible for a special event
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NftCollectible {
+    pub id: u64,
+    pub event_id: u64,
+    pub name: String,
+    pub description: String,
+    pub rarity: RarityTier,
+    pub owner: Address,
+    pub minted_at: u64,
+    pub transferable: bool,
+    pub metadata_hash: BytesN<32>,
+}
+
+/// Collectible inventory tracking per event
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CollectibleInventory {
+    pub event_id: u64,
+    pub total_minted: u32,
+    pub max_supply: u32,
+    pub common_minted: u32,
+    pub uncommon_minted: u32,
+    pub rare_minted: u32,
+    pub epic_minted: u32,
+    pub legendary_minted: u32,
+}


### PR DESCRIPTION
this PR 
Closes #578

- Add RarityTier enum (Common, Uncommon, Rare, Epic, Legendary) to types.rs
- Add EventMerchandise, NftCollectible, CollectibleInventory structs to types.rs
- Add 9 new error variants (MerchandiseNotFound, MerchandiseSoldOut, MerchandiseNotActive, NftNotFound, NftNotTransferable, CollectibleInventoryNotFound, CollectibleMaxSupplyReached, RarityTierExhausted, NftNotOwned) to error.rs
- Add MerchandiseCreated, MerchandisePurchased, NftMinted, NftTraded, CollectibleInventoryUpdated events to events/mod.rs
- Add storage functions for merchandise, NFT, and collectible inventory to storage.rs (get/set/increment for each entity)
- Implement trade_nft for transferable NFT trading between addresses
- Implement get_nft read function
- Add merchandise_nft_tests.rs with 14 tests covering all new functions, edge cases (sold out, unauthorized, rarity exhaustion, non-transferable)
- Export all new types and events from lib.rs
