### PR TITLE
feat: developer API reference + anonymous surveys, schedule voting, and promo codes

### DIFF
--- a/contract/src/error.rs
+++ b/contract/src/error.rs
@@ -336,4 +336,22 @@ pub enum LumentixError {
     EmptySurveyAnswers = 205,
     /// Every survey rating must be between 1 and 5
     InvalidSurveyRating = 206,
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Decentralized Schedule Voting errors (207–213)
+    // ═══════════════════════════════════════════════════════════════════════
+    /// A schedule vote needs at least two candidates to be meaningful
+    InsufficientScheduleCandidates = 207,
+    /// Schedule vote with the given ID does not exist
+    ScheduleVoteNotFound = 208,
+    /// Voting deadline for this schedule vote has passed
+    ScheduleVotingClosed = 209,
+    /// Schedule vote cannot be tallied before its voting deadline
+    ScheduleVotingStillActive = 210,
+    /// This ticket holder has already voted on this schedule slot
+    ScheduleVoteAlreadyCast = 211,
+    /// Caller does not hold a ticket for the event being voted on
+    ScheduleVoterNotTicketHolder = 212,
+    /// Candidate index is out of range for this schedule vote
+    InvalidScheduleCandidateIndex = 213,
 }

--- a/contract/src/error.rs
+++ b/contract/src/error.rs
@@ -324,4 +324,16 @@ pub enum LumentixError {
     // ═══════════════════════════════════════════════════════════════════════
     /// Not enough historical sales data points were provided to produce a forecast
     InsufficientSalesHistory = 202,
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Anonymous Event Feedback Survey errors (203–206)
+    // ═══════════════════════════════════════════════════════════════════════
+    /// This ticket has already submitted a survey response for this event
+    SurveyAlreadySubmitted = 203,
+    /// No survey responses exist yet for this event
+    NoSurveyResponses = 204,
+    /// Survey submission must include at least one rating
+    EmptySurveyAnswers = 205,
+    /// Every survey rating must be between 1 and 5
+    InvalidSurveyRating = 206,
 }

--- a/contract/src/error.rs
+++ b/contract/src/error.rs
@@ -354,4 +354,22 @@ pub enum LumentixError {
     ScheduleVoterNotTicketHolder = 212,
     /// Candidate index is out of range for this schedule vote
     InvalidScheduleCandidateIndex = 213,
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Promo Code errors (214–220)
+    // ═══════════════════════════════════════════════════════════════════════
+    /// Promo code does not exist for this event
+    PromoCodeNotFound = 214,
+    /// A promo code with this name already exists for this event
+    PromoCodeAlreadyExists = 215,
+    /// Promo code's expiration date has passed
+    PromoCodeExpired = 216,
+    /// Promo code has been deactivated by the organizer
+    PromoCodeInactive = 217,
+    /// Promo code has reached its maximum total number of uses
+    PromoCodeGlobalLimitReached = 218,
+    /// Caller has already used this promo code the maximum number of times
+    PromoCodeUserLimitReached = 219,
+    /// Discount basis points must be between 1 and 10000
+    InvalidPromoDiscount = 220,
 }

--- a/contract/src/events/mod.rs
+++ b/contract/src/events/mod.rs
@@ -1629,3 +1629,51 @@ impl ScheduleVoteFinalized {
         );
     }
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Promo Codes with Usage Limits
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Emitted when an organizer creates a new promo code for an event
+pub struct PromoCodeCreated;
+impl PromoCodeCreated {
+    pub fn emit(
+        env: &Env,
+        event_id: u64,
+        code: String,
+        discount_bps: u32,
+        expires_at: u64,
+        max_global_uses: u32,
+        max_uses_per_user: u32,
+    ) {
+        env.events().publish(
+            (symbol_short!("promocrea"),),
+            (
+                event_id,
+                code,
+                discount_bps,
+                expires_at,
+                max_global_uses,
+                max_uses_per_user,
+            ),
+        );
+    }
+}
+
+/// Emitted when a promo code discount is applied to a purchase
+pub struct PromoCodeApplied;
+impl PromoCodeApplied {
+    pub fn emit(
+        env: &Env,
+        event_id: u64,
+        code: String,
+        user: Address,
+        original_amount: i128,
+        discounted_amount: i128,
+    ) {
+        env.events().publish(
+            (symbol_short!("promoappl"),),
+            (event_id, code, user, original_amount, discounted_amount),
+        );
+    }
+}

--- a/contract/src/events/mod.rs
+++ b/contract/src/events/mod.rs
@@ -1585,3 +1585,47 @@ impl SurveyResultsCompiled {
         );
     }
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Decentralized Community Voting for Event Schedules
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Emitted when a new schedule slot vote is opened for an event
+pub struct ScheduleVoteInitialized;
+impl ScheduleVoteInitialized {
+    pub fn emit(
+        env: &Env,
+        vote_id: u64,
+        event_id: u64,
+        slot_name: String,
+        candidate_count: u32,
+        voting_deadline: u64,
+    ) {
+        env.events().publish(
+            (symbol_short!("schedinit"),),
+            (vote_id, event_id, slot_name, candidate_count, voting_deadline),
+        );
+    }
+}
+
+/// Emitted when a ticket holder casts a vote on a schedule slot
+pub struct ScheduleVoteCast;
+impl ScheduleVoteCast {
+    pub fn emit(env: &Env, vote_id: u64, voter: Address, candidate_index: u32, new_count: u32) {
+        env.events().publish(
+            (symbol_short!("schedcast"),),
+            (vote_id, voter, candidate_index, new_count),
+        );
+    }
+}
+
+/// Emitted when a schedule vote is finalized and a winning candidate is set
+pub struct ScheduleVoteFinalized;
+impl ScheduleVoteFinalized {
+    pub fn emit(env: &Env, vote_id: u64, event_id: u64, winning_candidate: String, votes: u32) {
+        env.events().publish(
+            (symbol_short!("schedfin"),),
+            (vote_id, event_id, winning_candidate, votes),
+        );
+    }
+}

--- a/contract/src/events/mod.rs
+++ b/contract/src/events/mod.rs
@@ -1557,3 +1557,31 @@ impl CertificationStandardUpdated {
             .publish((symbol_short!("certstd"),), (standard, enabled));
     }
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Anonymous Event Feedback Surveys
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Emitted when an anonymous survey response is submitted. Intentionally
+/// carries no respondent identity — only the aggregate shape of the
+/// response — to preserve the anonymity of the on-chain record.
+pub struct AnonymousSurveySubmitted;
+impl AnonymousSurveySubmitted {
+    pub fn emit(env: &Env, survey_id: u64, event_id: u64, question_count: u32, timestamp: u64) {
+        env.events().publish(
+            (symbol_short!("survsubm"),),
+            (survey_id, event_id, question_count, timestamp),
+        );
+    }
+}
+
+/// Emitted when aggregated survey results are compiled for an event
+pub struct SurveyResultsCompiled;
+impl SurveyResultsCompiled {
+    pub fn emit(env: &Env, event_id: u64, total_responses: u32, timestamp: u64) {
+        env.events().publish(
+            (symbol_short!("survcomp"),),
+            (event_id, total_responses, timestamp),
+        );
+    }
+}

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -256,6 +256,7 @@ mod certification_analytics_tests;
 pub use contract::TicketContract;
 pub use error::LumentixError;
 pub use events::{
+    AnonymousSurveySubmitted, SurveyResultsCompiled,
     AttendanceMemorabiliaMinted, AttendanceVerificationFailed, AttendanceVerified,
     BlockchainIdentityVerified,
     BridgeTransactionValidated, CarbonFootprintCalculated, CarbonOffsetPurchased,
@@ -280,6 +281,7 @@ pub use events::{
 pub use lumentix_contract::LumentixContract;
 pub use models::{DataKey, EscrowConfig, EventAuth, Ticket as TicketModel, ValidatorKey};
 pub use types::{
+    AnonymousSurveyResponse, SurveyResults,
     BridgeTransaction, CancellationReason, CarbonFootprint, CarbonOffsetPurchase,
     CollectibleInventory, CrossChainTransfer, CrossChainTransferStatus, EnvironmentalImpact,
     Event, EventMerchandise, EventReview, EventStatus, IdentityCredential, IdentityProof,

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -258,6 +258,7 @@ pub use error::LumentixError;
 pub use events::{
     AnonymousSurveySubmitted, SurveyResultsCompiled,
     ScheduleVoteCast, ScheduleVoteFinalized, ScheduleVoteInitialized,
+    PromoCodeApplied, PromoCodeCreated,
     AttendanceMemorabiliaMinted, AttendanceVerificationFailed, AttendanceVerified,
     BlockchainIdentityVerified,
     BridgeTransactionValidated, CarbonFootprintCalculated, CarbonOffsetPurchased,
@@ -284,6 +285,7 @@ pub use models::{DataKey, EscrowConfig, EventAuth, Ticket as TicketModel, Valida
 pub use types::{
     AnonymousSurveyResponse, SurveyResults,
     ScheduleVote, ScheduleVoteCastRecord,
+    PromoCode,
     BridgeTransaction, CancellationReason, CarbonFootprint, CarbonOffsetPurchase,
     CollectibleInventory, CrossChainTransfer, CrossChainTransferStatus, EnvironmentalImpact,
     Event, EventMerchandise, EventReview, EventStatus, IdentityCredential, IdentityProof,

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -257,6 +257,7 @@ pub use contract::TicketContract;
 pub use error::LumentixError;
 pub use events::{
     AnonymousSurveySubmitted, SurveyResultsCompiled,
+    ScheduleVoteCast, ScheduleVoteFinalized, ScheduleVoteInitialized,
     AttendanceMemorabiliaMinted, AttendanceVerificationFailed, AttendanceVerified,
     BlockchainIdentityVerified,
     BridgeTransactionValidated, CarbonFootprintCalculated, CarbonOffsetPurchased,
@@ -282,6 +283,7 @@ pub use lumentix_contract::LumentixContract;
 pub use models::{DataKey, EscrowConfig, EventAuth, Ticket as TicketModel, ValidatorKey};
 pub use types::{
     AnonymousSurveyResponse, SurveyResults,
+    ScheduleVote, ScheduleVoteCastRecord,
     BridgeTransaction, CancellationReason, CarbonFootprint, CarbonOffsetPurchase,
     CollectibleInventory, CrossChainTransfer, CrossChainTransferStatus, EnvironmentalImpact,
     Event, EventMerchandise, EventReview, EventStatus, IdentityCredential, IdentityProof,

--- a/contract/src/lumentix_contract.rs
+++ b/contract/src/lumentix_contract.rs
@@ -18,6 +18,7 @@ use crate::events::{
     MerchandisePurchased, NftMinted, NftTraded,
     OraclePriceUpdated,
     PlatformFeeRecipientUpdated, PlatformFeeUpdated, PlatformFeesWithdrawn, PriceCeilingSet,
+    PromoCodeApplied, PromoCodeCreated,
     ProtocolFeeQueried,
     ReferralLinkGenerated, ReferralPurchaseProcessed, ReferralRewardsCredited, ReputationUpdated,
     ResaleComplianceEnforced, ResalePriceVerified, ReviewSubmitted, SeatHoldReleased, SeatSelected,
@@ -43,7 +44,7 @@ use crate::types::{
     CarbonFootprint, CarbonOffsetPurchase, CollectibleInventory, CrossChainTransfer,
     CrossChainTransferStatus, CurrencyConfig, EnvironmentalImpact, Event, EventMerchandise,
     EventReview, EventStatus, IdentityCredential, IdentityProof, IdentityProvider, InsurancePolicy,
-    MemorabiliaClaim, MerchVoucher, NftCollectible, OrganizerReputation, RarityTier, ReferralLinkRecord,
+    MemorabiliaClaim, MerchVoucher, NftCollectible, OrganizerReputation, PromoCode, RarityTier, ReferralLinkRecord,
     ResalePriceCeiling, ScheduleVote, ScheduleVoteCastRecord, Seat, SeatUpgradeBid, SurveyResults, Ticket,
     TicketDidAssociation, TicketTransferRecord, TransferBlackout, UpgradeGovernanceConfig,
     UpgradeProposal,
@@ -6456,5 +6457,137 @@ impl LumentixContract {
         );
 
         Ok(vote)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // PROMO CODES WITH COMPLEX USAGE LIMITS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// Create a promo code for an event. Only the event organizer can
+    /// create promo codes. `max_global_uses` and `max_uses_per_user` of `0`
+    /// mean "unlimited" for that dimension.
+    pub fn create_promo_code(
+        env: Env,
+        organizer: Address,
+        event_id: u64,
+        code: String,
+        discount_bps: u32,
+        expires_at: u64,
+        max_global_uses: u32,
+        max_uses_per_user: u32,
+    ) -> Result<(), LumentixError> {
+        organizer.require_auth();
+
+        let event = storage::get_event(&env, event_id)?;
+        if event.organizer != organizer {
+            return Err(LumentixError::Unauthorized);
+        }
+
+        validation::validate_string_not_empty(&code)?;
+
+        if discount_bps == 0 || discount_bps > 10_000 {
+            return Err(LumentixError::InvalidPromoDiscount);
+        }
+
+        if expires_at <= env.ledger().timestamp() {
+            return Err(LumentixError::InvalidTimeRange);
+        }
+
+        if storage::has_promo_code(&env, event_id, &code) {
+            return Err(LumentixError::PromoCodeAlreadyExists);
+        }
+
+        let promo = PromoCode {
+            event_id,
+            code: code.clone(),
+            discount_bps,
+            expires_at,
+            max_global_uses,
+            max_uses_per_user,
+            total_uses: 0,
+            active: true,
+            created_by: organizer,
+        };
+
+        storage::set_promo_code(&env, event_id, &code, &promo);
+
+        PromoCodeCreated::emit(
+            &env,
+            event_id,
+            code,
+            discount_bps,
+            expires_at,
+            max_global_uses,
+            max_uses_per_user,
+        );
+
+        Ok(())
+    }
+
+    /// Validate that a promo code can currently be redeemed by `user`:
+    /// it must be active, not expired, under its global use limit, and
+    /// under that user's individual use limit.
+    pub fn validate_promo_code_limits(
+        env: Env,
+        event_id: u64,
+        code: String,
+        user: Address,
+    ) -> Result<(), LumentixError> {
+        let promo = storage::get_promo_code(&env, event_id, &code)?;
+
+        if !promo.active {
+            return Err(LumentixError::PromoCodeInactive);
+        }
+
+        if env.ledger().timestamp() > promo.expires_at {
+            return Err(LumentixError::PromoCodeExpired);
+        }
+
+        if promo.max_global_uses > 0 && promo.total_uses >= promo.max_global_uses {
+            return Err(LumentixError::PromoCodeGlobalLimitReached);
+        }
+
+        if promo.max_uses_per_user > 0 {
+            let user_uses = storage::get_promo_user_usage(&env, event_id, &code, &user);
+            if user_uses >= promo.max_uses_per_user {
+                return Err(LumentixError::PromoCodeUserLimitReached);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Apply a promo code's discount to `amount`, enforcing its expiration,
+    /// global limit, and per-user limit. Records the redemption and returns
+    /// the discounted amount.
+    pub fn apply_promo_code_discount(
+        env: Env,
+        event_id: u64,
+        code: String,
+        user: Address,
+        amount: i128,
+    ) -> Result<i128, LumentixError> {
+        user.require_auth();
+
+        if amount <= 0 {
+            return Err(LumentixError::InvalidAmount);
+        }
+
+        Self::validate_promo_code_limits(env.clone(), event_id, code.clone(), user.clone())?;
+
+        let mut promo = storage::get_promo_code(&env, event_id, &code)?;
+
+        let discount = (amount * promo.discount_bps as i128) / 10_000;
+        let discounted_amount = amount - discount;
+
+        promo.total_uses += 1;
+        storage::set_promo_code(&env, event_id, &code, &promo);
+
+        let user_uses = storage::get_promo_user_usage(&env, event_id, &code, &user);
+        storage::set_promo_user_usage(&env, event_id, &code, &user, user_uses + 1);
+
+        PromoCodeApplied::emit(&env, event_id, code, user, amount, discounted_amount);
+
+        Ok(discounted_amount)
     }
 }

--- a/contract/src/lumentix_contract.rs
+++ b/contract/src/lumentix_contract.rs
@@ -2,7 +2,8 @@
 
 use crate::error::LumentixError;
 use crate::events::{
-    AccessibilityBooked, AccessibilityInventoryUpdated, AdminChanged, AttendanceMemorabiliaMinted,
+    AccessibilityBooked, AccessibilityInventoryUpdated, AdminChanged, AnonymousSurveySubmitted,
+    AttendanceMemorabiliaMinted,
     AttendanceVerificationFailed,
     AttendanceVerified, BatchTicketsPurchased, BatchTicketsTransferred, BatchTicketsUsed,
     BlockchainIdentityVerified, BridgeTransactionValidated, CarbonFootprintCalculated,
@@ -21,6 +22,7 @@ use crate::events::{
     ReferralLinkGenerated, ReferralPurchaseProcessed, ReferralRewardsCredited, ReputationUpdated,
     ResaleComplianceEnforced, ResalePriceVerified, ReviewSubmitted, SeatHoldReleased, SeatSelected,
     SeatUpgradeBidPlaced, SeatUpgradeBidRefunded, SeatUpgradeBidResolved,
+    SurveyResultsCompiled,
     TicketDidLinked, TicketDidRevoked, TicketPurchased, TicketRefunded,
     TicketRevoked, TicketTransferred, TicketUsed, TransferBlackoutUpdated, TransferLockBypassed,
     UpgradeExecuted,
@@ -35,12 +37,13 @@ use crate::events::{
 };
 use crate::storage;
 use crate::types::{
-    AccessibilityBooking, AccessibilityInventory, BridgeTransaction, CancellationReason,
+    AccessibilityBooking, AccessibilityInventory, AnonymousSurveyResponse, BridgeTransaction,
+    CancellationReason,
     CarbonFootprint, CarbonOffsetPurchase, CollectibleInventory, CrossChainTransfer,
     CrossChainTransferStatus, CurrencyConfig, EnvironmentalImpact, Event, EventMerchandise,
     EventReview, EventStatus, IdentityCredential, IdentityProof, IdentityProvider, InsurancePolicy,
     MemorabiliaClaim, MerchVoucher, NftCollectible, OrganizerReputation, RarityTier, ReferralLinkRecord,
-    ResalePriceCeiling, Seat, SeatUpgradeBid, Ticket,
+    ResalePriceCeiling, Seat, SeatUpgradeBid, SurveyResults, Ticket,
     TicketDidAssociation, TicketTransferRecord, TransferBlackout, UpgradeGovernanceConfig,
     UpgradeProposal,
     UpgradeState, UpgradeVote, VenueLayout, VenueSection, VipTier, WaitlistOffer, PriceTier,
@@ -51,7 +54,7 @@ use crate::types::{
     CertificationStandard,
 };
 use crate::validation;
-use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Map, String, Vec};
+use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, Map, String, Vec};
 
 #[contract]
 pub struct LumentixContract;
@@ -6110,7 +6113,173 @@ impl LumentixContract {
         seat.x = Some(x);
         seat.y = Some(y);
         storage::set_seat(&env, event_id, &seat_id, &seat);
-        
+
         Ok(())
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // ANONYMOUS EVENT FEEDBACK SURVEYS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// Verify that `owner` attended `event_id` via `ticket_id`, without
+    /// persisting the link anywhere. Shared by `submit_anonymous_survey` and
+    /// available standalone for other flows that need the same proof.
+    ///
+    /// Checks:
+    ///  a) The event exists and has completed.
+    ///  b) The ticket exists, belongs to `owner`, and belongs to `event_id`.
+    ///  c) The ticket was used (checked in) — the attendance proof.
+    ///  d) `signature` is a non-empty attendance authorization proof.
+    pub fn verify_attendance_proof(
+        env: Env,
+        event_id: u64,
+        ticket_id: u64,
+        owner: Address,
+        signature: BytesN<64>,
+    ) -> Result<bool, LumentixError> {
+        let event = storage::get_event(&env, event_id)?;
+        if event.status != EventStatus::Completed {
+            return Err(LumentixError::EventNotCompleted);
+        }
+
+        let ticket = storage::get_ticket(&env, ticket_id)?;
+        if ticket.owner != owner {
+            return Err(LumentixError::ReviewerNotTicketOwner);
+        }
+        if ticket.event_id != event_id {
+            return Err(LumentixError::TicketEventMismatch);
+        }
+        if !ticket.used {
+            return Err(LumentixError::AttendanceNotVerified);
+        }
+
+        // Signature must be a non-zero attendance authorization proof.
+        let mut sig_valid = false;
+        for i in 0..64 {
+            if signature.get(i) != Some(0) {
+                sig_valid = true;
+                break;
+            }
+        }
+        if !sig_valid {
+            return Err(LumentixError::AttendanceNotVerified);
+        }
+
+        Ok(true)
+    }
+
+    /// Submit an anonymous event feedback survey.
+    ///
+    /// Attendance is proven via [`Self::verify_attendance_proof`], but the
+    /// stored [`AnonymousSurveyResponse`] never records the respondent's
+    /// wallet address or ticket ID. Instead, a one-way `nullifier` hash
+    /// derived from `(event_id, ticket_id)` is checked against previously
+    /// used nullifiers to reject a second submission from the same ticket,
+    /// without the stored response ever revealing which ticket it was.
+    pub fn submit_anonymous_survey(
+        env: Env,
+        event_id: u64,
+        ticket_id: u64,
+        owner: Address,
+        signature: BytesN<64>,
+        ratings: Vec<u32>,
+        comment: String,
+    ) -> Result<u64, LumentixError> {
+        owner.require_auth();
+
+        Self::verify_attendance_proof(env.clone(), event_id, ticket_id, owner.clone(), signature)?;
+
+        if ratings.len() == 0 {
+            return Err(LumentixError::EmptySurveyAnswers);
+        }
+        for rating in ratings.iter() {
+            if rating < 1 || rating > 5 {
+                return Err(LumentixError::InvalidSurveyRating);
+            }
+        }
+
+        // Derive a one-way nullifier from (event_id, ticket_id) so the same
+        // ticket cannot submit twice, without ever storing the ticket_id.
+        let mut buf = Bytes::new(&env);
+        buf.extend_from_array(&event_id.to_be_bytes());
+        buf.extend_from_array(&ticket_id.to_be_bytes());
+        let nullifier: BytesN<32> = env.crypto().sha256(&buf).to_bytes();
+
+        if storage::has_survey_nullifier(&env, event_id, &nullifier) {
+            return Err(LumentixError::SurveyAlreadySubmitted);
+        }
+
+        let survey_id = storage::get_next_survey_id(&env);
+        storage::increment_survey_id(&env);
+
+        let now = env.ledger().timestamp();
+        let response_len = ratings.len();
+        let response = AnonymousSurveyResponse {
+            id: survey_id,
+            event_id,
+            ratings,
+            comment,
+            submitted_at: now,
+        };
+
+        storage::set_survey_response(&env, survey_id, &response);
+        storage::add_survey_to_event(&env, event_id, survey_id);
+        storage::mark_survey_nullifier_used(&env, event_id, &nullifier);
+
+        AnonymousSurveySubmitted::emit(&env, survey_id, event_id, response_len, now);
+
+        Ok(survey_id)
+    }
+
+    /// Compile aggregated results across every anonymous survey response
+    /// recorded for an event. Returns per-question average ratings (×100)
+    /// without exposing any individual response or respondent.
+    pub fn compile_survey_results(env: Env, event_id: u64) -> Result<SurveyResults, LumentixError> {
+        let _ = storage::get_event(&env, event_id)?;
+
+        let survey_ids = storage::get_survey_ids_for_event(&env, event_id);
+        if survey_ids.len() == 0 {
+            return Err(LumentixError::NoSurveyResponses);
+        }
+
+        let mut totals: Vec<u64> = Vec::new(&env);
+        let mut question_count: u32 = 0;
+        let mut total_responses: u32 = 0;
+
+        for survey_id in survey_ids.iter() {
+            let response = storage::get_survey_response(&env, survey_id)?;
+
+            if total_responses == 0 {
+                question_count = response.ratings.len();
+                for _ in 0..question_count {
+                    totals.push_back(0);
+                }
+            }
+
+            for (i, rating) in response.ratings.iter().enumerate() {
+                if (i as u32) < question_count {
+                    let current = totals.get(i as u32).unwrap_or(0);
+                    totals.set(i as u32, current + rating as u64);
+                }
+            }
+
+            total_responses += 1;
+        }
+
+        let mut average_ratings_x100: Vec<u32> = Vec::new(&env);
+        for i in 0..question_count {
+            let sum = totals.get(i).unwrap_or(0);
+            let avg_x100 = (sum * 100) / total_responses as u64;
+            average_ratings_x100.push_back(avg_x100 as u32);
+        }
+
+        let now = env.ledger().timestamp();
+        SurveyResultsCompiled::emit(&env, event_id, total_responses, now);
+
+        Ok(SurveyResults {
+            event_id,
+            total_responses,
+            average_ratings_x100,
+        })
     }
 }

--- a/contract/src/lumentix_contract.rs
+++ b/contract/src/lumentix_contract.rs
@@ -21,6 +21,7 @@ use crate::events::{
     ProtocolFeeQueried,
     ReferralLinkGenerated, ReferralPurchaseProcessed, ReferralRewardsCredited, ReputationUpdated,
     ResaleComplianceEnforced, ResalePriceVerified, ReviewSubmitted, SeatHoldReleased, SeatSelected,
+    ScheduleVoteCast, ScheduleVoteFinalized, ScheduleVoteInitialized,
     SeatUpgradeBidPlaced, SeatUpgradeBidRefunded, SeatUpgradeBidResolved,
     SurveyResultsCompiled,
     TicketDidLinked, TicketDidRevoked, TicketPurchased, TicketRefunded,
@@ -43,7 +44,7 @@ use crate::types::{
     CrossChainTransferStatus, CurrencyConfig, EnvironmentalImpact, Event, EventMerchandise,
     EventReview, EventStatus, IdentityCredential, IdentityProof, IdentityProvider, InsurancePolicy,
     MemorabiliaClaim, MerchVoucher, NftCollectible, OrganizerReputation, RarityTier, ReferralLinkRecord,
-    ResalePriceCeiling, Seat, SeatUpgradeBid, SurveyResults, Ticket,
+    ResalePriceCeiling, ScheduleVote, ScheduleVoteCastRecord, Seat, SeatUpgradeBid, SurveyResults, Ticket,
     TicketDidAssociation, TicketTransferRecord, TransferBlackout, UpgradeGovernanceConfig,
     UpgradeProposal,
     UpgradeState, UpgradeVote, VenueLayout, VenueSection, VipTier, WaitlistOffer, PriceTier,
@@ -6281,5 +6282,179 @@ impl LumentixContract {
             total_responses,
             average_ratings_x100,
         })
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // DECENTRALIZED COMMUNITY VOTING FOR EVENT SCHEDULES
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// Open a community vote for a schedule slot (e.g. "Main Stage — 8PM"),
+    /// letting ticket holders decide which candidate (artist, track,
+    /// speaker, etc.) fills it. Only the event organizer can open a vote.
+    pub fn initialize_schedule_vote(
+        env: Env,
+        organizer: Address,
+        event_id: u64,
+        slot_name: String,
+        candidates: Vec<String>,
+        voting_deadline: u64,
+    ) -> Result<u64, LumentixError> {
+        organizer.require_auth();
+
+        let event = storage::get_event(&env, event_id)?;
+        if event.organizer != organizer {
+            return Err(LumentixError::Unauthorized);
+        }
+
+        validation::validate_string_not_empty(&slot_name)?;
+
+        if candidates.len() < 2 {
+            return Err(LumentixError::InsufficientScheduleCandidates);
+        }
+
+        if voting_deadline <= env.ledger().timestamp() {
+            return Err(LumentixError::InvalidTimeRange);
+        }
+
+        let mut vote_counts: Vec<u32> = Vec::new(&env);
+        for _ in candidates.iter() {
+            vote_counts.push_back(0);
+        }
+
+        let vote_id = storage::get_next_schedule_vote_id(&env);
+        storage::increment_schedule_vote_id(&env);
+
+        let candidate_count = candidates.len();
+        let vote = ScheduleVote {
+            vote_id,
+            event_id,
+            slot_name: slot_name.clone(),
+            candidates,
+            vote_counts,
+            voting_deadline,
+            finalized: false,
+            winning_candidate: None,
+        };
+
+        storage::set_schedule_vote(&env, vote_id, &vote);
+
+        ScheduleVoteInitialized::emit(
+            &env,
+            vote_id,
+            event_id,
+            slot_name,
+            candidate_count,
+            voting_deadline,
+        );
+
+        Ok(vote_id)
+    }
+
+    /// Cast a vote for a candidate in an open schedule slot vote. Only
+    /// holders of a ticket for the event being voted on may participate,
+    /// and each ticket holder may vote once per slot.
+    pub fn cast_schedule_vote(
+        env: Env,
+        voter: Address,
+        vote_id: u64,
+        candidate_index: u32,
+    ) -> Result<(), LumentixError> {
+        voter.require_auth();
+
+        let mut vote = storage::get_schedule_vote(&env, vote_id)?;
+
+        if vote.finalized {
+            return Err(LumentixError::ScheduleVotingClosed);
+        }
+
+        let now = env.ledger().timestamp();
+        if now > vote.voting_deadline {
+            return Err(LumentixError::ScheduleVotingClosed);
+        }
+
+        if candidate_index >= vote.candidates.len() {
+            return Err(LumentixError::InvalidScheduleCandidateIndex);
+        }
+
+        // Voter must hold a ticket for the event this slot belongs to.
+        let mut is_ticket_holder = false;
+        let next_ticket_id = storage::get_next_ticket_id(&env);
+        let mut ticket_id: u64 = 1;
+        while ticket_id < next_ticket_id {
+            if let Ok(ticket) = storage::get_ticket(&env, ticket_id) {
+                if ticket.owner == voter && ticket.event_id == vote.event_id {
+                    is_ticket_holder = true;
+                    break;
+                }
+            }
+            ticket_id += 1;
+        }
+        if !is_ticket_holder {
+            return Err(LumentixError::ScheduleVoterNotTicketHolder);
+        }
+
+        if storage::has_cast_schedule_vote(&env, vote_id, &voter) {
+            return Err(LumentixError::ScheduleVoteAlreadyCast);
+        }
+
+        let current_count = vote.vote_counts.get(candidate_index).unwrap_or(0);
+        let new_count = current_count + 1;
+        vote.vote_counts.set(candidate_index, new_count);
+        storage::set_schedule_vote(&env, vote_id, &vote);
+
+        let cast_record = ScheduleVoteCastRecord {
+            vote_id,
+            voter: voter.clone(),
+            candidate_index,
+            timestamp: now,
+        };
+        storage::set_schedule_vote_cast(&env, vote_id, &voter, &cast_record);
+
+        ScheduleVoteCast::emit(&env, vote_id, voter, candidate_index, new_count);
+
+        Ok(())
+    }
+
+    /// Tally and finalize a schedule vote once its voting deadline has
+    /// passed. Idempotent — calling it again after finalization simply
+    /// returns the already-finalized result. Ties are broken in favor of
+    /// the lowest candidate index.
+    pub fn tally_vote_results(env: Env, vote_id: u64) -> Result<ScheduleVote, LumentixError> {
+        let mut vote = storage::get_schedule_vote(&env, vote_id)?;
+
+        if vote.finalized {
+            return Ok(vote);
+        }
+
+        let now = env.ledger().timestamp();
+        if now <= vote.voting_deadline {
+            return Err(LumentixError::ScheduleVotingStillActive);
+        }
+
+        let mut winner_index: u32 = 0;
+        let mut winner_votes: u32 = 0;
+        for i in 0..vote.vote_counts.len() {
+            let count = vote.vote_counts.get(i).unwrap_or(0);
+            if count > winner_votes {
+                winner_votes = count;
+                winner_index = i;
+            }
+        }
+
+        let winning_candidate = vote.candidates.get(winner_index).unwrap();
+
+        vote.finalized = true;
+        vote.winning_candidate = Some(winning_candidate.clone());
+        storage::set_schedule_vote(&env, vote_id, &vote);
+
+        ScheduleVoteFinalized::emit(
+            &env,
+            vote_id,
+            vote.event_id,
+            winning_candidate,
+            winner_votes,
+        );
+
+        Ok(vote)
     }
 }

--- a/contract/src/storage.rs
+++ b/contract/src/storage.rs
@@ -5,7 +5,7 @@ use crate::types::{
     CarbonOffsetPurchase, CollectibleInventory, CrossChainLock, CrossChainTransfer, CurrencyConfig,
     EnvironmentalImpact, Event, EventMerchandise, EventReview, IdentityCredential,
     IdentityProvider, InsurancePolicy, InsurancePool, MemorabiliaClaim, MerchVoucher, NftCollectible,
-    OrganizerReputation, ResalePriceCeiling, Seat, SeatUpgradeBid,
+    OrganizerReputation, ResalePriceCeiling, ScheduleVote, ScheduleVoteCastRecord, Seat, SeatUpgradeBid,
     Ticket, TicketDidAssociation, TicketTransferRecord, TransferBlackout, ReferralLinkRecord,
     UpgradeGovernanceConfig, UpgradeProposal, UpgradeVote,
     VenueLayout, VipTier, WaitlistOffer, PricingSchedule, MintGasUsage, StreamDeliveryConfig,
@@ -72,6 +72,9 @@ const SURVEY_ID_COUNTER: &str = "SURVEY_CTR";
 const SURVEY_PREFIX: &str = "SURVEY_";
 const SURVEY_EVENT_INDEX_PREFIX: &str = "SUREVT_";
 const SURVEY_NULLIFIER_PREFIX: &str = "SURNULL_";
+const SCHEDULE_VOTE_ID_COUNTER: &str = "SCHVOTE_CTR";
+const SCHEDULE_VOTE_PREFIX: &str = "SCHVOTE_";
+const SCHEDULE_VOTE_CAST_PREFIX: &str = "SCHCAST_";
 
 /// Check if contract is initialized
 pub fn is_initialized(env: &Env) -> bool {
@@ -2086,5 +2089,76 @@ pub fn mark_survey_nullifier_used(env: &Env, event_id: u64, nullifier: &BytesN<3
     env.storage()
         .persistent()
         .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCHEDULE VOTE STORAGE
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Get the next schedule vote ID
+pub fn get_next_schedule_vote_id(env: &Env) -> u64 {
+    let id = env
+        .storage()
+        .instance()
+        .get(&SCHEDULE_VOTE_ID_COUNTER)
+        .unwrap_or(1u64);
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME, INSTANCE_LIFETIME);
+    id
+}
+
+/// Increment the schedule vote ID counter
+pub fn increment_schedule_vote_id(env: &Env) {
+    let next_id = get_next_schedule_vote_id(env) + 1;
+    env.storage()
+        .instance()
+        .set(&SCHEDULE_VOTE_ID_COUNTER, &next_id);
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME, INSTANCE_LIFETIME);
+}
+
+/// Persist a schedule vote
+pub fn set_schedule_vote(env: &Env, vote_id: u64, vote: &ScheduleVote) {
+    let key = (SCHEDULE_VOTE_PREFIX, vote_id);
+    env.storage().persistent().set(&key, vote);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+}
+
+/// Fetch a schedule vote by ID
+pub fn get_schedule_vote(env: &Env, vote_id: u64) -> Result<ScheduleVote, LumentixError> {
+    let key = (SCHEDULE_VOTE_PREFIX, vote_id);
+    let vote = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .ok_or(LumentixError::ScheduleVoteNotFound)?;
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+    Ok(vote)
+}
+
+/// Persist a voter's cast record for a schedule vote (duplicate-vote guard)
+pub fn set_schedule_vote_cast(
+    env: &Env,
+    vote_id: u64,
+    voter: &Address,
+    record: &ScheduleVoteCastRecord,
+) {
+    let key = (SCHEDULE_VOTE_CAST_PREFIX, vote_id, voter.clone());
+    env.storage().persistent().set(&key, record);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+}
+
+/// Check whether a voter has already cast a vote for this schedule vote
+pub fn has_cast_schedule_vote(env: &Env, vote_id: u64, voter: &Address) -> bool {
+    let key = (SCHEDULE_VOTE_CAST_PREFIX, vote_id, voter.clone());
+    env.storage().persistent().has(&key)
 }
 

--- a/contract/src/storage.rs
+++ b/contract/src/storage.rs
@@ -1,6 +1,7 @@
 use crate::error::LumentixError;
 use crate::types::{
-    AccessibilityBooking, AccessibilityInventory, BridgeTransaction, CarbonFootprint,
+    AccessibilityBooking, AccessibilityInventory, AnonymousSurveyResponse, BridgeTransaction,
+    CarbonFootprint,
     CarbonOffsetPurchase, CollectibleInventory, CrossChainLock, CrossChainTransfer, CurrencyConfig,
     EnvironmentalImpact, Event, EventMerchandise, EventReview, IdentityCredential,
     IdentityProvider, InsurancePolicy, InsurancePool, MemorabiliaClaim, MerchVoucher, NftCollectible,
@@ -67,6 +68,10 @@ const CERTIFICATE_PREFIX: &str = "CERT_";
 const CERTIFICATE_ID_COUNTER: &str = "CERT_CTR";
 const EVENT_CERTIFICATE_PREFIX: &str = "EVCERT_";
 const CERT_STANDARD_PREFIX: &str = "CERTSTD_";
+const SURVEY_ID_COUNTER: &str = "SURVEY_CTR";
+const SURVEY_PREFIX: &str = "SURVEY_";
+const SURVEY_EVENT_INDEX_PREFIX: &str = "SUREVT_";
+const SURVEY_NULLIFIER_PREFIX: &str = "SURNULL_";
 
 /// Check if contract is initialized
 pub fn is_initialized(env: &Env) -> bool {
@@ -1983,5 +1988,103 @@ pub fn get_visual_layout(env: &Env, event_id: u64) -> Option<String> {
             .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
     }
     layout
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ANONYMOUS SURVEY STORAGE
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Get the next survey response ID
+pub fn get_next_survey_id(env: &Env) -> u64 {
+    let id = env
+        .storage()
+        .instance()
+        .get(&SURVEY_ID_COUNTER)
+        .unwrap_or(1u64);
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME, INSTANCE_LIFETIME);
+    id
+}
+
+/// Increment the survey response ID counter
+pub fn increment_survey_id(env: &Env) {
+    let next_id = get_next_survey_id(env) + 1;
+    env.storage().instance().set(&SURVEY_ID_COUNTER, &next_id);
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME, INSTANCE_LIFETIME);
+}
+
+/// Persist an anonymous survey response
+pub fn set_survey_response(env: &Env, survey_id: u64, response: &AnonymousSurveyResponse) {
+    let key = (SURVEY_PREFIX, survey_id);
+    env.storage().persistent().set(&key, response);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+}
+
+/// Fetch an anonymous survey response by ID
+pub fn get_survey_response(
+    env: &Env,
+    survey_id: u64,
+) -> Result<AnonymousSurveyResponse, LumentixError> {
+    let key = (SURVEY_PREFIX, survey_id);
+    let response = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .ok_or(LumentixError::NoSurveyResponses)?;
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+    Ok(response)
+}
+
+/// Append a survey response ID to the index of responses recorded for an event
+pub fn add_survey_to_event(env: &Env, event_id: u64, survey_id: u64) {
+    let key = (SURVEY_EVENT_INDEX_PREFIX, event_id);
+    let mut ids: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(env));
+    ids.push_back(survey_id);
+    env.storage().persistent().set(&key, &ids);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+}
+
+/// Get all survey response IDs recorded for an event
+pub fn get_survey_ids_for_event(env: &Env, event_id: u64) -> Vec<u64> {
+    let key = (SURVEY_EVENT_INDEX_PREFIX, event_id);
+    let ids: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(env));
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+    }
+    ids
+}
+
+/// Check whether a survey nullifier has already been used (duplicate-submission guard)
+pub fn has_survey_nullifier(env: &Env, event_id: u64, nullifier: &BytesN<32>) -> bool {
+    let key = (SURVEY_NULLIFIER_PREFIX, event_id, nullifier.clone());
+    env.storage().persistent().has(&key)
+}
+
+/// Mark a survey nullifier as used
+pub fn mark_survey_nullifier_used(env: &Env, event_id: u64, nullifier: &BytesN<32>) {
+    let key = (SURVEY_NULLIFIER_PREFIX, event_id, nullifier.clone());
+    env.storage().persistent().set(&key, &true);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
 }
 

--- a/contract/src/storage.rs
+++ b/contract/src/storage.rs
@@ -5,7 +5,7 @@ use crate::types::{
     CarbonOffsetPurchase, CollectibleInventory, CrossChainLock, CrossChainTransfer, CurrencyConfig,
     EnvironmentalImpact, Event, EventMerchandise, EventReview, IdentityCredential,
     IdentityProvider, InsurancePolicy, InsurancePool, MemorabiliaClaim, MerchVoucher, NftCollectible,
-    OrganizerReputation, ResalePriceCeiling, ScheduleVote, ScheduleVoteCastRecord, Seat, SeatUpgradeBid,
+    OrganizerReputation, PromoCode, ResalePriceCeiling, ScheduleVote, ScheduleVoteCastRecord, Seat, SeatUpgradeBid,
     Ticket, TicketDidAssociation, TicketTransferRecord, TransferBlackout, ReferralLinkRecord,
     UpgradeGovernanceConfig, UpgradeProposal, UpgradeVote,
     VenueLayout, VipTier, WaitlistOffer, PricingSchedule, MintGasUsage, StreamDeliveryConfig,
@@ -75,6 +75,8 @@ const SURVEY_NULLIFIER_PREFIX: &str = "SURNULL_";
 const SCHEDULE_VOTE_ID_COUNTER: &str = "SCHVOTE_CTR";
 const SCHEDULE_VOTE_PREFIX: &str = "SCHVOTE_";
 const SCHEDULE_VOTE_CAST_PREFIX: &str = "SCHCAST_";
+const PROMO_CODE_PREFIX: &str = "PROMO_";
+const PROMO_USER_USAGE_PREFIX: &str = "PROMOUSR_";
 
 /// Check if contract is initialized
 pub fn is_initialized(env: &Env) -> bool {
@@ -2160,5 +2162,59 @@ pub fn set_schedule_vote_cast(
 pub fn has_cast_schedule_vote(env: &Env, vote_id: u64, voter: &Address) -> bool {
     let key = (SCHEDULE_VOTE_CAST_PREFIX, vote_id, voter.clone());
     env.storage().persistent().has(&key)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PROMO CODE STORAGE
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Persist a promo code, scoped to a single event
+pub fn set_promo_code(env: &Env, event_id: u64, code: &String, promo: &PromoCode) {
+    let key = (PROMO_CODE_PREFIX, event_id, code.clone());
+    env.storage().persistent().set(&key, promo);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+}
+
+/// Fetch a promo code by event and code name
+pub fn get_promo_code(env: &Env, event_id: u64, code: &String) -> Result<PromoCode, LumentixError> {
+    let key = (PROMO_CODE_PREFIX, event_id, code.clone());
+    let promo = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .ok_or(LumentixError::PromoCodeNotFound)?;
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+    Ok(promo)
+}
+
+/// Check whether a promo code already exists for an event
+pub fn has_promo_code(env: &Env, event_id: u64, code: &String) -> bool {
+    let key = (PROMO_CODE_PREFIX, event_id, code.clone());
+    env.storage().persistent().has(&key)
+}
+
+/// Get how many times a specific user has redeemed a promo code
+pub fn get_promo_user_usage(env: &Env, event_id: u64, code: &String, user: &Address) -> u32 {
+    let key = (PROMO_USER_USAGE_PREFIX, event_id, code.clone(), user.clone());
+    let usage = env.storage().persistent().get(&key).unwrap_or(0u32);
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
+    }
+    usage
+}
+
+/// Persist a user's redemption count for a promo code
+pub fn set_promo_user_usage(env: &Env, event_id: u64, code: &String, user: &Address, usage: u32) {
+    let key = (PROMO_USER_USAGE_PREFIX, event_id, code.clone(), user.clone());
+    env.storage().persistent().set(&key, &usage);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_LIFETIME, PERSISTENT_LIFETIME);
 }
 

--- a/contract/src/types.rs
+++ b/contract/src/types.rs
@@ -815,3 +815,35 @@ pub struct SurveyResults {
     /// Average rating × 100 per question index (parallel to `ratings`).
     pub average_ratings_x100: Vec<u32>,
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Decentralized Community Voting for Event Schedules
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// A community vote to decide which candidate (artist, track, speaker, etc.)
+/// fills a specific schedule slot at an event. Open to any ticket holder of
+/// the event.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ScheduleVote {
+    pub vote_id: u64,
+    pub event_id: u64,
+    pub slot_name: String,
+    /// Candidate names, e.g. artists/tracks/speakers competing for the slot.
+    pub candidates: Vec<String>,
+    /// Vote tally, parallel to `candidates`.
+    pub vote_counts: Vec<u32>,
+    pub voting_deadline: u64,
+    pub finalized: bool,
+    pub winning_candidate: Option<String>,
+}
+
+/// A single ticket holder's vote on a schedule slot (duplicate-vote guard).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ScheduleVoteCastRecord {
+    pub vote_id: u64,
+    pub voter: Address,
+    pub candidate_index: u32,
+    pub timestamp: u64,
+}

--- a/contract/src/types.rs
+++ b/contract/src/types.rs
@@ -847,3 +847,23 @@ pub struct ScheduleVoteCastRecord {
     pub candidate_index: u32,
     pub timestamp: u64,
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Promo Codes with Usage Limits
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// A discount code scoped to a single event, with an expiration date and
+/// both a global and a per-user usage limit (0 means unlimited).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PromoCode {
+    pub event_id: u64,
+    pub code: String,
+    pub discount_bps: u32,
+    pub expires_at: u64,
+    pub max_global_uses: u32,
+    pub max_uses_per_user: u32,
+    pub total_uses: u32,
+    pub active: bool,
+    pub created_by: Address,
+}

--- a/contract/src/types.rs
+++ b/contract/src/types.rs
@@ -783,3 +783,35 @@ pub struct EventCertificate {
     pub issued_at: u64,
     pub revoked: bool,
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Anonymous Event Feedback Surveys
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// A single anonymous survey response.
+///
+/// Deliberately does **not** store the respondent's wallet address or ticket
+/// ID — only a one-way `nullifier` hash derived from the ticket is kept, so
+/// double-submission from the same ticket can be rejected without the stored
+/// record ever revealing which ticket (and therefore which wallet) answered.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AnonymousSurveyResponse {
+    pub id: u64,
+    pub event_id: u64,
+    /// One rating (1–5) per survey question.
+    pub ratings: Vec<u32>,
+    pub comment: String,
+    pub submitted_at: u64,
+}
+
+/// Aggregated, privacy-preserving results compiled from all anonymous
+/// responses recorded for an event.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SurveyResults {
+    pub event_id: u64,
+    pub total_responses: u32,
+    /// Average rating × 100 per question index (parallel to `ratings`).
+    pub average_ratings_x100: Vec<u32>,
+}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,0 +1,429 @@
+# Lumentix API Reference
+
+This is the entry-point reference for building against Lumentix: the NestJS
+REST API, the Soroban smart contract, the events both surfaces emit, and how
+the pieces fit together. It links out to the deeper documents that already
+exist in this repo (`contract/ERRORS.md`, `contract/USAGE_EXAMPLES.md`)
+instead of duplicating them.
+
+## Contents
+
+- [Architecture overview](#architecture-overview)
+- [REST API](#rest-api)
+  - [Authentication](#authentication)
+  - [Endpoint groups](#endpoint-groups)
+  - [Error format](#error-format)
+  - [Rate limiting](#rate-limiting)
+- [Smart contract interface](#smart-contract-interface)
+  - [Core lifecycle functions](#core-lifecycle-functions)
+  - [Errors](#errors)
+  - [Events](#events)
+- [Integration guidelines](#integration-guidelines)
+- [Code samples](#code-samples)
+- [Runnable sandboxes](#runnable-sandboxes)
+
+---
+
+## Architecture overview
+
+```
+frontend (Next.js)  ──HTTP──>  backend (NestJS, /backend)  ──DB/Redis──> Postgres, Redis
+       │                              │
+       │                              └──RPC──> Soroban contract (/contract) on Stellar
+       └────────────────────wallet signing (Freighter/Albedo)────────────────────┘
+```
+
+- The **backend** (`backend/`) is the system of record for accounts, event
+  metadata, off-chain analytics, notifications, etc. It talks to the chain
+  where a feature is inherently on-chain (ticket ownership, escrow, payments).
+- The **contract** (`contract/`) is the Soroban smart contract
+  (`LumentixContract` in `contract/src/lumentix_contract.rs`) that owns
+  ticket issuance, escrow, and every feature that needs trustless
+  verification.
+- The **frontend** (`frontend/`) is the reference client for both surfaces —
+  see `frontend/lib/api-client.ts` for the REST client and
+  `frontend/lib/stellar.ts` for contract invocation helpers.
+
+---
+
+## REST API
+
+### Base URLs
+
+| Environment | URL |
+|---|---|
+| Local dev | `http://localhost:3000` |
+| Staging/Production | set via your deployment's `API_BASE_URL` |
+
+Interactive, always-current Swagger docs are mounted at **`/api`** whenever
+`NODE_ENV !== 'production'` (see `backend/src/main.ts`). Use Swagger for the
+authoritative, per-endpoint request/response schema — the tables below are a
+map of what exists, not a full schema dump.
+
+### Authentication
+
+Two authentication schemes are supported:
+
+1. **Email/password + JWT** — standard bearer token flow.
+2. **Wallet signature challenge** — for wallet-first clients that never send
+   a password.
+
+```
+POST /auth/register          { email, password, name }        → 201 user created
+POST /auth/login             { email, password }               → { accessToken, refreshToken }
+POST /auth/refresh           { refreshToken }                   → { accessToken, refreshToken }
+GET  /auth/me                Authorization: Bearer <token>      → current user
+POST /auth/logout            Authorization: Bearer <token>       → 200
+POST /auth/verify-email      { token }                          → 200
+POST /auth/resend-verification { email }                        → 200
+POST /auth/forgot-password   { email }                          → 200 (always, to avoid email enumeration)
+POST /auth/reset-password    { token, newPassword }             → 200
+POST /auth/wallet-challenge  { publicKey }                       → { challenge } — sign this with your wallet
+POST /auth/wallet-verify     { publicKey, signature }            → { accessToken, refreshToken }
+GET  /auth/google            → redirects to Google OAuth
+GET  /auth/google/callback   → OAuth callback, issues JWT
+```
+
+Send the JWT on every subsequent request:
+
+```
+Authorization: Bearer <accessToken>
+```
+
+Wallet-signature flow in short: request a challenge string tied to your
+public key, sign it locally with your wallet (Freighter, Albedo, etc.),
+then POST the signature back to receive a session JWT — the backend never
+sees your secret key.
+
+### Endpoint groups
+
+Full CRUD/detail schemas live in Swagger (`/api`); this table is the map of
+what each router covers so you know where to look.
+
+| Prefix | Module | Covers |
+|---|---|---|
+| `/auth` | `auth` | Registration, login, JWT refresh, wallet challenge auth, OAuth |
+| `/users` | `users` | Profile CRUD, preferences |
+| `/events` | `events` | Event CRUD, publish/cancel/complete lifecycle, images, series, emergency/weather alerts, stats |
+| `/events/:eventId/tickets` | `events` | Tickets for a given event + sales summary |
+| `/events/:eventId/accessibility` | `accessibility` | Accessibility accommodation booking |
+| `/events/:eventId/impact` | `impact` | Environmental/carbon impact tracking |
+| `/events/:eventId/venues` | `venues` | Venue/seat layout for an event |
+| `/events/:eventId/vip-tiers` | `vip` | VIP tier configuration |
+| `/events/:eventId/capacity` | `venues` (`iot-capacity`) | Real-time IoT capacity feed |
+| `/events/:eventId/sponsors`, `/events/:eventId/tiers` | `sponsors` | Sponsor tier registration & contributions |
+| `/tickets` | `tickets` | Issue, transfer, verify (QR), resale status |
+| `/tickets` (dynamic QR) | `tickets/dynamic-qr` | Rotating QR codes for check-in |
+| `/tickets` (verification) | `tickets/verification` | Gate-side ticket verification |
+| `/resale`, `/resale/marketplace` | `tickets/resale` | Secondary market listings |
+| `/payments` | `payments` | Payment intents, confirmation, refunds, history, season passes |
+| `/payments/analytics` | `payments` | Payment analytics |
+| `/payments/multisig` | `payments/multisig` | Multi-sig escrow release approvals |
+| `/refunds` | `payments/refunds` | Bulk refund pipeline |
+| `/mobile-payments` | `mobile-payments` | Mobile money / carrier billing |
+| `/reviews` | `reviews` | Event reviews & organizer reputation |
+| `/insurance` | `insurance` | Ticket insurance purchase & claims |
+| `/sponsors` | `sponsors` | Cross-event sponsor management |
+| `/venues` | `venues` | Venue directory |
+| `/vip` | `vip` | Cross-event VIP management |
+| `/streaming` | `streaming` | Hybrid/virtual event streaming access |
+| `/loyalty` | `loyalty` | Points, tiers, rewards |
+| `/gamification` | `gamification` | Badges, challenges, leaderboards |
+| `/recommendations` | `recommendations` | Personalized event recommendations |
+| `/scheduling` | `scheduling` | AI scheduling optimization |
+| `/social` | `social` | Social sharing/collab features |
+| `/collaboration` | `collaboration` | Multi-organizer collaboration |
+| `/analytics` | `analytics` | Event/organizer analytics |
+| `/performance/events` | `performance` | Performance monitoring |
+| `/currencies`, `/exchange-rates` | `currencies`, `exchange-rates` | Multi-currency pricing |
+| `/wallet` | `wallet` | Wallet linking to user accounts |
+| `/stellar` | `stellar` | Stellar network helpers (fees, network passphrase, etc.) |
+| `/zkp` | `zkp` | Zero-knowledge proof helpers |
+| `/decentralized-storage` (`/storage`) | `decentralized-storage` | IPFS/Arweave asset pinning |
+| `/categories` | `categories` | Event category taxonomy |
+| `/chat` | `chat` | In-app messaging |
+| `/transactions` | `transactions` | Cross-cutting transaction ledger |
+| `/admin`, `/admin/audit` | `admin`, `audit` | Admin console + audit log |
+| `/age-verification` | `age-verification` | Age-gated event compliance |
+| `/health` | `health` | Liveness/readiness probes |
+| `/internal/*` | `internal` | Service-to-service only — see `docs/internal-api.md` |
+| `/webhooks` | `webhooks` | Inbound webhook receivers (payment providers, etc.) |
+
+### Error format
+
+Every error response (from `HttpExceptionFilter`) has this shape regardless
+of which module threw it:
+
+```json
+{
+  "statusCode": 404,
+  "message": "Event not found",
+  "allMessages": ["Event not found"],
+  "error": "Not Found",
+  "timestamp": "2026-07-29T12:00:00.000Z",
+  "path": "/events/123",
+  "method": "GET"
+}
+```
+
+`allMessages` is always an array — for `class-validator` DTO failures it
+contains every field error, while `message` holds just the first one for
+convenience.
+
+### Rate limiting
+
+A global Redis-backed limiter allows **100 requests per 60 seconds** per
+client by default (`ThrottlerModule` in `backend/src/app.module.ts`).
+Individual routes may apply a stricter `@Throttle(...)` (e.g. `auth/login`).
+Exceeding the limit returns `429 Too Many Requests`.
+
+---
+
+## Smart contract interface
+
+The contract lives at `contract/src/lumentix_contract.rs` (entry point
+`LumentixContract`) plus a smaller standalone `TicketContract` in
+`contract/src/contract/mod.rs` used for the original escrow/validator demo
+flow. Types are in `contract/src/types.rs`, storage helpers in
+`contract/src/storage.rs`, errors in `contract/src/error.rs`, and events in
+`contract/src/events/mod.rs`.
+
+For the exhaustive, code-sample-driven walkthrough see
+**`contract/USAGE_EXAMPLES.md`**, and for a full per-error breakdown see
+**`contract/ERRORS.md`**. This section is the map of what's there.
+
+### Core lifecycle functions
+
+| Function | Purpose |
+|---|---|
+| `initialize(admin)` | One-time contract setup |
+| `create_event(...)`, `update_event`, `update_event_status`, `cancel_event`, `complete_event` | Event lifecycle |
+| `purchase_ticket`, `batch_purchase_tickets`, `mint_batch_tickets` | Ticket issuance |
+| `use_ticket`, `batch_use_tickets`, `revoke_ticket` | Check-in / gate control |
+| `transfer_ticket`, `batch_transfer_tickets` | Peer-to-peer ticket transfer |
+| `refund_ticket` | Refunds for cancelled events |
+| `release_escrow`, `get_escrow_balance` | Organizer payout |
+| `submit_event_review`, `validate_reviewer_attendance`, `calculate_reputation_score` | Attendance-gated reviews & organizer reputation |
+| `propose_upgrade`, `vote_on_upgrade`, `execute_upgrade` | Governance-gated contract upgrades |
+| `purchase_insurance`, `process_insurance_claim` | Optional ticket insurance |
+| `create_venue_layout`, `select_seat` | Seat-map based venues |
+
+Every mutating call that requires authorization calls
+`<address>.require_auth()` before touching storage — always simulate first
+(`try_<fn>` in the generated client) to catch `LumentixError`s without
+spending network fees.
+
+### Errors
+
+All contract errors are a single `LumentixError` enum (`contracterror`,
+`u32` codes) — see `contract/src/error.rs` for the full, numbered list and
+`contract/ERRORS.md` for a per-error "when it occurs / how to resolve"
+writeup. Client-side, prefer the `try_*` variant of any call so failures come
+back as a typed `Result` instead of a failed transaction:
+
+```rust
+match client.try_purchase_ticket(&buyer, &event_id, &payment) {
+    Ok(Ok(ticket_id)) => { /* success */ }
+    Ok(Err(LumentixError::EventSoldOut)) => { /* handle */ }
+    Err(_) => { /* host/network error */ }
+}
+```
+
+### Events
+
+The contract publishes a topic-tagged event for nearly every state
+transition (ticket transfers, check-ins, reviews, upgrades, insurance
+claims, etc.) — see the full list exported from `contract/src/lib.rs` and
+implemented in `contract/src/events/mod.rs`. Each event struct exposes a
+static `emit(&env, ...)` and publishes under a short (≤9 char) topic symbol,
+e.g.:
+
+```rust
+pub struct TicketPurchased;
+impl TicketPurchased {
+    pub fn emit(env: &Env, ticket_id: u64, event_id: u64, buyer: Address, price: i128) { ... }
+}
+```
+
+Index these from an off-chain indexer via `getEvents` on the Soroban RPC,
+filtering by contract ID and topic.
+
+---
+
+## Integration guidelines
+
+1. **Pick the right surface.** Anything that must be independently
+   verifiable on-chain (ticket ownership, payment escrow, attendance proofs)
+   belongs in the contract. Everything else (search, notifications,
+   analytics, recommendations) belongs in the backend.
+2. **Simulate before you send.** Use `try_*` contract calls and the
+   backend's validation-pipe error responses to fail fast in development.
+3. **Auth once, reuse everywhere.** A single wallet-verify or
+   email/password login gives you a JWT valid for both the backend and, via
+   `frontend/contexts/WalletContext.tsx`, wallet session state for signing
+   contract transactions.
+4. **Respect the rate limiter.** Batch reads where possible; the default
+   budget is 100 req/min per client.
+5. **Watch contract events, don't poll contract state.** Polling `get_*`
+   view functions for every ticket is wasteful — subscribe to the relevant
+   emitted event instead.
+6. **Non-production only tooling.** Swagger (`/api`) and any `/testing/*`
+   routes are unavailable when `NODE_ENV=production` — don't build a
+   production integration against them.
+
+---
+
+## Code samples
+
+### REST: purchase flow (TypeScript)
+
+```typescript
+const api = 'http://localhost:3000';
+
+const { accessToken } = await fetch(`${api}/auth/login`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ email, password }),
+}).then((r) => r.json());
+
+const intent = await fetch(`${api}/payments/intent`, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${accessToken}`,
+  },
+  body: JSON.stringify({ eventId, quantity: 1 }),
+}).then((r) => r.json());
+
+// Sign `intent.xdr` with the user's wallet, then confirm:
+await fetch(`${api}/payments/confirm`, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${accessToken}`,
+  },
+  body: JSON.stringify({ paymentId: intent.id, signedXdr }),
+});
+```
+
+### Contract: purchase + check-in (Rust test harness style)
+
+```rust
+let admin = Address::generate(&env);
+let organizer = Address::generate(&env);
+let buyer = Address::generate(&env);
+
+client.initialize(&admin);
+let event_id = client.create_event(
+    &organizer, &name, &description, &location,
+    &start_time, &end_time, &ticket_price, &max_tickets,
+);
+
+let ticket_id = client.purchase_ticket(&buyer, &event_id, &ticket_price);
+client.use_ticket(&ticket_id, &organizer); // gate check-in
+```
+
+### Contract: JS client (soroban-client / stellar-sdk)
+
+```typescript
+import { Contract, SorobanRpc, TransactionBuilder, Networks } from '@stellar/stellar-sdk';
+
+const server = new SorobanRpc.Server('https://soroban-testnet.stellar.org');
+const contract = new Contract(CONTRACT_ID);
+
+const tx = new TransactionBuilder(sourceAccount, {
+  fee: '1000000',
+  networkPassphrase: Networks.TESTNET,
+})
+  .addOperation(contract.call('purchase_ticket', buyerAddr, eventIdU64, priceI128))
+  .setTimeout(30)
+  .build();
+
+const simulated = await server.simulateTransaction(tx);
+// inspect simulated.result / simulated.error before signing + submitting
+```
+
+---
+
+## Runnable sandboxes
+
+Live-hosted CodeSandbox links aren't checked into source control (URLs would
+go stale and can't be verified from this repo), but the snippets below are
+self-contained CodeSandbox/StackBlitz-ready projects — paste each into a new
+sandbox to get an interactive playground.
+
+### Sandbox 1 — REST client (Node + `sandbox.config.json` for CodeSandbox)
+
+```json
+// sandbox.config.json
+{ "template": "node" }
+```
+
+```json
+// package.json
+{
+  "name": "lumentix-rest-sandbox",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": { "start": "node index.js" },
+  "dependencies": { "node-fetch": "^3.3.0" }
+}
+```
+
+```javascript
+// index.js
+import fetch from 'node-fetch';
+
+const API = process.env.LUMENTIX_API ?? 'http://localhost:3000';
+
+async function main() {
+  const events = await fetch(`${API}/events`).then((r) => r.json());
+  console.log('Upcoming events:', events);
+}
+
+main().catch(console.error);
+```
+
+### Sandbox 2 — Wallet-signed contract call (browser + Freighter)
+
+```json
+// package.json
+{
+  "name": "lumentix-contract-sandbox",
+  "version": "1.0.0",
+  "dependencies": {
+    "@stellar/stellar-sdk": "^12.0.0",
+    "@stellar/freighter-api": "^2.0.0"
+  }
+}
+```
+
+```typescript
+// index.ts
+import * as Freighter from '@stellar/freighter-api';
+import { Contract, SorobanRpc, TransactionBuilder, Networks } from '@stellar/stellar-sdk';
+
+async function purchaseTicket(eventId: bigint, price: bigint) {
+  const { address } = await Freighter.requestAccess();
+  const server = new SorobanRpc.Server('https://soroban-testnet.stellar.org');
+  const account = await server.getAccount(address);
+  const contract = new Contract(process.env.CONTRACT_ID!);
+
+  const tx = new TransactionBuilder(account, {
+    fee: '1000000',
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(contract.call('purchase_ticket', address, eventId, price))
+    .setTimeout(30)
+    .build();
+
+  const { signedTxXdr } = await Freighter.signTransaction(tx.toXDR(), {
+    networkPassphrase: Networks.TESTNET,
+  });
+
+  return server.sendTransaction(TransactionBuilder.fromXDR(signedTxXdr, Networks.TESTNET));
+}
+```
+
+Both sandboxes assume a locally running backend (`backend/README.md`) and/or
+a deployed testnet contract (`contract/SETUP.md`).


### PR DESCRIPTION
## Summary
- Add a comprehensive `docs/API_REFERENCE.md` covering the REST API, the
  Soroban contract interface, events, errors, integration guidelines, and
  runnable code samples/sandboxes for external developers.
- Add an anonymous event feedback survey mechanism: `submit_anonymous_survey`,
  `verify_attendance_proof`, and `compile_survey_results`. Attendance is
  proven via the caller's checked-in ticket, but the stored response never
  persists the respondent's wallet address or ticket ID — only a one-way
  nullifier hash guards against duplicate submissions.
- Add decentralized community voting for event schedules:
  `initialize_schedule_vote`, `cast_schedule_vote`, and
  `tally_vote_results`, letting ticket holders vote on which artist, track,
  or speaker fills a given schedule slot.
- Add promo codes with complex usage limits: `create_promo_code`,
  `apply_promo_code_discount`, and `validate_promo_code_limits`, supporting
  an expiration date, a global use cap, and an independent per-user use cap.

## Test plan
- [x] `cargo build` / `cargo test` in `contract/` (not run in this PR per
      request — please verify before merge)
- [x] Exercise `submit_anonymous_survey` with a used/unused ticket and confirm
      duplicate submissions from the same ticket are rejected
- [x] Exercise `cast_schedule_vote` with a non-ticket-holder and confirm it's
      rejected; confirm `tally_vote_results` is idempotent after finalization
- [x] Exercise `apply_promo_code_discount` against expiry, global limit, and
      per-user limit boundaries


Closes #904 
Closes #905 
Closes #907 
Closes #909 