### PR TITLE
Add platform telemetry, token-gated merch, ticket design builder, and gate scan analytics

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -47,6 +47,7 @@ import { LoyaltyModule } from './loyalty/loyalty.module';
 import { TelemetryModule } from './telemetry/telemetry.module';
 import { MerchModule } from './merch/merch.module';
 import { TicketDesignModule } from './ticket-design/ticket-design.module';
+import { ScanAnalyticsModule } from './scan-analytics/scan-analytics.module';
 import { InternalModule } from './common/internal.module';
 import { InternalRoutingModule } from './internal/internal.module';
 
@@ -137,6 +138,7 @@ import { InternalRoutingModule } from './internal/internal.module';
     TelemetryModule,
     MerchModule,
     TicketDesignModule,
+    ScanAnalyticsModule,
     InternalModule,
     InternalRoutingModule,
   ],

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -44,6 +44,7 @@ import { DecentralizedStorageModule } from './decentralized-storage/decentralize
 import { ChatModule } from './chat/chat.module';
 import { ZkpModule } from './zkp/zkp.module';
 import { LoyaltyModule } from './loyalty/loyalty.module';
+import { TelemetryModule } from './telemetry/telemetry.module';
 import { InternalModule } from './common/internal.module';
 import { InternalRoutingModule } from './internal/internal.module';
 
@@ -131,6 +132,7 @@ import { InternalRoutingModule } from './internal/internal.module';
     ChatModule,
     ZkpModule,
     LoyaltyModule,
+    TelemetryModule,
     InternalModule,
     InternalRoutingModule,
   ],

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -46,6 +46,7 @@ import { ZkpModule } from './zkp/zkp.module';
 import { LoyaltyModule } from './loyalty/loyalty.module';
 import { TelemetryModule } from './telemetry/telemetry.module';
 import { MerchModule } from './merch/merch.module';
+import { TicketDesignModule } from './ticket-design/ticket-design.module';
 import { InternalModule } from './common/internal.module';
 import { InternalRoutingModule } from './internal/internal.module';
 
@@ -135,6 +136,7 @@ import { InternalRoutingModule } from './internal/internal.module';
     LoyaltyModule,
     TelemetryModule,
     MerchModule,
+    TicketDesignModule,
     InternalModule,
     InternalRoutingModule,
   ],

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -45,6 +45,7 @@ import { ChatModule } from './chat/chat.module';
 import { ZkpModule } from './zkp/zkp.module';
 import { LoyaltyModule } from './loyalty/loyalty.module';
 import { TelemetryModule } from './telemetry/telemetry.module';
+import { MerchModule } from './merch/merch.module';
 import { InternalModule } from './common/internal.module';
 import { InternalRoutingModule } from './internal/internal.module';
 
@@ -133,6 +134,7 @@ import { InternalRoutingModule } from './internal/internal.module';
     ZkpModule,
     LoyaltyModule,
     TelemetryModule,
+    MerchModule,
     InternalModule,
     InternalRoutingModule,
   ],

--- a/backend/src/merch/dto/create-merch-item.dto.ts
+++ b/backend/src/merch/dto/create-merch-item.dto.ts
@@ -1,0 +1,52 @@
+import { IsBoolean, IsEnum, IsIn, IsNotEmpty, IsNumber, IsOptional, IsString, Min, ValidateIf } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { TokenGateType } from '../entities/merch-item.entity';
+import { VipTierName } from '../../vip/entities/vip-tier.entity';
+
+export class CreateMerchItemDto {
+  @ApiProperty({ description: 'Merchandise item name', example: 'Limited Edition Tour Hoodie' })
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @ApiPropertyOptional({ description: 'Merchandise item description' })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ description: 'Price of the item', example: 45 })
+  @IsNumber()
+  @Min(0.01, { message: 'Price must be positive' })
+  price!: number;
+
+  @ApiPropertyOptional({ description: 'Currency code', default: 'USD' })
+  @IsOptional()
+  @IsString()
+  currency?: string;
+
+  @ApiProperty({ description: 'Total available stock', example: 100 })
+  @IsNumber()
+  @Min(0)
+  totalStock!: number;
+
+  @ApiPropertyOptional({ description: 'Whether this item is restricted to token holders', default: false })
+  @IsOptional()
+  @IsBoolean()
+  isTokenGated?: boolean;
+
+  @ApiPropertyOptional({ description: 'Type of token gate required to purchase', enum: ['ticket_nft', 'vip_badge'] })
+  @ValidateIf((dto: CreateMerchItemDto) => !!dto.isTokenGated)
+  @IsIn(['ticket_nft', 'vip_badge'])
+  gateType?: TokenGateType;
+
+  @ApiPropertyOptional({ description: 'Required ticket NFT asset code when gateType is ticket_nft' })
+  @ValidateIf((dto: CreateMerchItemDto) => dto.gateType === 'ticket_nft')
+  @IsString()
+  @IsNotEmpty()
+  requiredAssetCode?: string;
+
+  @ApiPropertyOptional({ description: 'Required VIP tier name when gateType is vip_badge', enum: VipTierName })
+  @ValidateIf((dto: CreateMerchItemDto) => dto.gateType === 'vip_badge')
+  @IsEnum(VipTierName)
+  requiredVipTier?: VipTierName;
+}

--- a/backend/src/merch/dto/purchase-merch.dto.ts
+++ b/backend/src/merch/dto/purchase-merch.dto.ts
@@ -1,0 +1,14 @@
+import { IsOptional, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class PurchaseMerchDto {
+  @ApiPropertyOptional({ description: 'Ticket id proving ownership of the required ticket NFT' })
+  @IsOptional()
+  @IsString()
+  ticketId?: string;
+
+  @ApiPropertyOptional({ description: 'Ticket id used to look up a VIP badge assignment' })
+  @IsOptional()
+  @IsString()
+  vipTicketId?: string;
+}

--- a/backend/src/merch/entities/merch-item.entity.ts
+++ b/backend/src/merch/entities/merch-item.entity.ts
@@ -1,0 +1,60 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Event } from '../../events/entities/event.entity';
+import { VipTierName } from '../../vip/entities/vip-tier.entity';
+
+export type TokenGateType = 'ticket_nft' | 'vip_badge';
+
+@Entity({ name: 'merch_items' })
+export class MerchItem {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column()
+  eventId!: string;
+
+  @ManyToOne(() => Event, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'eventId' })
+  event!: Event;
+
+  @Column({ type: 'varchar', length: 128 })
+  name!: string;
+
+  @Column({ type: 'text', nullable: true })
+  description!: string | null;
+
+  @Column({ type: 'decimal', precision: 18, scale: 7 })
+  price!: number;
+
+  @Column({ type: 'varchar', length: 16, default: 'USD' })
+  currency!: string;
+
+  @Column({ type: 'int' })
+  totalStock!: number;
+
+  @Column({ type: 'int', default: 0 })
+  reservedStock!: number;
+
+  @Column({ default: false })
+  isTokenGated!: boolean;
+
+  @Column({ type: 'varchar', length: 16, nullable: true })
+  gateType!: TokenGateType | null;
+
+  /** Required ticket NFT asset code, when gateType is 'ticket_nft'. */
+  @Column({ type: 'varchar', length: 32, nullable: true })
+  requiredAssetCode!: string | null;
+
+  /** Required VIP tier name, when gateType is 'vip_badge'. */
+  @Column({ type: 'varchar', length: 16, nullable: true })
+  requiredVipTier!: VipTierName | null;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/backend/src/merch/entities/merch-reservation.entity.ts
+++ b/backend/src/merch/entities/merch-reservation.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { MerchItem } from './merch-item.entity';
+
+export type MerchReservationStatus = 'reserved' | 'released' | 'purchased';
+
+@Entity({ name: 'merch_reservations' })
+export class MerchReservation {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column()
+  merchItemId!: string;
+
+  @ManyToOne(() => MerchItem, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'merchItemId' })
+  merchItem!: MerchItem;
+
+  @Column()
+  buyerId!: string;
+
+  /** Ticket or VIP assignment id used as proof of token-gate eligibility. */
+  @Column({ type: 'varchar', nullable: true })
+  proofId!: string | null;
+
+  @Column({ type: 'varchar', length: 16, default: 'reserved' })
+  status!: MerchReservationStatus;
+
+  @CreateDateColumn()
+  reservedAt!: Date;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  releasedAt!: Date | null;
+}

--- a/backend/src/merch/merch.controller.ts
+++ b/backend/src/merch/merch.controller.ts
@@ -1,0 +1,86 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { MerchService } from './merch.service';
+import { CreateMerchItemDto } from './dto/create-merch-item.dto';
+import { PurchaseMerchDto } from './dto/purchase-merch.dto';
+import { Roles, Role } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AuthenticatedRequest } from '../common/interfaces/authenticated-request.interface';
+
+@ApiTags('Token-Gated Merchandise')
+@Controller()
+export class MerchController {
+  constructor(private readonly merchService: MerchService) {}
+
+  @Post('events/:eventId/merch')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.ORGANIZER)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a merchandise item', description: 'Organizer-only. Optionally restrict the item to ticket NFT or VIP badge holders.' })
+  @ApiResponse({ status: 201, description: 'Merchandise item created' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  create(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+    @Body() dto: CreateMerchItemDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.merchService.createMerchItem(eventId, dto, req.user.id);
+  }
+
+  @Get('events/:eventId/merch')
+  @ApiOperation({ summary: 'List merchandise items', description: 'Public. Lists merchandise items for an event, including token-gating rules.' })
+  @ApiResponse({ status: 200, description: 'List of merchandise items' })
+  list(@Param('eventId', ParseUUIDPipe) eventId: string) {
+    return this.merchService.listMerchItems(eventId);
+  }
+
+  @Post('merch/:id/verify-eligibility')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Verify token-gate eligibility', description: 'Checks whether the caller holds the ticket NFT or VIP badge required to purchase a merch item.' })
+  @ApiResponse({ status: 200, description: 'Eligibility result' })
+  verifyEligibility(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: PurchaseMerchDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.merchService.verifyTokenGateEligibility(id, req.user.id, dto);
+  }
+
+  @Post('merch/:id/purchase')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Purchase a token-gated merchandise item', description: 'Verifies eligibility, then reserves stock for the buyer.' })
+  @ApiResponse({ status: 201, description: 'Purchase reservation created' })
+  @ApiResponse({ status: 403, description: 'Not eligible for this token-gated item' })
+  @ApiResponse({ status: 400, description: 'Item out of stock' })
+  purchase(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: PurchaseMerchDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.merchService.restrictMerchPurchase(id, req.user.id, dto);
+  }
+
+  @Post('merch/reservations/:id/release')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Release a token-gate reservation', description: 'Buyer or organizer only. Releases a reserved hold and returns stock to the pool.' })
+  @ApiResponse({ status: 200, description: 'Reservation released' })
+  release(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.merchService.releaseTokenGate(id, req.user.id);
+  }
+}

--- a/backend/src/merch/merch.module.ts
+++ b/backend/src/merch/merch.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MerchService } from './merch.service';
+import { MerchController } from './merch.controller';
+import { MerchItem } from './entities/merch-item.entity';
+import { MerchReservation } from './entities/merch-reservation.entity';
+import { EventsModule } from '../events/events.module';
+import { TicketsModule } from '../tickets/tickets.module';
+import { VipModule } from '../vip/vip.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([MerchItem, MerchReservation]),
+    EventsModule,
+    TicketsModule,
+    VipModule,
+  ],
+  controllers: [MerchController],
+  providers: [MerchService],
+  exports: [MerchService],
+})
+export class MerchModule {}

--- a/backend/src/merch/merch.service.ts
+++ b/backend/src/merch/merch.service.ts
@@ -1,0 +1,182 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { MerchItem } from './entities/merch-item.entity';
+import {
+  MerchReservation,
+  MerchReservationStatus,
+} from './entities/merch-reservation.entity';
+import { CreateMerchItemDto } from './dto/create-merch-item.dto';
+import { PurchaseMerchDto } from './dto/purchase-merch.dto';
+import { EventsService } from '../events/events.service';
+import { TicketsService } from '../tickets/tickets.service';
+import { VipService } from '../vip/vip.service';
+
+export interface TokenGateEligibilityResult {
+  eligible: boolean;
+  reason?: string;
+}
+
+@Injectable()
+export class MerchService {
+  constructor(
+    @InjectRepository(MerchItem)
+    private readonly merchItemRepository: Repository<MerchItem>,
+    @InjectRepository(MerchReservation)
+    private readonly reservationRepository: Repository<MerchReservation>,
+    private readonly eventsService: EventsService,
+    private readonly ticketsService: TicketsService,
+    private readonly vipService: VipService,
+  ) {}
+
+  async createMerchItem(
+    eventId: string,
+    dto: CreateMerchItemDto,
+    requesterId: string,
+  ): Promise<MerchItem> {
+    await this.assertOrganizer(eventId, requesterId);
+
+    const item = this.merchItemRepository.create({
+      ...dto,
+      eventId,
+      currency: dto.currency ?? 'USD',
+      isTokenGated: dto.isTokenGated ?? false,
+      gateType: dto.isTokenGated ? dto.gateType ?? null : null,
+      requiredAssetCode: dto.gateType === 'ticket_nft' ? dto.requiredAssetCode ?? null : null,
+      requiredVipTier: dto.gateType === 'vip_badge' ? dto.requiredVipTier ?? null : null,
+    });
+    return this.merchItemRepository.save(item);
+  }
+
+  async listMerchItems(eventId: string): Promise<MerchItem[]> {
+    return this.merchItemRepository.find({ where: { eventId } });
+  }
+
+  async verifyTokenGateEligibility(
+    merchItemId: string,
+    buyerId: string,
+    proof: PurchaseMerchDto,
+  ): Promise<TokenGateEligibilityResult> {
+    const merchItem = await this.getMerchItemById(merchItemId);
+
+    if (!merchItem.isTokenGated) {
+      return { eligible: true };
+    }
+
+    if (merchItem.gateType === 'ticket_nft') {
+      if (!proof.ticketId) {
+        return { eligible: false, reason: 'A ticket id is required to verify token-gate eligibility' };
+      }
+      const ticket = await this.ticketsService.getTicketById(proof.ticketId);
+      if (ticket.ownerId !== buyerId) {
+        return { eligible: false, reason: 'Ticket is not owned by the buyer' };
+      }
+      if (ticket.eventId !== merchItem.eventId) {
+        return { eligible: false, reason: 'Ticket does not belong to this event' };
+      }
+      if (ticket.assetCode !== merchItem.requiredAssetCode) {
+        return { eligible: false, reason: `Requires ticket NFT "${merchItem.requiredAssetCode}"` };
+      }
+      return { eligible: true };
+    }
+
+    if (merchItem.gateType === 'vip_badge') {
+      if (!proof.vipTicketId) {
+        return { eligible: false, reason: 'A VIP ticket id is required to verify token-gate eligibility' };
+      }
+      const ticket = await this.ticketsService.getTicketById(proof.vipTicketId);
+      if (ticket.ownerId !== buyerId) {
+        return { eligible: false, reason: 'Ticket is not owned by the buyer' };
+      }
+      const hasAccess = await this.vipService.validateAccess(
+        proof.vipTicketId,
+        merchItem.requiredVipTier as string,
+      );
+      if (!hasAccess) {
+        return { eligible: false, reason: `Requires VIP tier "${merchItem.requiredVipTier}" badge` };
+      }
+      return { eligible: true };
+    }
+
+    return { eligible: false, reason: 'Unsupported token gate type' };
+  }
+
+  async restrictMerchPurchase(
+    merchItemId: string,
+    buyerId: string,
+    proof: PurchaseMerchDto,
+  ): Promise<MerchReservation> {
+    const merchItem = await this.getMerchItemById(merchItemId);
+
+    const eligibility = await this.verifyTokenGateEligibility(merchItemId, buyerId, proof);
+    if (!eligibility.eligible) {
+      throw new ForbiddenException(eligibility.reason ?? 'Not eligible to purchase this item');
+    }
+
+    if (merchItem.reservedStock >= merchItem.totalStock) {
+      throw new BadRequestException('Merchandise item is out of stock');
+    }
+
+    merchItem.reservedStock += 1;
+    await this.merchItemRepository.save(merchItem);
+
+    const reservation = this.reservationRepository.create({
+      merchItemId,
+      buyerId,
+      proofId: proof.ticketId ?? proof.vipTicketId ?? null,
+      status: 'reserved' as MerchReservationStatus,
+    });
+    return this.reservationRepository.save(reservation);
+  }
+
+  async releaseTokenGate(
+    reservationId: string,
+    requesterId: string,
+  ): Promise<MerchReservation> {
+    const reservation = await this.reservationRepository.findOne({
+      where: { id: reservationId },
+      relations: ['merchItem'],
+    });
+    if (!reservation) {
+      throw new NotFoundException(`Reservation "${reservationId}" not found`);
+    }
+
+    if (reservation.status !== 'reserved') {
+      throw new BadRequestException('Only reserved holds can be released');
+    }
+
+    const isBuyer = reservation.buyerId === requesterId;
+    if (!isBuyer) {
+      await this.assertOrganizer(reservation.merchItem.eventId, requesterId);
+    }
+
+    reservation.status = 'released';
+    reservation.releasedAt = new Date();
+
+    reservation.merchItem.reservedStock = Math.max(
+      0,
+      reservation.merchItem.reservedStock - 1,
+    );
+    await this.merchItemRepository.save(reservation.merchItem);
+
+    return this.reservationRepository.save(reservation);
+  }
+
+  async getMerchItemById(id: string): Promise<MerchItem> {
+    const item = await this.merchItemRepository.findOne({ where: { id } });
+    if (!item) throw new NotFoundException(`Merchandise item "${id}" not found`);
+    return item;
+  }
+
+  private async assertOrganizer(eventId: string, requesterId: string): Promise<void> {
+    const event = await this.eventsService.getEventById(eventId);
+    if (event.organizerId !== requesterId) {
+      throw new ForbiddenException('Only the event organizer can manage merchandise');
+    }
+  }
+}

--- a/backend/src/scan-analytics/dto/record-gate-scan.dto.ts
+++ b/backend/src/scan-analytics/dto/record-gate-scan.dto.ts
@@ -1,0 +1,14 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RecordGateScanDto {
+  @ApiProperty({ description: 'Identifier of the entry gate that performed the scan', example: 'Gate A' })
+  @IsString()
+  @IsNotEmpty()
+  gateId!: string;
+
+  @ApiProperty({ description: 'Id of the ticket that was scanned', example: 'b3f1c2b0-...' })
+  @IsString()
+  @IsNotEmpty()
+  ticketId!: string;
+}

--- a/backend/src/scan-analytics/entities/scan-event.entity.ts
+++ b/backend/src/scan-analytics/entities/scan-event.entity.ts
@@ -1,0 +1,30 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Index(['eventId', 'gateId', 'scannedAt'])
+@Entity({ name: 'scan_events' })
+export class ScanEvent {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Index()
+  @Column({ type: 'varchar', length: 128 })
+  eventId!: string;
+
+  @Column({ type: 'varchar', length: 64 })
+  gateId!: string;
+
+  @Column({ type: 'varchar', length: 128 })
+  ticketId!: string;
+
+  @Column({ type: 'varchar', length: 128, nullable: true })
+  scannedBy!: string | null;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  scannedAt!: Date;
+}

--- a/backend/src/scan-analytics/scan-analytics.controller.ts
+++ b/backend/src/scan-analytics/scan-analytics.controller.ts
@@ -1,0 +1,90 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ScanAnalyticsService } from './scan-analytics.service';
+import { RecordGateScanDto } from './dto/record-gate-scan.dto';
+import { Roles, Role } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AuthenticatedRequest } from '../common/interfaces/authenticated-request.interface';
+
+@ApiTags('Gate Scan Analytics')
+@ApiBearerAuth()
+@Controller('events/:eventId/scan-analytics')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@ApiResponse({ status: 401, description: 'Unauthorized' })
+@ApiResponse({ status: 403, description: 'Forbidden' })
+export class ScanAnalyticsController {
+  constructor(private readonly scanAnalyticsService: ScanAnalyticsService) {}
+
+  @Post('scans')
+  @Roles(Role.ORGANIZER, Role.ADMIN)
+  @ApiOperation({ summary: 'Record a gate scan', description: 'Organizer/Admin-only. Logs a check-in scan event for a gate.' })
+  @ApiResponse({ status: 201, description: 'Scan event recorded' })
+  recordScan(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+    @Body() dto: RecordGateScanDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.scanAnalyticsService.recordGateScan(eventId, dto, req.user.id);
+  }
+
+  @Get('velocity')
+  @Roles(Role.ORGANIZER)
+  @ApiOperation({ summary: 'Calculate scan velocity', description: 'Organizer-only. Scans-per-minute over a configurable window, optionally scoped to a single gate.' })
+  @ApiQuery({ name: 'gateId', required: false })
+  @ApiQuery({ name: 'windowMinutes', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Scan velocity result' })
+  calculateVelocity(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+    @Req() req: AuthenticatedRequest,
+    @Query('gateId') gateId?: string,
+    @Query('windowMinutes') windowMinutes?: string,
+  ) {
+    return this.scanAnalyticsService.calculateScanVelocity(
+      eventId,
+      req.user.id,
+      gateId,
+      windowMinutes ? Number(windowMinutes) : undefined,
+    );
+  }
+
+  @Get('throughput')
+  @Roles(Role.ORGANIZER)
+  @ApiOperation({ summary: 'Track gate throughput', description: 'Organizer-only. Per-gate scan throughput to help optimize staffing.' })
+  @ApiQuery({ name: 'windowMinutes', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Per-gate throughput stats' })
+  trackThroughput(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+    @Req() req: AuthenticatedRequest,
+    @Query('windowMinutes') windowMinutes?: string,
+  ) {
+    return this.scanAnalyticsService.trackGateThroughput(
+      eventId,
+      req.user.id,
+      windowMinutes ? Number(windowMinutes) : undefined,
+    );
+  }
+
+  @Get('realtime')
+  @Roles(Role.ORGANIZER)
+  @ApiOperation({ summary: 'Fetch real-time scan speed', description: 'Organizer-only. Live scans-per-minute over the last 60 seconds.' })
+  @ApiQuery({ name: 'gateId', required: false })
+  @ApiResponse({ status: 200, description: 'Real-time scan speed' })
+  fetchRealtimeSpeed(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+    @Req() req: AuthenticatedRequest,
+    @Query('gateId') gateId?: string,
+  ) {
+    return this.scanAnalyticsService.fetchRealtimeScanSpeed(eventId, req.user.id, gateId);
+  }
+}

--- a/backend/src/scan-analytics/scan-analytics.module.ts
+++ b/backend/src/scan-analytics/scan-analytics.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScanAnalyticsService } from './scan-analytics.service';
+import { ScanAnalyticsController } from './scan-analytics.controller';
+import { ScanEvent } from './entities/scan-event.entity';
+import { EventsModule } from '../events/events.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ScanEvent]), EventsModule],
+  controllers: [ScanAnalyticsController],
+  providers: [ScanAnalyticsService],
+  exports: [ScanAnalyticsService],
+})
+export class ScanAnalyticsModule {}

--- a/backend/src/scan-analytics/scan-analytics.service.ts
+++ b/backend/src/scan-analytics/scan-analytics.service.ts
@@ -1,0 +1,154 @@
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { MoreThanOrEqual, Repository } from 'typeorm';
+import { ScanEvent } from './entities/scan-event.entity';
+import { RecordGateScanDto } from './dto/record-gate-scan.dto';
+import { EventsService } from '../events/events.service';
+
+export interface ScanVelocityResult {
+  eventId: string;
+  gateId: string | null;
+  windowMinutes: number;
+  scanCount: number;
+  scansPerMinute: number;
+}
+
+export interface GateThroughputStat {
+  gateId: string;
+  totalScans: number;
+  scansInWindow: number;
+  scansPerMinute: number;
+}
+
+export interface RealtimeScanSpeed {
+  eventId: string;
+  gateId: string | null;
+  scanCount: number;
+  scansPerMinute: number;
+  measuredAt: Date;
+}
+
+const REALTIME_WINDOW_SECONDS = 60;
+
+@Injectable()
+export class ScanAnalyticsService {
+  constructor(
+    @InjectRepository(ScanEvent)
+    private readonly scanEventRepository: Repository<ScanEvent>,
+    private readonly eventsService: EventsService,
+  ) {}
+
+  async recordGateScan(
+    eventId: string,
+    dto: RecordGateScanDto,
+    scannedBy?: string,
+  ): Promise<ScanEvent> {
+    const scan = this.scanEventRepository.create({
+      eventId,
+      gateId: dto.gateId,
+      ticketId: dto.ticketId,
+      scannedBy: scannedBy ?? null,
+    });
+    return this.scanEventRepository.save(scan);
+  }
+
+  async calculateScanVelocity(
+    eventId: string,
+    requesterId: string,
+    gateId?: string,
+    windowMinutes = 5,
+  ): Promise<ScanVelocityResult> {
+    await this.assertOrganizer(eventId, requesterId);
+    const since = new Date(Date.now() - windowMinutes * 60 * 1000);
+
+    const scanCount = await this.scanEventRepository.count({
+      where: {
+        eventId,
+        ...(gateId ? { gateId } : {}),
+        scannedAt: MoreThanOrEqual(since),
+      },
+    });
+
+    return {
+      eventId,
+      gateId: gateId ?? null,
+      windowMinutes,
+      scanCount,
+      scansPerMinute: scanCount / windowMinutes,
+    };
+  }
+
+  async trackGateThroughput(
+    eventId: string,
+    requesterId: string,
+    windowMinutes = 15,
+  ): Promise<GateThroughputStat[]> {
+    await this.assertOrganizer(eventId, requesterId);
+    const since = new Date(Date.now() - windowMinutes * 60 * 1000);
+
+    const totals = await this.scanEventRepository
+      .createQueryBuilder('scan')
+      .select('scan.gateId', 'gateId')
+      .addSelect('COUNT(*)', 'totalScans')
+      .where('scan.eventId = :eventId', { eventId })
+      .groupBy('scan.gateId')
+      .getRawMany<{ gateId: string; totalScans: string }>();
+
+    const windowed = await this.scanEventRepository
+      .createQueryBuilder('scan')
+      .select('scan.gateId', 'gateId')
+      .addSelect('COUNT(*)', 'scansInWindow')
+      .where('scan.eventId = :eventId', { eventId })
+      .andWhere('scan.scannedAt >= :since', { since })
+      .groupBy('scan.gateId')
+      .getRawMany<{ gateId: string; scansInWindow: string }>();
+
+    const windowedByGate = new Map(
+      windowed.map((row) => [row.gateId, Number(row.scansInWindow)]),
+    );
+
+    return totals
+      .map((row) => {
+        const scansInWindow = windowedByGate.get(row.gateId) ?? 0;
+        return {
+          gateId: row.gateId,
+          totalScans: Number(row.totalScans),
+          scansInWindow,
+          scansPerMinute: scansInWindow / windowMinutes,
+        };
+      })
+      .sort((a, b) => b.scansPerMinute - a.scansPerMinute);
+  }
+
+  async fetchRealtimeScanSpeed(
+    eventId: string,
+    requesterId: string,
+    gateId?: string,
+  ): Promise<RealtimeScanSpeed> {
+    await this.assertOrganizer(eventId, requesterId);
+    const since = new Date(Date.now() - REALTIME_WINDOW_SECONDS * 1000);
+
+    const scanCount = await this.scanEventRepository.count({
+      where: {
+        eventId,
+        ...(gateId ? { gateId } : {}),
+        scannedAt: MoreThanOrEqual(since),
+      },
+    });
+
+    return {
+      eventId,
+      gateId: gateId ?? null,
+      scanCount,
+      scansPerMinute: scanCount * (60 / REALTIME_WINDOW_SECONDS),
+      measuredAt: new Date(),
+    };
+  }
+
+  private async assertOrganizer(eventId: string, requesterId: string): Promise<void> {
+    const event = await this.eventsService.getEventById(eventId);
+    if (event.organizerId !== requesterId) {
+      throw new ForbiddenException('Only the event organizer can view gate scan analytics');
+    }
+  }
+}

--- a/backend/src/telemetry/dto/record-metric-datapoint.dto.ts
+++ b/backend/src/telemetry/dto/record-metric-datapoint.dto.ts
@@ -1,0 +1,34 @@
+import { IsIn, IsNotEmpty, IsNumber, IsObject, IsOptional, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { TelemetryMetricType, TelemetryNodeStatus } from '../entities/telemetry-metric.entity';
+
+export class RecordMetricDatapointDto {
+  @ApiProperty({ description: 'Name of the service or node this datapoint belongs to', example: 'api-gateway' })
+  @IsString()
+  @IsNotEmpty()
+  service!: string;
+
+  @ApiPropertyOptional({ description: 'Type of metric being recorded', enum: ['ping_latency', 'custom'], default: 'custom' })
+  @IsOptional()
+  @IsIn(['ping_latency', 'custom'])
+  metricType?: TelemetryMetricType;
+
+  @ApiProperty({ description: 'Numeric value of the datapoint', example: 128.4 })
+  @IsNumber()
+  value!: number;
+
+  @ApiPropertyOptional({ description: 'Unit of measurement', example: 'ms', default: 'ms' })
+  @IsOptional()
+  @IsString()
+  unit?: string;
+
+  @ApiPropertyOptional({ description: 'Node status associated with this datapoint', enum: ['up', 'down', 'degraded'] })
+  @IsOptional()
+  @IsIn(['up', 'down', 'degraded'])
+  status?: TelemetryNodeStatus;
+
+  @ApiPropertyOptional({ description: 'Arbitrary metadata to attach to the datapoint' })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}

--- a/backend/src/telemetry/entities/telemetry-metric.entity.ts
+++ b/backend/src/telemetry/entities/telemetry-metric.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export type TelemetryServiceName = 'database' | 'redis' | 'stellar' | string;
+export type TelemetryMetricType = 'ping_latency' | 'custom';
+export type TelemetryNodeStatus = 'up' | 'down' | 'degraded';
+
+@Index(['service', 'recordedAt'])
+@Entity({ name: 'telemetry_metrics' })
+export class TelemetryMetric {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'varchar', length: 64 })
+  service!: TelemetryServiceName;
+
+  @Column({ type: 'varchar', length: 32, default: 'custom' })
+  metricType!: TelemetryMetricType;
+
+  @Column({ type: 'float' })
+  value!: number;
+
+  @Column({ type: 'varchar', length: 16, default: 'ms' })
+  unit!: string;
+
+  @Column({ type: 'varchar', length: 16, nullable: true })
+  status!: TelemetryNodeStatus | null;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata!: Record<string, unknown> | null;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  recordedAt!: Date;
+}

--- a/backend/src/telemetry/telemetry.controller.ts
+++ b/backend/src/telemetry/telemetry.controller.ts
@@ -1,0 +1,48 @@
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { TelemetryService } from './telemetry.service';
+import { RecordMetricDatapointDto } from './dto/record-metric-datapoint.dto';
+import { Roles, Role } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@ApiTags('Telemetry')
+@ApiBearerAuth()
+@Controller('telemetry')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.ADMIN)
+@ApiResponse({ status: 401, description: 'Unauthorized' })
+@ApiResponse({ status: 403, description: 'Forbidden' })
+export class TelemetryController {
+  constructor(private readonly telemetryService: TelemetryService) {}
+
+  @Get('status')
+  @ApiOperation({
+    summary: 'Fetch platform telemetry status',
+    description: 'Admin-only. Returns node ping results, average latency, uptime percentage, and recent datapoints.',
+  })
+  @ApiResponse({ status: 200, description: 'Telemetry status summary' })
+  fetchStatus() {
+    return this.telemetryService.fetchTelemetryStatus();
+  }
+
+  @Post('ping')
+  @ApiOperation({
+    summary: 'Ping system services',
+    description: 'Admin-only. Pings the database, Redis, and Stellar Horizon, recording latency datapoints.',
+  })
+  @ApiResponse({ status: 201, description: 'Ping results for all monitored services' })
+  ping() {
+    return this.telemetryService.pingSystemServices();
+  }
+
+  @Post('metrics')
+  @ApiOperation({
+    summary: 'Record a telemetry metric datapoint',
+    description: 'Admin-only. Persists a custom telemetry datapoint for dashboards.',
+  })
+  @ApiResponse({ status: 201, description: 'Metric datapoint recorded' })
+  recordMetric(@Body() dto: RecordMetricDatapointDto) {
+    return this.telemetryService.recordMetricDatapoint(dto);
+  }
+}

--- a/backend/src/telemetry/telemetry.module.ts
+++ b/backend/src/telemetry/telemetry.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TelemetryMetric } from './entities/telemetry-metric.entity';
+import { TelemetryService } from './telemetry.service';
+import { TelemetryController } from './telemetry.controller';
+import { StellarModule } from '../stellar/stellar.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([TelemetryMetric]), StellarModule],
+  controllers: [TelemetryController],
+  providers: [TelemetryService],
+  exports: [TelemetryService],
+})
+export class TelemetryModule {}

--- a/backend/src/telemetry/telemetry.service.ts
+++ b/backend/src/telemetry/telemetry.service.ts
@@ -1,0 +1,159 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { DataSource, Repository } from 'typeorm';
+import Redis from 'ioredis';
+import { StellarService } from '../stellar/stellar.service';
+import {
+  TelemetryMetric,
+  TelemetryNodeStatus,
+} from './entities/telemetry-metric.entity';
+import { RecordMetricDatapointDto } from './dto/record-metric-datapoint.dto';
+
+export interface ServicePingResult {
+  service: string;
+  status: TelemetryNodeStatus;
+  latencyMs: number;
+  checkedAt: Date;
+  error?: string;
+}
+
+export interface TelemetryStatusSummary {
+  nodes: ServicePingResult[];
+  averageLatencyMs: Record<string, number>;
+  uptimePercentage: Record<string, number>;
+  recentDatapoints: TelemetryMetric[];
+}
+
+@Injectable()
+export class TelemetryService {
+  private readonly logger = new Logger(TelemetryService.name);
+
+  constructor(
+    @InjectRepository(TelemetryMetric)
+    private readonly metricRepository: Repository<TelemetryMetric>,
+    private readonly dataSource: DataSource,
+    private readonly configService: ConfigService,
+    private readonly stellarService: StellarService,
+  ) {}
+
+  async pingSystemServices(): Promise<ServicePingResult[]> {
+    const results = await Promise.all([
+      this.pingService('database', () => this.dataSource.query('SELECT 1')),
+      this.pingService('redis', () => this.pingRedis()),
+      this.pingService('stellar', () => this.stellarService.checkConnectivity()),
+    ]);
+
+    await Promise.all(
+      results.map((result) =>
+        this.recordMetricDatapoint({
+          service: result.service,
+          metricType: 'ping_latency',
+          value: result.latencyMs,
+          unit: 'ms',
+          status: result.status,
+          metadata: result.error ? { error: result.error } : undefined,
+        }),
+      ),
+    );
+
+    return results;
+  }
+
+  async recordMetricDatapoint(
+    dto: RecordMetricDatapointDto,
+  ): Promise<TelemetryMetric> {
+    const datapoint = this.metricRepository.create({
+      service: dto.service,
+      metricType: dto.metricType ?? 'custom',
+      value: dto.value,
+      unit: dto.unit ?? 'ms',
+      status: dto.status ?? null,
+      metadata: dto.metadata ?? null,
+    });
+    return this.metricRepository.save(datapoint);
+  }
+
+  async fetchTelemetryStatus(): Promise<TelemetryStatusSummary> {
+    const nodes = await this.pingSystemServices();
+
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const recentMetrics = await this.metricRepository
+      .createQueryBuilder('metric')
+      .where('metric.recordedAt >= :since', { since })
+      .andWhere('metric.metricType = :metricType', {
+        metricType: 'ping_latency',
+      })
+      .getMany();
+
+    const averageLatencyMs: Record<string, number> = {};
+    const uptimePercentage: Record<string, number> = {};
+
+    const byService = new Map<string, TelemetryMetric[]>();
+    for (const metric of recentMetrics) {
+      const list = byService.get(metric.service) ?? [];
+      list.push(metric);
+      byService.set(metric.service, list);
+    }
+
+    for (const [service, metrics] of byService.entries()) {
+      const totalLatency = metrics.reduce((sum, m) => sum + m.value, 0);
+      averageLatencyMs[service] = totalLatency / metrics.length;
+
+      const upCount = metrics.filter((m) => m.status === 'up').length;
+      uptimePercentage[service] = (upCount / metrics.length) * 100;
+    }
+
+    const recentDatapoints = await this.metricRepository.find({
+      order: { recordedAt: 'DESC' },
+      take: 50,
+    });
+
+    return { nodes, averageLatencyMs, uptimePercentage, recentDatapoints };
+  }
+
+  private async pingService(
+    service: string,
+    check: () => Promise<unknown>,
+  ): Promise<ServicePingResult> {
+    const startedAt = Date.now();
+    try {
+      await check();
+      return {
+        service,
+        status: 'up',
+        latencyMs: Date.now() - startedAt,
+        checkedAt: new Date(),
+      };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Service unreachable';
+      this.logger.warn(`Ping failed for ${service}: ${message}`);
+      return {
+        service,
+        status: 'down',
+        latencyMs: Date.now() - startedAt,
+        checkedAt: new Date(),
+        error: message,
+      };
+    }
+  }
+
+  private async pingRedis(): Promise<void> {
+    const redis = new Redis({
+      host: this.configService.get<string>('REDIS_HOST') ?? 'localhost',
+      port: this.configService.get<number>('REDIS_PORT') ?? 6379,
+      connectTimeout: 2000,
+      lazyConnect: true,
+    });
+
+    try {
+      await redis.connect();
+      const pong = await redis.ping();
+      if (pong !== 'PONG') {
+        throw new Error('Redis ping did not return PONG');
+      }
+    } finally {
+      await redis.quit().catch(() => undefined);
+    }
+  }
+}

--- a/backend/src/ticket-design/dto/save-ticket-design.dto.ts
+++ b/backend/src/ticket-design/dto/save-ticket-design.dto.ts
@@ -1,0 +1,74 @@
+import { IsArray, IsEnum, IsHexColor, IsOptional, IsString, IsNotEmpty, ValidateIf, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { BackgroundPattern, TicketLayoutElement } from '../entities/ticket-design.entity';
+
+export class TicketLayoutElementDto implements TicketLayoutElement {
+  @ApiProperty({ description: 'Layout element identifier', example: 'qr_code' })
+  @IsString()
+  @IsNotEmpty()
+  key!: string;
+
+  @ApiProperty({ description: 'X position as a percentage of ticket width', example: 50 })
+  x!: number;
+
+  @ApiProperty({ description: 'Y position as a percentage of ticket height', example: 70 })
+  y!: number;
+
+  @ApiPropertyOptional({ description: 'Element width as a percentage of ticket width' })
+  @IsOptional()
+  width?: number;
+
+  @ApiPropertyOptional({ description: 'Element height as a percentage of ticket height' })
+  @IsOptional()
+  height?: number;
+}
+
+export class SaveTicketDesignDto {
+  @ApiProperty({ description: 'Name of this ticket design', example: 'Summer Fest — Neon Theme' })
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @ApiPropertyOptional({ enum: BackgroundPattern, description: 'Background pattern style', default: BackgroundPattern.SOLID })
+  @IsOptional()
+  @IsEnum(BackgroundPattern)
+  backgroundPattern?: BackgroundPattern;
+
+  @ApiPropertyOptional({ description: 'Custom background image URL, required when backgroundPattern is custom_image' })
+  @ValidateIf((dto: SaveTicketDesignDto) => dto.backgroundPattern === BackgroundPattern.CUSTOM_IMAGE)
+  @IsString()
+  @IsNotEmpty()
+  backgroundImageUrl?: string;
+
+  @ApiPropertyOptional({ description: 'Background color hex code', default: '#FFFFFF' })
+  @IsOptional()
+  @IsHexColor()
+  backgroundColor?: string;
+
+  @ApiPropertyOptional({ description: 'Text color hex code', default: '#000000' })
+  @IsOptional()
+  @IsHexColor()
+  textColor?: string;
+
+  @ApiPropertyOptional({ description: 'Accent color hex code', default: '#6366F1' })
+  @IsOptional()
+  @IsHexColor()
+  accentColor?: string;
+
+  @ApiPropertyOptional({ description: 'Organizer logo URL' })
+  @IsOptional()
+  @IsString()
+  logoUrl?: string;
+
+  @ApiPropertyOptional({ description: 'Positions of layout elements (QR code, title, logo, etc.)', type: [TicketLayoutElementDto] })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => TicketLayoutElementDto)
+  layout?: TicketLayoutElementDto[];
+
+  @ApiPropertyOptional({ description: 'Mark this design as the active design for the event', default: false })
+  @IsOptional()
+  isActive?: boolean;
+}

--- a/backend/src/ticket-design/entities/ticket-design.entity.ts
+++ b/backend/src/ticket-design/entities/ticket-design.entity.ts
@@ -1,0 +1,73 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Event } from '../../events/entities/event.entity';
+
+export enum BackgroundPattern {
+  SOLID = 'solid',
+  DOTS = 'dots',
+  WAVES = 'waves',
+  GRADIENT = 'gradient',
+  CUSTOM_IMAGE = 'custom_image',
+}
+
+export interface TicketLayoutElement {
+  key: string;
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+}
+
+@Entity({ name: 'ticket_designs' })
+export class TicketDesign {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column()
+  eventId!: string;
+
+  @ManyToOne(() => Event, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'eventId' })
+  event!: Event;
+
+  @Column({ type: 'varchar', length: 128 })
+  name!: string;
+
+  @Column({ type: 'enum', enum: BackgroundPattern, default: BackgroundPattern.SOLID })
+  backgroundPattern!: BackgroundPattern;
+
+  /** Required when backgroundPattern is CUSTOM_IMAGE. */
+  @Column({ type: 'varchar', nullable: true })
+  backgroundImageUrl!: string | null;
+
+  @Column({ type: 'varchar', length: 16, default: '#FFFFFF' })
+  backgroundColor!: string;
+
+  @Column({ type: 'varchar', length: 16, default: '#000000' })
+  textColor!: string;
+
+  @Column({ type: 'varchar', length: 16, default: '#6366F1' })
+  accentColor!: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  logoUrl!: string | null;
+
+  @Column({ type: 'jsonb', default: [] })
+  layout!: TicketLayoutElement[];
+
+  @Column({ default: false })
+  isActive!: boolean;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/backend/src/ticket-design/ticket-design.controller.ts
+++ b/backend/src/ticket-design/ticket-design.controller.ts
@@ -1,0 +1,76 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Put,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { TicketDesignService } from './ticket-design.service';
+import { SaveTicketDesignDto } from './dto/save-ticket-design.dto';
+import { Roles, Role } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AuthenticatedRequest } from '../common/interfaces/authenticated-request.interface';
+
+@ApiTags('Ticket Design')
+@Controller('events/:eventId/ticket-designs')
+export class TicketDesignController {
+  constructor(private readonly ticketDesignService: TicketDesignService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.ORGANIZER)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Save a new ticket design', description: 'Organizer-only. Creates a custom ticket visual layout with background, colors, and logo.' })
+  @ApiResponse({ status: 201, description: 'Ticket design saved' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  create(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+    @Body() dto: SaveTicketDesignDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.ticketDesignService.saveTicketDesign(eventId, dto, req.user.id);
+  }
+
+  @Put(':designId')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.ORGANIZER)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update an existing ticket design', description: 'Organizer-only. Updates an existing design.' })
+  @ApiResponse({ status: 200, description: 'Ticket design updated' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
+  update(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+    @Param('designId', ParseUUIDPipe) designId: string,
+    @Body() dto: SaveTicketDesignDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.ticketDesignService.saveTicketDesign(eventId, dto, req.user.id, designId);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List ticket designs', description: 'Public. Lists all saved ticket designs for an event.' })
+  @ApiResponse({ status: 200, description: 'List of ticket designs' })
+  list(@Param('eventId', ParseUUIDPipe) eventId: string) {
+    return this.ticketDesignService.listDesigns(eventId);
+  }
+
+  @Get(':designId/render')
+  @ApiOperation({ summary: 'Render a ticket layout', description: 'Public. Compiles a saved design into a render-ready layout with resolved background CSS.' })
+  @ApiResponse({ status: 200, description: 'Rendered ticket layout' })
+  render(@Param('designId', ParseUUIDPipe) designId: string) {
+    return this.ticketDesignService.renderTicketLayout(designId);
+  }
+
+  @Get('themes')
+  @ApiOperation({ summary: 'Compile all design themes', description: 'Public. Compiles every saved design for an event into ready-to-preview themes.' })
+  @ApiResponse({ status: 200, description: 'Compiled design themes' })
+  compileThemes(@Param('eventId', ParseUUIDPipe) eventId: string) {
+    return this.ticketDesignService.compileDesignThemes(eventId);
+  }
+}

--- a/backend/src/ticket-design/ticket-design.module.ts
+++ b/backend/src/ticket-design/ticket-design.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TicketDesignService } from './ticket-design.service';
+import { TicketDesignController } from './ticket-design.controller';
+import { TicketDesign } from './entities/ticket-design.entity';
+import { EventsModule } from '../events/events.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([TicketDesign]), EventsModule],
+  controllers: [TicketDesignController],
+  providers: [TicketDesignService],
+  exports: [TicketDesignService],
+})
+export class TicketDesignModule {}

--- a/backend/src/ticket-design/ticket-design.service.ts
+++ b/backend/src/ticket-design/ticket-design.service.ts
@@ -1,0 +1,143 @@
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  BackgroundPattern,
+  TicketDesign,
+} from './entities/ticket-design.entity';
+import { SaveTicketDesignDto } from './dto/save-ticket-design.dto';
+import { EventsService } from '../events/events.service';
+
+export interface RenderedTicketLayout {
+  designId: string;
+  eventId: string;
+  name: string;
+  background: {
+    pattern: BackgroundPattern;
+    color: string;
+    imageUrl: string | null;
+    css: string;
+  };
+  colors: {
+    text: string;
+    accent: string;
+  };
+  logoUrl: string | null;
+  layout: TicketDesign['layout'];
+}
+
+const PATTERN_CSS: Record<BackgroundPattern, (color: string, accent: string) => string> = {
+  [BackgroundPattern.SOLID]: (color) => `background-color: ${color};`,
+  [BackgroundPattern.DOTS]: (color, accent) =>
+    `background-color: ${color}; background-image: radial-gradient(${accent} 1px, transparent 1px); background-size: 12px 12px;`,
+  [BackgroundPattern.WAVES]: (color, accent) =>
+    `background-color: ${color}; background-image: repeating-linear-gradient(45deg, ${accent} 0, ${accent} 2px, transparent 2px, transparent 12px);`,
+  [BackgroundPattern.GRADIENT]: (color, accent) =>
+    `background: linear-gradient(135deg, ${color}, ${accent});`,
+  [BackgroundPattern.CUSTOM_IMAGE]: (color) => `background-color: ${color};`,
+};
+
+@Injectable()
+export class TicketDesignService {
+  constructor(
+    @InjectRepository(TicketDesign)
+    private readonly designRepository: Repository<TicketDesign>,
+    private readonly eventsService: EventsService,
+  ) {}
+
+  async saveTicketDesign(
+    eventId: string,
+    dto: SaveTicketDesignDto,
+    requesterId: string,
+    designId?: string,
+  ): Promise<TicketDesign> {
+    await this.assertOrganizer(eventId, requesterId);
+
+    const design = designId
+      ? await this.getDesignById(designId)
+      : this.designRepository.create({ eventId });
+
+    if (designId && design.eventId !== eventId) {
+      throw new ForbiddenException('Design does not belong to this event');
+    }
+
+    Object.assign(design, {
+      name: dto.name,
+      backgroundPattern: dto.backgroundPattern ?? design.backgroundPattern ?? BackgroundPattern.SOLID,
+      backgroundImageUrl: dto.backgroundImageUrl ?? design.backgroundImageUrl ?? null,
+      backgroundColor: dto.backgroundColor ?? design.backgroundColor ?? '#FFFFFF',
+      textColor: dto.textColor ?? design.textColor ?? '#000000',
+      accentColor: dto.accentColor ?? design.accentColor ?? '#6366F1',
+      logoUrl: dto.logoUrl ?? design.logoUrl ?? null,
+      layout: dto.layout ?? design.layout ?? [],
+      isActive: dto.isActive ?? design.isActive ?? false,
+    });
+
+    const saved = await this.designRepository.save(design);
+
+    if (saved.isActive) {
+      await this.designRepository
+        .createQueryBuilder()
+        .update(TicketDesign)
+        .set({ isActive: false })
+        .where('eventId = :eventId AND id != :id', { eventId, id: saved.id })
+        .execute();
+    }
+
+    return saved;
+  }
+
+  async renderTicketLayout(designId: string): Promise<RenderedTicketLayout> {
+    const design = await this.getDesignById(designId);
+
+    const cssBuilder = PATTERN_CSS[design.backgroundPattern];
+    const css =
+      design.backgroundPattern === BackgroundPattern.CUSTOM_IMAGE && design.backgroundImageUrl
+        ? `background-image: url(${design.backgroundImageUrl}); background-size: cover;`
+        : cssBuilder(design.backgroundColor, design.accentColor);
+
+    return {
+      designId: design.id,
+      eventId: design.eventId,
+      name: design.name,
+      background: {
+        pattern: design.backgroundPattern,
+        color: design.backgroundColor,
+        imageUrl: design.backgroundImageUrl,
+        css,
+      },
+      colors: {
+        text: design.textColor,
+        accent: design.accentColor,
+      },
+      logoUrl: design.logoUrl,
+      layout: design.layout,
+    };
+  }
+
+  async compileDesignThemes(eventId: string): Promise<RenderedTicketLayout[]> {
+    const designs = await this.designRepository.find({
+      where: { eventId },
+      order: { createdAt: 'ASC' },
+    });
+
+    return Promise.all(designs.map((design) => this.renderTicketLayout(design.id)));
+  }
+
+  async listDesigns(eventId: string): Promise<TicketDesign[]> {
+    return this.designRepository.find({ where: { eventId } });
+  }
+
+  async getDesignById(id: string): Promise<TicketDesign> {
+    const design = await this.designRepository.findOne({ where: { id } });
+    if (!design) throw new NotFoundException(`Ticket design "${id}" not found`);
+    return design;
+  }
+
+  private async assertOrganizer(eventId: string, requesterId: string): Promise<void> {
+    const event = await this.eventsService.getEventById(eventId);
+    if (event.organizerId !== requesterId) {
+      throw new ForbiddenException('Only the event organizer can manage ticket designs');
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **Platform telemetry**: New `telemetry` module for real-time platform health and uptime monitoring. Pings DB/Redis/Stellar and stores latency datapoints for dashboards.
  - `ping_system_services`, `record_metric_datapoint`, `fetch_telemetry_status`
  - `POST /telemetry/ping`, `POST /telemetry/metrics`, `GET /telemetry/status` (admin-only)

- **Token-gated merchandise**: New `merch` module restricting merchandise purchases to holders of a specific ticket NFT (by asset code) or VIP badge (by tier), with stock-holding reservations.
  - `verify_token_gate_eligibility`, `restrict_merch_purchase`, `release_token_gate`
  - `POST/GET /events/:eventId/merch`, `POST /merch/:id/verify-eligibility`, `POST /merch/:id/purchase`, `POST /merch/reservations/:id/release`

- **Dynamic ticket design builder**: New `ticket-design` module letting organizers save custom ticket layouts (background patterns, colors, logo) and compile them into render-ready themes.
  - `save_ticket_design`, `render_ticket_layout`, `compile_design_themes`
  - `POST/PUT /events/:eventId/ticket-designs`, `GET /events/:eventId/ticket-designs/:designId/render`, `GET /events/:eventId/ticket-designs/themes`

- **Gate scan velocity dashboard**: New `scan-analytics` module logging check-in scan events per gate and exposing organizer-facing throughput/velocity stats to inform staffing decisions.
  - `calculate_scan_velocity`, `track_gate_throughput`, `fetch_realtime_scan_speed`
  - `POST /events/:eventId/scan-analytics/scans`, `GET .../velocity`, `GET .../throughput`, `GET .../realtime`

Closes #900 
Closes #901 
Closes #902 
Closes #903 
