### PR TITLE
Fix 4 frontend gaps: password reset flow, 404/error pages, frontend CI, middleware tests

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,115 @@
+name: Frontend CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: frontend/node_modules
+          key: ${{ runner.os }}-frontend-node-modules-${{ hashFiles('frontend/package-lock.json') }}
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Lint
+        working-directory: frontend
+        run: npm run lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: frontend/node_modules
+          key: ${{ runner.os }}-frontend-node-modules-${{ hashFiles('frontend/package-lock.json') }}
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Typecheck
+        working-directory: frontend
+        run: npx tsc --noEmit
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: frontend/node_modules
+          key: ${{ runner.os }}-frontend-node-modules-${{ hashFiles('frontend/package-lock.json') }}
+
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: frontend/.next/cache
+          key: ${{ runner.os }}-frontend-next-${{ hashFiles('frontend/package-lock.json') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-frontend-next-${{ hashFiles('frontend/package-lock.json') }}-
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build
+        working-directory: frontend
+        run: npm run build
+
+  dep-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Check for duplicate dependencies
+        run: |
+          node -e "
+            const pkg = require('./frontend/package.json');
+            const deps = Object.keys(pkg.dependencies || {});
+            const devDeps = pkg.devDependencies || {};
+            const duplicates = deps.filter((name) => devDeps[name]);
+            if (duplicates.length) {
+              console.error('Packages listed in both dependencies and devDependencies:');
+              duplicates.forEach((name) => console.error('  - ' + name));
+              process.exit(1);
+            }
+            console.log('No duplicate dependencies found.');
+          "

--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import Link from 'next/link';
 
 interface ErrorProps {
   error: Error & { digest?: string };
@@ -72,6 +73,12 @@ export default function Error({ error, reset }: ErrorProps) {
           >
             Try Again
           </button>
+          <Link
+            href="/events"
+            className="px-6 py-3 bg-white/[0.06] border border-white/[0.1] text-white rounded-lg font-semibold hover:bg-white/[0.1] transition-colors text-center"
+          >
+            Browse Events
+          </Link>
           <button
             onClick={() => (window.location.href = '/')}
             className="px-6 py-3 bg-white/[0.06] border border-white/[0.1] text-white rounded-lg font-semibold hover:bg-white/[0.1] transition-colors"

--- a/frontend/app/forgot-password/page.tsx
+++ b/frontend/app/forgot-password/page.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useToast } from '@/contexts/ToastContext';
+import { apiPost } from '@/lib/api-client';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000';
+const RESEND_COOLDOWN_SECONDS = 60;
 
 const forgotPasswordSchema = z.object({
   email: z.string().email('Enter a valid email address'),
@@ -19,6 +20,7 @@ export default function ForgotPasswordPage() {
   const { toast } = useToast();
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
+  const [cooldown, setCooldown] = useState(0);
 
   const {
     register,
@@ -29,31 +31,32 @@ export default function ForgotPasswordPage() {
     resolver: zodResolver(forgotPasswordSchema),
   });
 
+  // Tick down the resend cooldown once a submission has been made
+  useEffect(() => {
+    if (cooldown <= 0) return;
+    const timer = setTimeout(() => setCooldown((seconds) => seconds - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [cooldown]);
+
   const onSubmit = async (values: ForgotPasswordFormValues) => {
     setServerError(null);
 
     try {
-      const response = await fetch(`${API_BASE}/auth/forgot-password`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: values.email }),
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        // Don't reveal whether email exists - show generic message
-        setServerError(data?.message ?? 'An error occurred. Please try again.');
+      await apiPost('/auth/forgot-password', { email: values.email });
+    } catch {
+      // Swallow API errors so a rejected request can't reveal whether the
+      // email is registered - only surface genuine connectivity failures.
+      if (typeof navigator !== 'undefined' && !navigator.onLine) {
+        setServerError('Network error. Please check your connection and try again.');
         return;
       }
-
-      // Success - show confirmation but don't reveal if email exists
-      setIsSubmitted(true);
-      toast.success('If an account exists with this email, you will receive password reset instructions.');
-      reset();
-    } catch {
-      setServerError('Network error. Please check your connection and try again.');
     }
+
+    // Always report the same outcome regardless of whether the email exists
+    setIsSubmitted(true);
+    setCooldown(RESEND_COOLDOWN_SECONDS);
+    toast.success('If that email is registered, you will receive a link shortly.');
+    reset();
   };
 
   return (
@@ -91,7 +94,7 @@ export default function ForgotPasswordPage() {
               <div className="space-y-2">
                 <h2 className="text-xl font-bold text-white">Check Your Email</h2>
                 <p className="text-gray-400 text-sm">
-                  If an account exists with the email you provided, you'll receive a password reset link shortly.
+                  If that email is registered, you will receive a link shortly.
                 </p>
                 <p className="text-gray-500 text-xs">
                   Didn't receive an email? Check your spam folder or try again.
@@ -100,9 +103,10 @@ export default function ForgotPasswordPage() {
               <div className="space-y-3 pt-4">
                 <button
                   onClick={() => setIsSubmitted(false)}
-                  className="w-full bg-blue-600 text-white py-3 rounded-xl font-semibold hover:bg-blue-500 transition-colors"
+                  disabled={cooldown > 0}
+                  className="w-full bg-blue-600 text-white py-3 rounded-xl font-semibold hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                 >
-                  Try Another Email
+                  {cooldown > 0 ? `Try Another Email in ${cooldown}s` : 'Try Another Email'}
                 </button>
                 <Link
                   href="/login"
@@ -142,10 +146,12 @@ export default function ForgotPasswordPage() {
 
               <button
                 type="submit"
-                disabled={isSubmitting}
+                disabled={isSubmitting || cooldown > 0}
                 className="w-full bg-blue-600 text-white py-3 rounded-xl font-semibold hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
               >
-                {isSubmitting ? (
+                {cooldown > 0 ? (
+                  `Resend in ${cooldown}s`
+                ) : isSubmitting ? (
                   <>
                     <svg
                       className="animate-spin h-4 w-4 text-white"

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -17,6 +17,7 @@ export default function LoginPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const showPasswordResetBanner = searchParams.get("message") === "password_reset";
 
   const {
     register,
@@ -68,6 +69,12 @@ export default function LoginPage() {
           className="bg-gray-800 rounded-xl p-8 shadow-lg space-y-6"
           noValidate
         >
+          {showPasswordResetBanner && (
+            <p className="text-sm text-green-400 bg-green-900/30 border border-green-800 rounded-lg px-4 py-3">
+              Your password has been reset. Sign in with your new password.
+            </p>
+          )}
+
           {errorMessage && (
             <p className="text-sm text-red-400 bg-red-900/30 border border-red-800 rounded-lg px-4 py-3">
               {errorMessage}

--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -11,6 +11,21 @@ export default function NotFound() {
                 <p className="text-gray-400 mb-12 max-w-md mx-auto">
                     The coordinate you're looking for doesn't exist in this galaxy. Let's get you back home.
                 </p>
+                <form action="/events" className="max-w-md mx-auto mb-12 flex gap-2">
+                    <input
+                        type="search"
+                        name="search"
+                        placeholder="Search events..."
+                        aria-label="Search events"
+                        className="flex-1 bg-white/[0.06] border border-white/[0.1] rounded-full px-6 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-white/20"
+                    />
+                    <button
+                        type="submit"
+                        className="px-6 py-3 bg-white text-black rounded-full font-bold hover:bg-gray-200 transition-colors"
+                    >
+                        Search
+                    </button>
+                </form>
                 <Link
                     href="/"
                     className="px-8 py-4 bg-white text-black rounded-full font-bold hover:bg-gray-200 transition-colors shadow-xl"

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -7,8 +7,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useToast } from '@/contexts/ToastContext';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000';
+import { apiPost } from '@/lib/api-client';
 
 const resetPasswordSchema = z
   .object({
@@ -47,10 +46,11 @@ export default function ResetPasswordPage() {
     if (!token) {
       setIsValidToken(false);
       toast.error('Invalid or missing reset token. Please request a new password reset link.');
+      router.replace('/forgot-password');
     } else {
       setIsValidToken(true);
     }
-  }, [token, toast]);
+  }, [token, toast, router]);
 
   const onSubmit = async (values: ResetPasswordFormValues) => {
     setServerError(null);
@@ -61,35 +61,23 @@ export default function ResetPasswordPage() {
     }
 
     try {
-      const response = await fetch(`${API_BASE}/auth/reset-password`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          token: token,
-          newPassword: values.password,
-        }),
+      await apiPost('/auth/reset-password', {
+        token: token,
+        newPassword: values.password,
       });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        // Handle specific error cases
-        const errorMessage = data?.message ?? 'Failed to reset password. Please try again.';
-        
-        if (errorMessage.includes('expired') || errorMessage.includes('expired')) {
-          setServerError('This password reset link has expired. Please request a new one.');
-        } else if (errorMessage.includes('invalid') || errorMessage.includes('Invalid')) {
-          setServerError('This password reset link is invalid or has already been used.');
-        } else {
-          setServerError(errorMessage);
-        }
-        return;
-      }
 
       // Success
       toast.success('Your password has been reset successfully!');
-      router.push('/login?reset=success');
-    } catch {
+      router.push('/login?message=password_reset');
+    } catch (error) {
+      // A rejected or already-consumed token comes back as 400 or 410
+      const status = (error as { status?: number })?.status;
+
+      if (status === 400 || status === 410) {
+        setServerError('This link has expired');
+        return;
+      }
+
       setServerError('Network error. Please check your connection and try again.');
     }
   };

--- a/frontend/tests/middleware.test.ts
+++ b/frontend/tests/middleware.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { NextRequest } from 'next/server';
+import middleware from '@/middleware';
+
+const ACCESS_TOKEN_COOKIE = 'lumentix_access_token';
+
+function encodeSegment(value: object): string {
+  return Buffer.from(JSON.stringify(value)).toString('base64');
+}
+
+/** Builds an unsigned JWT - middleware only reads the payload, it never verifies. */
+function buildToken(payload: Record<string, unknown>): string {
+  return [encodeSegment({ alg: 'HS256', typ: 'JWT' }), encodeSegment(payload), 'signature'].join(
+    '.',
+  );
+}
+
+function tokenFor(role: string, secondsUntilExpiry = 3600): string {
+  return buildToken({ role, exp: Math.floor(Date.now() / 1000) + secondsUntilExpiry });
+}
+
+function buildRequest(pathname: string, token?: string): NextRequest {
+  const headers = new Headers();
+  if (token) {
+    headers.set('cookie', `${ACCESS_TOKEN_COOKIE}=${token}`);
+  }
+  return new NextRequest(`https://lumentix.test${pathname}`, { headers });
+}
+
+describe('middleware', () => {
+  describe('authentication redirect', () => {
+    it('redirects to login when no token is present', () => {
+      const res = middleware(buildRequest('/create'));
+      const location = new URL(res.headers.get('location') as string);
+
+      expect(res.status).toBe(307);
+      expect(location.pathname).toBe('/login');
+    });
+
+    it('preserves the requested path as the redirect param', () => {
+      const res = middleware(buildRequest('/my-tickets'));
+      const location = new URL(res.headers.get('location') as string);
+
+      expect(location.searchParams.get('redirect')).toBe('/my-tickets');
+    });
+
+    it('redirects to login when the token is expired', () => {
+      const res = middleware(buildRequest('/profile', tokenFor('attendee', -60)));
+      const location = new URL(res.headers.get('location') as string);
+
+      expect(res.status).toBe(307);
+      expect(location.pathname).toBe('/login');
+    });
+
+    it('redirects to login when the token is malformed', () => {
+      const res = middleware(buildRequest('/profile', 'not-a-jwt'));
+      const location = new URL(res.headers.get('location') as string);
+
+      expect(location.pathname).toBe('/login');
+    });
+
+    it('redirects to login when the token has no exp claim', () => {
+      const res = middleware(buildRequest('/profile', buildToken({ role: 'attendee' })));
+      const location = new URL(res.headers.get('location') as string);
+
+      expect(location.pathname).toBe('/login');
+    });
+
+    it('allows a valid token through to a non-role-guarded route', () => {
+      const res = middleware(buildRequest('/profile', tokenFor('attendee')));
+
+      expect(res.headers.get('location')).toBeNull();
+      expect(res.headers.get('x-middleware-next')).toBe('1');
+    });
+  });
+
+  describe('organizer role guard', () => {
+    it('allows an organizer through to /organizer', () => {
+      const res = middleware(buildRequest('/organizer/dashboard', tokenFor('organizer')));
+
+      expect(res.headers.get('location')).toBeNull();
+      expect(res.headers.get('x-middleware-next')).toBe('1');
+    });
+
+    it('allows an admin through to /organizer', () => {
+      const res = middleware(buildRequest('/organizer/dashboard', tokenFor('admin')));
+
+      expect(res.headers.get('x-middleware-next')).toBe('1');
+    });
+
+    it('redirects a non-organizer away from /organizer', () => {
+      const res = middleware(buildRequest('/organizer/dashboard', tokenFor('attendee')));
+      const location = new URL(res.headers.get('location') as string);
+
+      expect(res.status).toBe(307);
+      expect(location.pathname).toBe('/');
+      expect(location.searchParams.has('redirect')).toBe(false);
+    });
+  });
+
+  describe('admin role guard', () => {
+    it('allows an admin through to /admin', () => {
+      const res = middleware(buildRequest('/admin/users', tokenFor('admin')));
+
+      expect(res.headers.get('x-middleware-next')).toBe('1');
+    });
+
+    it('redirects an organizer away from /admin', () => {
+      const res = middleware(buildRequest('/admin/users', tokenFor('organizer')));
+      const location = new URL(res.headers.get('location') as string);
+
+      expect(location.pathname).toBe('/');
+    });
+  });
+});


### PR DESCRIPTION
### Changes

- **#869** — `forgot-password` now posts through `apiPost` (proxy cookie auth) instead of hitting `NEXT_PUBLIC_API_URL` directly, always reports the same "If that email is registered, you will receive a link shortly." outcome so a failed request can't reveal whether an email exists, and disables the submit/retry button for 60s with a live countdown. `reset-password` now redirects to `/forgot-password` when `?token` is absent, keys expiry off the 400/410 status instead of substring-matching the error message, and redirects to `/login?message=password_reset` on success. The login page renders a green banner for that param.
- **#870** — Added the missing search input to `app/not-found.tsx` (submits to `/events?search=`) and a `Browse Events` link to the global `app/error.tsx`. The `error.tsx` boundaries for `/`, `/events` and `/events/[id]` and the 404 page already existed and already gate raw error text behind `NODE_ENV === 'development'`, so they were left alone.
- **#871** — New `.github/workflows/frontend-ci.yml` with `lint`, `typecheck`, `build` and `dep-check` jobs, `actions/cache` on `frontend/node_modules` and `frontend/.next/cache` keyed on the `frontend/package-lock.json` hash, and a `frontend/**` path filter so backend-only changes don't trigger it.
- **#872** — Added `frontend/tests/middleware.test.ts` (11 tests) covering missing token, expired token, malformed token, missing `exp` claim, redirect-param preservation, and the organizer/admin role guards. Vitest config, setup, the `test`/`test:coverage` scripts, and the `WalletContext`/`apiClient` suites already existed and already cover their stated criteria, so only the missing middleware file was added.

Closes #869
Closes #870
Closes #871
Closes #872
