### PR TITLE
feat: add transfer blackout and referral reward contract flows

### DIFF
--- a/contract/src/error.rs
+++ b/contract/src/error.rs
@@ -264,4 +264,14 @@ pub enum LumentixError {
     // Security Monitoring errors (108–110)
     /// Security incident not found
     SecurityIncidentNotFound = 108,
+    /// Ticket transfers are currently locked by an organizer-defined blackout window
+    TransferBlackoutActive = 109,
+    /// Referral link code is already claimed by another referrer
+    ReferralLinkAlreadyExists = 110,
+    /// Referral link does not exist for the requested event
+    ReferralLinkNotFound = 111,
+    /// Referral purchase has already been processed for this buyer
+    ReferralPurchaseAlreadyProcessed = 112,
+    /// Referrers cannot refer themselves
+    SelfReferralNotAllowed = 113,
 }

--- a/contract/src/events/mod.rs
+++ b/contract/src/events/mod.rs
@@ -255,6 +255,82 @@ impl BatchTicketsTransferred {
     }
 }
 
+/// Event emitted when organizers update a transfer blackout window.
+pub struct TransferBlackoutUpdated;
+
+impl TransferBlackoutUpdated {
+    pub fn emit(
+        env: &Env,
+        event_id: u64,
+        organizer: Address,
+        starts_at: u64,
+        ends_at: u64,
+    ) {
+        env.events().publish(
+            (symbol_short!("txblack"),),
+            (event_id, organizer, starts_at, ends_at),
+        );
+    }
+}
+
+/// Event emitted when an organizer or admin overrides a transfer lock.
+pub struct TransferLockBypassed;
+
+impl TransferLockBypassed {
+    pub fn emit(
+        env: &Env,
+        event_id: u64,
+        ticket_id: u64,
+        operator: Address,
+        from: Address,
+        to: Address,
+    ) {
+        env.events().publish(
+            (symbol_short!("txbypass"),),
+            (event_id, ticket_id, operator, from, to),
+        );
+    }
+}
+
+/// Event emitted when a referral link is generated for an event.
+pub struct ReferralLinkGenerated;
+
+impl ReferralLinkGenerated {
+    pub fn emit(env: &Env, event_id: u64, referrer: Address, link_code: String) {
+        env.events()
+            .publish((symbol_short!("reflink"),), (event_id, referrer, link_code));
+    }
+}
+
+/// Event emitted when a referred purchase is processed.
+pub struct ReferralPurchaseProcessed;
+
+impl ReferralPurchaseProcessed {
+    pub fn emit(
+        env: &Env,
+        event_id: u64,
+        referrer: Address,
+        buyer: Address,
+        discounted_price: i128,
+        reward_amount: i128,
+    ) {
+        env.events().publish(
+            (symbol_short!("refproc"),),
+            (event_id, referrer, buyer, discounted_price, reward_amount),
+        );
+    }
+}
+
+/// Event emitted when pending referral rewards are credited to the referrer ledger state.
+pub struct ReferralRewardsCredited;
+
+impl ReferralRewardsCredited {
+    pub fn emit(env: &Env, event_id: u64, referrer: Address, amount: i128) {
+        env.events()
+            .publish((symbol_short!("refcredit"),), (event_id, referrer, amount));
+    }
+}
+
 /// Event emitted when a ticket is marked as used (checked in)
 pub struct TicketUsed;
 

--- a/contract/src/lumentix_contract.rs
+++ b/contract/src/lumentix_contract.rs
@@ -13,8 +13,10 @@ use crate::events::{
     IdentityCredentialRevoked, InsuranceClaimProcessed, InsurancePoolUpdated, InsurancePurchased,
     MerchandiseCreated, MerchandisePurchased, NftMinted, NftTraded, OraclePriceUpdated,
     PlatformFeeRecipientUpdated, PlatformFeeUpdated, PlatformFeesWithdrawn, ProtocolFeeQueried,
-    ReputationUpdated, ReviewSubmitted, SeatHoldReleased, SeatSelected, TicketPurchased,
-    TicketRefunded, TicketRevoked, TicketTransferred, TicketUsed, UpgradeExecuted,
+    ReferralLinkGenerated, ReferralPurchaseProcessed, ReferralRewardsCredited, ReputationUpdated,
+    ReviewSubmitted, SeatHoldReleased, SeatSelected, TicketPurchased, TicketRefunded,
+    TicketRevoked, TicketTransferred, TicketUsed, TransferBlackoutUpdated, TransferLockBypassed,
+    UpgradeExecuted,
     UpgradeGovernanceConfigUpdated, UpgradeProposed, UpgradeVoteCast, VenueLayoutCreated,
     VipTicketAssigned, VipTierCreated, WaitlistAvailabilityNotified, WaitlistJoined,
     VenueSpaceAllocated, SpaceUtilizationOptimized, VenueConflictManaged,
@@ -28,10 +30,11 @@ use crate::types::{
     CarbonFootprint, CarbonOffsetPurchase, CollectibleInventory, CrossChainTransfer,
     CrossChainTransferStatus, CurrencyConfig, EnvironmentalImpact, Event, EventMerchandise,
     EventReview, EventStatus, IdentityCredential, IdentityProof, IdentityProvider, InsurancePolicy,
-    NftCollectible, OrganizerReputation, RarityTier, Seat, Ticket, TicketTransferRecord,
-    UpgradeGovernanceConfig, UpgradeProposal, UpgradeState, UpgradeVote, VenueLayout, VenueSection,
-    VipTier, WaitlistOffer, PriceTier, PricingSchedule, MintGasUsage, StreamDeliveryConfig,
-    StreamPerformanceMetrics, PERSISTENT_LIFETIME,
+    NftCollectible, OrganizerReputation, RarityTier, ReferralLinkRecord, Seat, Ticket,
+    TicketTransferRecord, TransferBlackout, UpgradeGovernanceConfig, UpgradeProposal,
+    UpgradeState, UpgradeVote, VenueLayout, VenueSection, VipTier, WaitlistOffer, PriceTier,
+    PricingSchedule, MintGasUsage, StreamDeliveryConfig, StreamPerformanceMetrics,
+    PERSISTENT_LIFETIME,
     VipTier, WaitlistOffer, PERSISTENT_LIFETIME, VenueSpaceAllocation, SubscriptionPlan,
     SubscriptionStatus, SecurityIncident, UserPreferences,
 };
@@ -47,6 +50,8 @@ const THIRTY_DAYS_SECONDS: u64 = 30 * 24 * 60 * 60;
 const MAX_BATCH_MINT_SIZE: u32 = 10;
 const MINT_BASE_RESOURCE_UNITS: u64 = 5_000;
 const MINT_PER_TICKET_RESOURCE_UNITS: u64 = 1_200;
+const REFERRAL_DISCOUNT_BPS: i128 = 500;
+const REFERRAL_REWARD_BPS: i128 = 500;
 
 #[contractimpl]
 impl LumentixContract {
@@ -809,52 +814,9 @@ impl LumentixContract {
     ) -> Result<(), LumentixError> {
         from.require_auth();
 
-        // Read the ticket
         let mut ticket = storage::get_ticket(&env, ticket_id)?;
-
-        // Verify the caller is the current owner
-        if ticket.owner != from {
-            return Err(LumentixError::Unauthorized);
-        }
-
-        if ticket.revoked {
-            return Err(LumentixError::RevokedTicket);
-        }
-
-        // Verify ticket is not used
-        if ticket.used {
-            return Err(LumentixError::TicketAlreadyUsed);
-        }
-
-        // Verify ticket is not refunded
-        if ticket.refunded {
-            return Err(LumentixError::RefundNotAllowed);
-        }
-
-        // Read the event and verify it's published
-        let event = storage::get_event(&env, ticket.event_id)?;
-        if event.status != EventStatus::Published {
-            return Err(LumentixError::InvalidStatusTransition);
-        }
-
-        // Update ticket owner
-        ticket.owner = to.clone();
-        storage::set_ticket(&env, ticket_id, &ticket);
-
-        // Record transfer in history
-        storage::append_ticket_transfer_history(
-            &env,
-            ticket_id,
-            TicketTransferRecord {
-                from: from.clone(),
-                to: to.clone(),
-                timestamp: env.ledger().timestamp(),
-            },
-        );
-
-        // Emit TicketTransferred event
-        TicketTransferred::emit(&env, ticket_id, ticket.event_id, from, to);
-
+        Self::validate_ticket_transfer(&env, &ticket, &from, true)?;
+        Self::persist_ticket_transfer(&env, ticket_id, &mut ticket, from, to);
         Ok(())
     }
 
@@ -869,6 +831,179 @@ impl LumentixContract {
         // Verify the ticket exists before returning history
         storage::get_ticket(&env, ticket_id)?;
         Ok(storage::get_ticket_transfer_history(&env, ticket_id))
+    }
+
+    /// Configure a blackout window during which peer-to-peer ticket transfers are locked.
+    pub fn set_transfer_blackout(
+        env: Env,
+        organizer: Address,
+        event_id: u64,
+        starts_at: u64,
+        ends_at: u64,
+    ) -> Result<(), LumentixError> {
+        organizer.require_auth();
+
+        let event = storage::get_event(&env, event_id)?;
+        if event.organizer != organizer {
+            return Err(LumentixError::Unauthorized);
+        }
+
+        validation::validate_time_range(starts_at, ends_at)?;
+
+        storage::set_transfer_blackout(
+            &env,
+            event_id,
+            &TransferBlackout {
+                starts_at,
+                ends_at,
+            },
+        );
+
+        TransferBlackoutUpdated::emit(&env, event_id, organizer, starts_at, ends_at);
+        Ok(())
+    }
+
+    /// Return whether the current ledger time is inside the configured transfer blackout window.
+    pub fn is_transfer_blackout_active(env: Env, event_id: u64) -> Result<bool, LumentixError> {
+        storage::get_event(&env, event_id)?;
+        Ok(Self::is_transfer_blackout_active_for_event(&env, event_id))
+    }
+
+    /// Organizer or platform admin override for transfer blackouts.
+    pub fn bypass_transfer_lock(
+        env: Env,
+        operator: Address,
+        ticket_id: u64,
+        from: Address,
+        to: Address,
+    ) -> Result<(), LumentixError> {
+        operator.require_auth();
+
+        let mut ticket = storage::get_ticket(&env, ticket_id)?;
+        let event = storage::get_event(&env, ticket.event_id)?;
+        let admin = storage::get_admin(&env);
+        if operator != event.organizer && operator != admin {
+            return Err(LumentixError::Unauthorized);
+        }
+
+        Self::validate_ticket_transfer(&env, &ticket, &from, false)?;
+        let event_id = ticket.event_id;
+        Self::persist_ticket_transfer(&env, ticket_id, &mut ticket, from.clone(), to.clone());
+        TransferLockBypassed::emit(&env, event_id, ticket_id, operator, from, to);
+        Ok(())
+    }
+
+    /// Create a reusable referral link code for a referrer on a published event.
+    pub fn generate_referral_link(
+        env: Env,
+        referrer: Address,
+        event_id: u64,
+        link_code: String,
+    ) -> Result<String, LumentixError> {
+        referrer.require_auth();
+        validation::validate_string_not_empty(&link_code)?;
+
+        let event = storage::get_event(&env, event_id)?;
+        if event.status != EventStatus::Published {
+            return Err(LumentixError::InvalidStatusTransition);
+        }
+
+        if let Some(existing) = storage::get_referral_link_record(&env, event_id, &referrer) {
+            return Ok(existing.link_code);
+        }
+
+        if let Some(existing_owner) = storage::get_referral_code_owner(&env, event_id, &link_code) {
+            if existing_owner != referrer {
+                return Err(LumentixError::ReferralLinkAlreadyExists);
+            }
+        }
+
+        storage::set_referral_code_owner(&env, event_id, &link_code, &referrer);
+        storage::set_referral_link_record(
+            &env,
+            event_id,
+            &referrer,
+            &ReferralLinkRecord {
+                link_code: link_code.clone(),
+                successful_purchases: 0,
+                pending_rewards: 0,
+                total_rewards_paid: 0,
+                total_discount_awarded: 0,
+            },
+        );
+
+        ReferralLinkGenerated::emit(&env, event_id, referrer, link_code.clone());
+        Ok(link_code)
+    }
+
+    /// Register a referred purchase and accrue the referrer's pending rewards.
+    pub fn process_referred_purchase(
+        env: Env,
+        buyer: Address,
+        event_id: u64,
+        link_code: String,
+    ) -> Result<(i128, i128), LumentixError> {
+        buyer.require_auth();
+        validation::validate_string_not_empty(&link_code)?;
+
+        let event = storage::get_event(&env, event_id)?;
+        if event.status != EventStatus::Published {
+            return Err(LumentixError::InvalidStatusTransition);
+        }
+
+        let referrer = storage::get_referral_code_owner(&env, event_id, &link_code)
+            .ok_or(LumentixError::ReferralLinkNotFound)?;
+        if referrer == buyer {
+            return Err(LumentixError::SelfReferralNotAllowed);
+        }
+        if storage::has_referral_purchase_processed(&env, event_id, &buyer) {
+            return Err(LumentixError::ReferralPurchaseAlreadyProcessed);
+        }
+
+        let mut record = storage::get_referral_link_record(&env, event_id, &referrer)
+            .ok_or(LumentixError::ReferralLinkNotFound)?;
+        let discount_amount = (event.ticket_price * REFERRAL_DISCOUNT_BPS) / 10000;
+        let reward_amount = (event.ticket_price * REFERRAL_REWARD_BPS) / 10000;
+        let discounted_price = event.ticket_price - discount_amount;
+
+        record.successful_purchases = record.successful_purchases.saturating_add(1);
+        record.pending_rewards += reward_amount;
+        record.total_discount_awarded += discount_amount;
+        storage::set_referral_link_record(&env, event_id, &referrer, &record);
+        storage::set_referral_purchase_processed(&env, event_id, &buyer);
+
+        ReferralPurchaseProcessed::emit(
+            &env,
+            event_id,
+            referrer,
+            buyer,
+            discounted_price,
+            reward_amount,
+        );
+        Ok((discounted_price, reward_amount))
+    }
+
+    /// Move accrued referral rewards from pending into paid state for a referrer.
+    pub fn credit_referral_rewards(
+        env: Env,
+        referrer: Address,
+        event_id: u64,
+    ) -> Result<i128, LumentixError> {
+        referrer.require_auth();
+
+        let mut record = storage::get_referral_link_record(&env, event_id, &referrer)
+            .ok_or(LumentixError::ReferralLinkNotFound)?;
+        let amount = record.pending_rewards;
+        if amount == 0 {
+            return Ok(0);
+        }
+
+        record.pending_rewards = 0;
+        record.total_rewards_paid += amount;
+        storage::set_referral_link_record(&env, event_id, &referrer, &record);
+
+        ReferralRewardsCredited::emit(&env, event_id, referrer, amount);
+        Ok(amount)
     }
 
     /// Refund a ticket for a cancelled event.
@@ -1412,51 +1547,9 @@ impl LumentixContract {
         from.require_auth();
 
         for ticket_id in ticket_ids.iter() {
-            // Read the ticket
             let mut ticket = storage::get_ticket(&env, ticket_id)?;
-
-            // Verify the caller is the current owner
-            if ticket.owner != from {
-                return Err(LumentixError::Unauthorized);
-            }
-
-            if ticket.revoked {
-                return Err(LumentixError::RevokedTicket);
-            }
-
-            // Verify ticket is not used
-            if ticket.used {
-                return Err(LumentixError::TicketAlreadyUsed);
-            }
-
-            // Verify ticket is not refunded
-            if ticket.refunded {
-                return Err(LumentixError::RefundNotAllowed);
-            }
-
-            // Read the event and verify it's published
-            let event = storage::get_event(&env, ticket.event_id)?;
-            if event.status != EventStatus::Published {
-                return Err(LumentixError::InvalidStatusTransition);
-            }
-
-            // Update ticket owner
-            ticket.owner = to.clone();
-            storage::set_ticket(&env, ticket_id, &ticket);
-
-            // Record transfer in history
-            storage::append_ticket_transfer_history(
-                &env,
-                ticket_id,
-                TicketTransferRecord {
-                    from: from.clone(),
-                    to: to.clone(),
-                    timestamp: env.ledger().timestamp(),
-                },
-            );
-
-            // Emit TicketTransferred event
-            TicketTransferred::emit(&env, ticket_id, ticket.event_id, from.clone(), to.clone());
+            Self::validate_ticket_transfer(&env, &ticket, &from, true)?;
+            Self::persist_ticket_transfer(&env, ticket_id, &mut ticket, from.clone(), to.clone());
         }
 
         // Resolves Issue #546
@@ -5031,5 +5124,65 @@ impl LumentixContract {
         UserJourneyOptimized::emit(&env, user, journey_steps.len(), env.ledger().timestamp());
 
         Ok(())
+    }
+
+    fn is_transfer_blackout_active_for_event(env: &Env, event_id: u64) -> bool {
+        if let Some(blackout) = storage::get_transfer_blackout(env, event_id) {
+            let now = env.ledger().timestamp();
+            return now >= blackout.starts_at && now <= blackout.ends_at;
+        }
+        false
+    }
+
+    fn validate_ticket_transfer(
+        env: &Env,
+        ticket: &Ticket,
+        from: &Address,
+        enforce_blackout: bool,
+    ) -> Result<(), LumentixError> {
+        if ticket.owner != from.clone() {
+            return Err(LumentixError::Unauthorized);
+        }
+        if ticket.revoked {
+            return Err(LumentixError::RevokedTicket);
+        }
+        if ticket.used {
+            return Err(LumentixError::TicketAlreadyUsed);
+        }
+        if ticket.refunded {
+            return Err(LumentixError::RefundNotAllowed);
+        }
+
+        let event = storage::get_event(env, ticket.event_id)?;
+        if event.status != EventStatus::Published {
+            return Err(LumentixError::InvalidStatusTransition);
+        }
+        if enforce_blackout && Self::is_transfer_blackout_active_for_event(env, ticket.event_id) {
+            return Err(LumentixError::TransferBlackoutActive);
+        }
+
+        Ok(())
+    }
+
+    fn persist_ticket_transfer(
+        env: &Env,
+        ticket_id: u64,
+        ticket: &mut Ticket,
+        from: Address,
+        to: Address,
+    ) {
+        let event_id = ticket.event_id;
+        ticket.owner = to.clone();
+        storage::set_ticket(env, ticket_id, ticket);
+        storage::append_ticket_transfer_history(
+            env,
+            ticket_id,
+            TicketTransferRecord {
+                from: from.clone(),
+                to: to.clone(),
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+        TicketTransferred::emit(env, ticket_id, event_id, from, to);
     }
 }

--- a/contract/src/storage.rs
+++ b/contract/src/storage.rs
@@ -4,7 +4,8 @@ use crate::types::{
     CarbonOffsetPurchase, CollectibleInventory, CrossChainTransfer, CurrencyConfig,
     EnvironmentalImpact, Event, EventMerchandise, EventReview, IdentityCredential,
     IdentityProvider, InsurancePolicy, InsurancePool, NftCollectible, OrganizerReputation, Seat,
-    Ticket, TicketTransferRecord, UpgradeGovernanceConfig, UpgradeProposal, UpgradeVote,
+    Ticket, TicketTransferRecord, TransferBlackout, ReferralLinkRecord,
+    UpgradeGovernanceConfig, UpgradeProposal, UpgradeVote,
     VenueLayout, VipTier, WaitlistOffer, PricingSchedule, MintGasUsage, StreamDeliveryConfig,
     StreamPerformanceMetrics, INSTANCE_LIFETIME, PERSISTENT_LIFETIME,
     VenueLayout, VipTier, WaitlistOffer, INSTANCE_LIFETIME, PERSISTENT_LIFETIME,
@@ -24,6 +25,10 @@ const ESCROW_PREFIX: &str = "ESCROW_";
 const PLATFORM_FEE_BPS: &str = "PLATFORM_FEE_BPS";
 const PLATFORM_BALANCE: &str = "PLATFORM_BAL";
 const TRANSFER_HISTORY_PREFIX: &str = "TXHIST_";
+const TRANSFER_BLACKOUT_PREFIX: &str = "TXBLK_";
+const REFERRAL_LINK_PREFIX: &str = "REFLINK_";
+const REFERRAL_CODE_PREFIX: &str = "REFCODE_";
+const REFERRAL_PURCHASE_PREFIX: &str = "REFBUY_";
 const VIP_TIER_PREFIX: &str = "VIP_";
 const ACCESSIBILITY_INV_PREFIX: &str = "ACCINV_";
 const ACCESSIBILITY_BOOKING_PREFIX: &str = "ACCBOOK_";
@@ -324,6 +329,99 @@ pub fn get_ticket_transfer_history(env: &Env, ticket_id: u64) -> Vec<TicketTrans
             .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
     }
     history
+}
+
+/// Store a transfer blackout window for an event.
+pub fn set_transfer_blackout(env: &Env, event_id: u64, blackout: &TransferBlackout) {
+    let key = (TRANSFER_BLACKOUT_PREFIX, event_id);
+    env.storage().persistent().set(&key, blackout);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+}
+
+/// Return an event transfer blackout window if one has been configured.
+pub fn get_transfer_blackout(env: &Env, event_id: u64) -> Option<TransferBlackout> {
+    let key = (TRANSFER_BLACKOUT_PREFIX, event_id);
+    let blackout = env.storage().persistent().get(&key);
+    if blackout.is_some() {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+    }
+    blackout
+}
+
+/// Store referral reward state for a referrer in a specific event.
+pub fn set_referral_link_record(
+    env: &Env,
+    event_id: u64,
+    referrer: &Address,
+    record: &ReferralLinkRecord,
+) {
+    let key = (REFERRAL_LINK_PREFIX, event_id, referrer.clone());
+    env.storage().persistent().set(&key, record);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+}
+
+/// Load referral reward state for a referrer in a specific event.
+pub fn get_referral_link_record(
+    env: &Env,
+    event_id: u64,
+    referrer: &Address,
+) -> Option<ReferralLinkRecord> {
+    let key = (REFERRAL_LINK_PREFIX, event_id, referrer.clone());
+    let record = env.storage().persistent().get(&key);
+    if record.is_some() {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+    }
+    record
+}
+
+/// Claim or look up a referral code owner for an event.
+pub fn set_referral_code_owner(env: &Env, event_id: u64, link_code: &String, referrer: &Address) {
+    let key = (REFERRAL_CODE_PREFIX, event_id, link_code.clone());
+    env.storage().persistent().set(&key, referrer);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+}
+
+/// Load the owner of a referral code for an event.
+pub fn get_referral_code_owner(env: &Env, event_id: u64, link_code: &String) -> Option<Address> {
+    let key = (REFERRAL_CODE_PREFIX, event_id, link_code.clone());
+    let owner = env.storage().persistent().get(&key);
+    if owner.is_some() {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+    }
+    owner
+}
+
+/// Mark a buyer as already processed for referral rewards in an event.
+pub fn set_referral_purchase_processed(env: &Env, event_id: u64, buyer: &Address) {
+    let key = (REFERRAL_PURCHASE_PREFIX, event_id, buyer.clone());
+    env.storage().persistent().set(&key, &true);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+}
+
+/// Return whether a buyer has already been counted for a referral reward in an event.
+pub fn has_referral_purchase_processed(env: &Env, event_id: u64, buyer: &Address) -> bool {
+    let key = (REFERRAL_PURCHASE_PREFIX, event_id, buyer.clone());
+    let has = env.storage().persistent().has(&key);
+    if has {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+    }
+    has
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -4249,6 +4249,100 @@ fn test_batch_transfer_tickets_require_auth_once_for_sender() {
     assert_eq!(*addr, buyer_a);
 }
 
+#[test]
+fn test_transfer_ticket_blocked_during_blackout_window() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+    client.set_transfer_blackout(&organizer, &event_id, &0u64, &100u64);
+
+    let ticket_id = client.purchase_ticket(&owner, &event_id, &100i128);
+    assert!(client.is_transfer_blackout_active(&event_id));
+
+    let result = client.try_transfer_ticket(&ticket_id, &owner, &recipient);
+    assert_eq!(result, Err(Ok(LumentixError::TransferBlackoutActive)));
+}
+
+#[test]
+fn test_bypass_transfer_lock_allows_override_during_blackout() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+    client.set_transfer_blackout(&organizer, &event_id, &0u64, &100u64);
+
+    let ticket_id = client.purchase_ticket(&owner, &event_id, &100i128);
+    client.bypass_transfer_lock(&organizer, &ticket_id, &owner, &recipient);
+
+    let ticket = client.get_ticket_info(&ticket_id);
+    assert_eq!(ticket.owner, recipient);
+}
+
+#[test]
+fn test_referral_flow_tracks_discount_and_reward_credit() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+    let referrer = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+    let link_code = String::from_str(&env, "summer-share");
+    let generated = client.generate_referral_link(&referrer, &event_id, &link_code);
+    assert_eq!(generated, link_code);
+
+    let (discounted_price, reward_amount) =
+        client.process_referred_purchase(&buyer, &event_id, &generated);
+    assert_eq!(discounted_price, 95i128);
+    assert_eq!(reward_amount, 5i128);
+
+    let credited = client.credit_referral_rewards(&referrer, &event_id);
+    assert_eq!(credited, 5i128);
+}
+
+#[test]
+fn test_referral_purchase_rejects_self_referral_and_duplicate_buyer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_admin, client) = create_test_contract(&env);
+    let organizer = Address::generate(&env);
+    let referrer = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let event_id = create_and_publish_event(&env, &client, &organizer);
+    let link_code = client.generate_referral_link(
+        &referrer,
+        &event_id,
+        &String::from_str(&env, "friend-pass"),
+    );
+
+    let self_referral = client.try_process_referred_purchase(&referrer, &event_id, &link_code);
+    assert_eq!(self_referral, Err(Ok(LumentixError::SelfReferralNotAllowed)));
+
+    let first = client.try_process_referred_purchase(&buyer, &event_id, &link_code);
+    assert!(first.is_ok());
+
+    let duplicate = client.try_process_referred_purchase(&buyer, &event_id, &link_code);
+    assert_eq!(
+        duplicate,
+        Err(Ok(LumentixError::ReferralPurchaseAlreadyProcessed))
+    );
+}
+
 // ============================================================================
 // TOKEN CONFIGURATION TESTS
 // ============================================================================

--- a/contract/src/types.rs
+++ b/contract/src/types.rs
@@ -65,6 +65,25 @@ pub struct TicketTransferRecord {
     pub timestamp: u64,
 }
 
+/// Organizer-defined transfer lock window for an event.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransferBlackout {
+    pub starts_at: u64,
+    pub ends_at: u64,
+}
+
+/// Tracks referral link ownership and reward accrual for a single event.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReferralLinkRecord {
+    pub link_code: String,
+    pub successful_purchases: u32,
+    pub pending_rewards: i128,
+    pub total_rewards_paid: i128,
+    pub total_discount_awarded: i128,
+}
+
 /// Fee collected event for tracking platform fees
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
Closes #692
Closes #678
Closes #684 
Closes #679

## Changes
- add organizer-defined transfer blackout windows for events
- block standard and batch ticket transfers while a blackout is active
- add organizer/admin bypass flow for locked transfers
- add referral link generation and event-scoped referral ownership storage
- add referred purchase processing with discount and reward accounting
- add referral reward crediting flow and new contract events/errors
- add contract tests for blackout enforcement, bypass behavior, and referral flows

## Testing
- Added targeted smart contract tests in `contract/src/test.rs`
- Could not run `cargo test` in this environment because `cargo` is not installed

## Notes
- `upstream` is configured to `LumenTix-HQ/lumentix`
- Work is on branch `feat/referral-blackout-678-692`