### PR TITLE
feat(frontend): Create Event image upload with drag-and-drop, preview and progress indicator

### DIFF
--- a/frontend/app/api/proxy/[...path]/route.ts
+++ b/frontend/app/api/proxy/[...path]/route.ts
@@ -11,8 +11,13 @@ async function proxyRequest(
   const url = new URL(path, BACKEND_URL);
   url.search = request.nextUrl.search;
 
+  const contentType = request.headers.get('content-type') ?? 'application/json';
+  // Multipart bodies carry binary data and a boundary token; decoding them as
+  // text corrupts the payload, so they are forwarded as raw bytes instead.
+  const isBinaryBody = !contentType.includes('application/json');
+
   const headers = new Headers();
-  headers.set('Content-Type', request.headers.get('content-type') ?? 'application/json');
+  headers.set('Content-Type', contentType);
   if (accessToken) {
     headers.set('Authorization', `Bearer ${accessToken}`);
   }
@@ -23,7 +28,7 @@ async function proxyRequest(
   };
 
   if (request.method !== 'GET' && request.method !== 'HEAD') {
-    init.body = await request.text();
+    init.body = isBinaryBody ? await request.arrayBuffer() : await request.text();
   }
 
   const backendResponse = await fetch(url.toString(), init);

--- a/frontend/app/create/page.tsx
+++ b/frontend/app/create/page.tsx
@@ -3,12 +3,16 @@
 import { useEffect, useState, useCallback } from "react";
 import EventForm, { type EventFormSubmitValues } from "@/components/events/EventForm";
 import EventPreviewOverlay from "@/components/EventPreviewOverlay";
+import ImageDropzone from "@/components/ImageDropzone";
 import { defaultCreateEventValues, type CreateEventFormValues } from "@/lib/schemas/create-event.schema";
 import { localDateTimeToUTC } from "@/lib/utils/datetime";
 import { apiGet, apiPost } from "@/lib/api-client";
+import { uploadEventImage } from "@/lib/utils/image-upload";
 import { useWallet } from "@/contexts/WalletContext";
 
 type EventRecord = { id: string; title: string; location?: string };
+
+type UploadStatus = "idle" | "uploading" | "success" | "error";
 
 function toApiDate(value: string, timezone: string): string {
     return localDateTimeToUTC(value, timezone);
@@ -20,6 +24,22 @@ export default function CreateEventPage() {
     const [submitError, setSubmitError] = useState<string | null>(null);
     const [submitSuccess, setSubmitSuccess] = useState<string | null>(null);
     const [loadError, setLoadError] = useState<string | null>(null);
+
+    // Cover-image upload state. The file is staged locally while the form is
+    // filled in and only uploaded once the event exists and has an id.
+    const [imageFile, setImageFile] = useState<File | null>(null);
+    const [imagePreview, setImagePreview] = useState<string | null>(null);
+    const [uploadProgress, setUploadProgress] = useState(0);
+    const [uploadStatus, setUploadStatus] = useState<UploadStatus>("idle");
+    const [uploadError, setUploadError] = useState<string | null>(null);
+
+    const handleImageChange = useCallback((file: File | null) => {
+        setImageFile(file);
+        setUploadError(null);
+        setUploadProgress(0);
+        setUploadStatus("idle");
+        if (!file) setImagePreview(null);
+    }, []);
 
     const fetchEvents = async () => {
         setLoadError(null);
@@ -54,6 +74,33 @@ export default function CreateEventPage() {
                 status: values.status,
             });
             setSubmitSuccess(`Event "${created.title}" created successfully.`);
+
+            // The image endpoint needs the event id, so the upload is a second
+            // step. A failure here must not read as "the event was not created".
+            if (imageFile) {
+                setUploadStatus("uploading");
+                setUploadProgress(0);
+                setUploadError(null);
+                try {
+                    const result = await uploadEventImage({
+                        eventId: created.id,
+                        file: imageFile,
+                        onProgress: setUploadProgress,
+                    });
+                    setUploadStatus("success");
+                    if (typeof result.imageUrl === "string") {
+                        setImagePreview(result.imageUrl);
+                    }
+                } catch (error) {
+                    setUploadStatus("error");
+                    setUploadError(
+                        error instanceof Error
+                            ? `${error.message} The event was created — you can add the image from the edit page.`
+                            : "Image upload failed.",
+                    );
+                }
+            }
+
             await fetchEvents();
         } catch (error) {
             setSubmitError(error instanceof Error ? error.message : "Event creation failed");
@@ -82,7 +129,7 @@ export default function CreateEventPage() {
                         currency: formData.currency,
                         category: "",
                         maxAttendees: null,
-                        imageUrl: "",
+                        imageUrl: imagePreview ?? "",
                     }}
                     onClose={() => setShowPreview(false)}
                     onSubmit={() => {
@@ -96,6 +143,16 @@ export default function CreateEventPage() {
                 <section className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur-md sm:p-8">
                     <h1 className="mb-2 bg-gradient-to-r from-purple-300 to-pink-400 bg-clip-text text-3xl font-extrabold text-transparent sm:text-4xl">Create New Event</h1>
                     <p className="mb-6 text-sm text-gray-300">Organizers can publish events and optional sponsor tiers.</p>
+                    <div className="mb-6">
+                        <ImageDropzone
+                            file={imageFile}
+                            onFileChange={handleImageChange}
+                            progress={uploadProgress}
+                            status={uploadStatus}
+                            uploadError={uploadError}
+                            initialPreviewUrl={imagePreview}
+                        />
+                    </div>
                     <EventForm mode="create" initialValues={defaultCreateEventValues} submitLabel="Create Event" loadingLabel="Creating Event..." successMessage={submitSuccess} errorMessage={submitError} onSubmit={handleSubmit} />
                 </section>
                 <section className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur-md sm:p-8">

--- a/frontend/components/ImageDropzone.tsx
+++ b/frontend/components/ImageDropzone.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import {
+    ACCEPTED_IMAGE_EXTENSIONS,
+    ACCEPTED_IMAGE_TYPES,
+    MAX_IMAGE_BYTES,
+    formatBytes,
+    validateImageFile,
+} from "@/lib/utils/image-upload";
+
+export type ImageDropzoneProps = {
+    /** Currently selected file, or `null` when nothing is staged. */
+    file: File | null;
+    /** Emitted with the validated file, or `null` when the user removes it. */
+    onFileChange: (file: File | null) => void;
+    /** 0-100 upload progress; only rendered while `status` is "uploading". */
+    progress?: number;
+    status?: "idle" | "uploading" | "success" | "error";
+    /** Server-side error surfaced by the parent (upload failures). */
+    uploadError?: string | null;
+    /** Existing remote image (edit flows) shown when no local file is staged. */
+    initialPreviewUrl?: string | null;
+    disabled?: boolean;
+    label?: string;
+};
+
+const ACCEPT_ATTR = [...ACCEPTED_IMAGE_TYPES, ...ACCEPTED_IMAGE_EXTENSIONS].join(",");
+
+/**
+ * Accessible drag-and-drop image picker.
+ *
+ * The zone is a real `<button>` so it is focusable and activates on Enter/Space
+ * for free; the `<input type="file">` stays visually hidden and is triggered
+ * programmatically. Object URLs for the preview are revoked whenever the file
+ * changes or the component unmounts so blobs are not leaked.
+ */
+export default function ImageDropzone({
+    file,
+    onFileChange,
+    progress = 0,
+    status = "idle",
+    uploadError = null,
+    initialPreviewUrl = null,
+    disabled = false,
+    label = "Event Image",
+}: ImageDropzoneProps) {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const [isDragging, setIsDragging] = useState(false);
+    const [validationError, setValidationError] = useState<string | null>(null);
+    const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+    const descriptionId = useId();
+    const errorId = useId();
+
+    // Build (and tear down) the object URL for the staged file.
+    useEffect(() => {
+        if (!file) {
+            setPreviewUrl(null);
+            return;
+        }
+        const url = URL.createObjectURL(file);
+        setPreviewUrl(url);
+        return () => URL.revokeObjectURL(url);
+    }, [file]);
+
+    const acceptFile = useCallback(
+        (candidate: File | undefined | null) => {
+            if (!candidate) return;
+            const result = validateImageFile(candidate);
+            if (!result.ok) {
+                setValidationError(result.error);
+                onFileChange(null);
+                return;
+            }
+            setValidationError(null);
+            onFileChange(candidate);
+        },
+        [onFileChange],
+    );
+
+    const openPicker = useCallback(() => {
+        if (disabled) return;
+        inputRef.current?.click();
+    }, [disabled]);
+
+    const handleDragOver = (event: React.DragEvent<HTMLElement>) => {
+        if (disabled) return;
+        event.preventDefault();
+        setIsDragging(true);
+    };
+
+    const handleDragLeave = (event: React.DragEvent<HTMLElement>) => {
+        event.preventDefault();
+        setIsDragging(false);
+    };
+
+    const handleDrop = (event: React.DragEvent<HTMLElement>) => {
+        event.preventDefault();
+        setIsDragging(false);
+        if (disabled) return;
+        acceptFile(event.dataTransfer?.files?.[0]);
+    };
+
+    const handleRemove = () => {
+        setValidationError(null);
+        if (inputRef.current) inputRef.current.value = "";
+        onFileChange(null);
+    };
+
+    const shownPreview = previewUrl ?? initialPreviewUrl;
+    const error = validationError ?? uploadError;
+    const isUploading = status === "uploading";
+
+    return (
+        <div>
+            <span className="mb-2 block text-sm text-gray-300">{label}</span>
+
+            <input
+                ref={inputRef}
+                type="file"
+                accept={ACCEPT_ATTR}
+                className="sr-only"
+                tabIndex={-1}
+                disabled={disabled}
+                aria-hidden="true"
+                onChange={(event) => {
+                    acceptFile(event.target.files?.[0]);
+                    // Reset so re-selecting the same file still fires `change`.
+                    event.target.value = "";
+                }}
+            />
+
+            {shownPreview ? (
+                <div className="relative overflow-hidden rounded-2xl border border-white/15 bg-black/30">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                        src={shownPreview}
+                        alt={file ? `Preview of ${file.name}` : "Current event image"}
+                        className="h-48 w-full object-cover"
+                    />
+                    <div className="flex items-center justify-between gap-3 px-4 py-3">
+                        <p className="truncate text-xs text-gray-300">
+                            {file ? `${file.name} — ${formatBytes(file.size)}` : "Current image"}
+                        </p>
+                        <div className="flex shrink-0 gap-2">
+                            <button
+                                type="button"
+                                onClick={openPicker}
+                                disabled={disabled || isUploading}
+                                className="rounded-lg border border-white/20 bg-white/10 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-white/15 disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                                Replace
+                            </button>
+                            <button
+                                type="button"
+                                onClick={handleRemove}
+                                disabled={disabled || isUploading}
+                                aria-label="Remove selected image"
+                                className="rounded-lg border border-red-400/30 bg-red-500/10 px-3 py-1.5 text-xs font-semibold text-red-200 transition hover:bg-red-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                                Remove
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            ) : (
+                <button
+                    type="button"
+                    onClick={openPicker}
+                    onDragOver={handleDragOver}
+                    onDragEnter={handleDragOver}
+                    onDragLeave={handleDragLeave}
+                    onDrop={handleDrop}
+                    disabled={disabled}
+                    aria-describedby={`${descriptionId}${error ? ` ${errorId}` : ""}`}
+                    data-dragging={isDragging || undefined}
+                    className={`flex w-full flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed px-4 py-10 text-center transition-colors outline-none focus-visible:border-purple-400 focus-visible:ring-2 focus-visible:ring-purple-400/60 disabled:cursor-not-allowed disabled:opacity-50 ${
+                        isDragging
+                            ? "border-purple-400 bg-purple-500/10"
+                            : "border-white/20 bg-white/5 hover:border-purple-400/60"
+                    } ${error ? "border-red-400/60" : ""}`}
+                >
+                    <svg className="h-8 w-8 text-purple-300" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24" aria-hidden="true">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 16.5V6m0 0L8.25 9.75M12 6l3.75 3.75M4.5 16.5v1.875A2.625 2.625 0 0 0 7.125 21h9.75a2.625 2.625 0 0 0 2.625-2.625V16.5" />
+                    </svg>
+                    <span className="text-sm font-semibold text-white">
+                        Drag &amp; drop an image, or click to browse
+                    </span>
+                    <span id={descriptionId} className="text-xs text-gray-400">
+                        JPEG or PNG, up to {formatBytes(MAX_IMAGE_BYTES)}
+                    </span>
+                </button>
+            )}
+
+            {isUploading ? (
+                <div className="mt-3">
+                    <div
+                        role="progressbar"
+                        aria-label="Image upload progress"
+                        aria-valuemin={0}
+                        aria-valuemax={100}
+                        aria-valuenow={progress}
+                        className="h-2 w-full overflow-hidden rounded-full bg-white/10"
+                    >
+                        <div
+                            className="h-full rounded-full bg-gradient-to-r from-purple-500 to-pink-500 transition-[width] duration-150"
+                            style={{ width: `${progress}%` }}
+                        />
+                    </div>
+                    <p className="mt-1 text-xs text-gray-400">Uploading image… {progress}%</p>
+                </div>
+            ) : null}
+
+            {status === "success" && !error ? (
+                <p className="mt-2 text-xs text-green-300">Image uploaded successfully.</p>
+            ) : null}
+
+            {error ? (
+                <p id={errorId} role="alert" className="mt-2 text-xs text-red-300">
+                    {error}
+                </p>
+            ) : null}
+        </div>
+    );
+}

--- a/frontend/lib/utils/image-upload.ts
+++ b/frontend/lib/utils/image-upload.ts
@@ -1,0 +1,160 @@
+/**
+ * Client-side helpers for the event cover-image upload flow.
+ *
+ * Validation runs before anything touches the network so an oversized or
+ * unsupported file never leaves the browser, and the upload itself goes through
+ * `XMLHttpRequest` rather than `fetch` because only XHR exposes byte-level
+ * progress events (`fetch` has no upload-progress equivalent yet).
+ */
+
+/** MIME types the backend accepts for event cover images. */
+export const ACCEPTED_IMAGE_TYPES = ["image/jpeg", "image/png"] as const;
+
+/** Extensions shown in the native file picker / used as a filename fallback. */
+export const ACCEPTED_IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png"] as const;
+
+/** Hard size ceiling enforced both here and by the backend (5 MB). */
+export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
+export type ImageValidationResult = { ok: true } | { ok: false; error: string };
+
+/** Human-readable byte count, e.g. `5 MB` or `1.4 MB`. */
+export function formatBytes(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+    const mb = bytes / (1024 * 1024);
+    return `${mb >= 10 ? Math.round(mb) : Number(mb.toFixed(1))} MB`;
+}
+
+/**
+ * Validate a user-selected file against the accepted type and size rules.
+ *
+ * Some browsers report an empty `type` for files dragged from odd sources, so
+ * we fall back to the filename extension before rejecting.
+ */
+export function validateImageFile(file: File): ImageValidationResult {
+    const type = file.type.toLowerCase();
+    const name = file.name.toLowerCase();
+
+    const typeAllowed = (ACCEPTED_IMAGE_TYPES as readonly string[]).includes(type);
+    const extensionAllowed = ACCEPTED_IMAGE_EXTENSIONS.some((ext) => name.endsWith(ext));
+
+    if (!typeAllowed && !(type === "" && extensionAllowed)) {
+        return {
+            ok: false,
+            error: "Unsupported file type. Upload a JPEG or PNG image.",
+        };
+    }
+
+    if (file.size > MAX_IMAGE_BYTES) {
+        return {
+            ok: false,
+            error: `Image is ${formatBytes(file.size)}. The maximum size is ${formatBytes(MAX_IMAGE_BYTES)}.`,
+        };
+    }
+
+    if (file.size === 0) {
+        return { ok: false, error: "The selected file is empty." };
+    }
+
+    return { ok: true };
+}
+
+export type UploadEventImageOptions = {
+    eventId: string;
+    file: File;
+    /** Called with an integer 0-100 as bytes are flushed to the server. */
+    onProgress?: (percent: number) => void;
+    /** Abort the in-flight upload (e.g. the user removed the image). */
+    signal?: AbortSignal;
+};
+
+export type UploadEventImageResult = {
+    imageUrl?: string;
+    [key: string]: unknown;
+};
+
+/** Error thrown when the upload endpoint responds with a non-2xx status. */
+export class ImageUploadError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+        super(message);
+        this.name = "ImageUploadError";
+        this.status = status;
+    }
+}
+
+function extractErrorMessage(raw: string, status: number): string {
+    if (!raw) return `Image upload failed (${status})`;
+    try {
+        const parsed = JSON.parse(raw) as { message?: string | string[] };
+        if (Array.isArray(parsed.message)) return parsed.message[0];
+        if (parsed.message) return parsed.message;
+    } catch {
+        // Non-JSON error body — fall through to the raw text.
+    }
+    return raw;
+}
+
+/**
+ * POST the image to `/events/:id/image` as multipart form data, reporting
+ * progress along the way. Resolves with the parsed JSON body on success.
+ */
+export function uploadEventImage({
+    eventId,
+    file,
+    onProgress,
+    signal,
+}: UploadEventImageOptions): Promise<UploadEventImageResult> {
+    return new Promise((resolve, reject) => {
+        if (signal?.aborted) {
+            reject(new DOMException("Upload aborted", "AbortError"));
+            return;
+        }
+
+        const form = new FormData();
+        form.append("file", file, file.name);
+
+        const xhr = new XMLHttpRequest();
+        xhr.open("POST", `/api/proxy/events/${encodeURIComponent(eventId)}/image`);
+        // Let the browser set `Content-Type` so the multipart boundary is correct.
+        xhr.responseType = "text";
+
+        const onAbort = () => xhr.abort();
+        signal?.addEventListener("abort", onAbort, { once: true });
+
+        const cleanup = () => signal?.removeEventListener("abort", onAbort);
+
+        xhr.upload.onprogress = (event) => {
+            if (!event.lengthComputable) return;
+            onProgress?.(Math.min(100, Math.round((event.loaded / event.total) * 100)));
+        };
+
+        xhr.onload = () => {
+            cleanup();
+            const body = typeof xhr.response === "string" ? xhr.response : "";
+            if (xhr.status < 200 || xhr.status >= 300) {
+                reject(new ImageUploadError(xhr.status, extractErrorMessage(body, xhr.status)));
+                return;
+            }
+            onProgress?.(100);
+            try {
+                resolve(body ? (JSON.parse(body) as UploadEventImageResult) : {});
+            } catch {
+                resolve({});
+            }
+        };
+
+        xhr.onerror = () => {
+            cleanup();
+            reject(new ImageUploadError(0, "Network error while uploading the image."));
+        };
+
+        xhr.onabort = () => {
+            cleanup();
+            reject(new DOMException("Upload aborted", "AbortError"));
+        };
+
+        xhr.send(form);
+    });
+}

--- a/frontend/tests/components/ImageDropzone.test.tsx
+++ b/frontend/tests/components/ImageDropzone.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import ImageDropzone from '@/components/ImageDropzone';
+import { MAX_IMAGE_BYTES } from '@/lib/utils/image-upload';
+
+function makeFile(name: string, type: string, size: number): File {
+  const file = new File(['x'], name, { type });
+  Object.defineProperty(file, 'size', { value: size });
+  return file;
+}
+
+function dropFiles(zone: HTMLElement, files: File[]) {
+  fireEvent.drop(zone, { dataTransfer: { files, types: ['Files'] } });
+}
+
+beforeEach(() => {
+  cleanup();
+  // jsdom does not implement object URLs.
+  vi.stubGlobal('URL', Object.assign(URL, {
+    createObjectURL: vi.fn(() => 'blob:preview'),
+    revokeObjectURL: vi.fn(),
+  }));
+});
+
+describe('ImageDropzone', () => {
+  it('renders a focusable drop zone with the accepted formats', () => {
+    render(<ImageDropzone file={null} onFileChange={vi.fn()} />);
+    const zone = screen.getByRole('button', { name: /drag & drop an image/i });
+    expect(zone).toBeTruthy();
+    expect(zone.tagName).toBe('BUTTON'); // focusable + Enter/Space activation
+    expect(screen.getByText(/JPEG or PNG, up to 5 MB/i)).toBeTruthy();
+  });
+
+  it('opens the file picker when activated by keyboard', () => {
+    const { container } = render(<ImageDropzone file={null} onFileChange={vi.fn()} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const clickSpy = vi.spyOn(input, 'click');
+
+    const zone = screen.getByRole('button', { name: /drag & drop an image/i });
+    zone.focus();
+    expect(document.activeElement).toBe(zone);
+    // A native button fires `click` for both Enter and Space.
+    fireEvent.click(zone);
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it('accepts a valid dropped file', () => {
+    const onFileChange = vi.fn();
+    render(<ImageDropzone file={null} onFileChange={onFileChange} />);
+    const file = makeFile('cover.png', 'image/png', 1024);
+    dropFiles(screen.getByRole('button', { name: /drag & drop an image/i }), [file]);
+    expect(onFileChange).toHaveBeenCalledWith(file);
+  });
+
+  it('shows an inline error and clears the selection for an invalid type', () => {
+    const onFileChange = vi.fn();
+    render(<ImageDropzone file={null} onFileChange={onFileChange} />);
+    dropFiles(
+      screen.getByRole('button', { name: /drag & drop an image/i }),
+      [makeFile('notes.pdf', 'application/pdf', 1024)],
+    );
+    expect(screen.getByRole('alert').textContent).toMatch(/JPEG or PNG/);
+    expect(onFileChange).toHaveBeenCalledWith(null);
+  });
+
+  it('shows an inline error for an oversized file', () => {
+    render(<ImageDropzone file={null} onFileChange={vi.fn()} />);
+    dropFiles(
+      screen.getByRole('button', { name: /drag & drop an image/i }),
+      [makeFile('huge.jpg', 'image/jpeg', MAX_IMAGE_BYTES + 1)],
+    );
+    expect(screen.getByRole('alert').textContent).toMatch(/maximum size is 5 MB/);
+  });
+
+  it('renders a preview with a remove button once a file is staged', () => {
+    const onFileChange = vi.fn();
+    const file = makeFile('cover.png', 'image/png', 2048);
+    render(<ImageDropzone file={file} onFileChange={onFileChange} />);
+
+    const preview = screen.getByAltText(/preview of cover.png/i) as HTMLImageElement;
+    expect(preview.src).toBe('blob:preview');
+    expect(screen.getByText(/cover.png — 2 KB/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /remove selected image/i }));
+    expect(onFileChange).toHaveBeenCalledWith(null);
+  });
+
+  it('renders an accessible progress bar while uploading', () => {
+    render(
+      <ImageDropzone
+        file={makeFile('cover.png', 'image/png', 2048)}
+        onFileChange={vi.fn()}
+        status="uploading"
+        progress={42}
+      />,
+    );
+    const bar = screen.getByRole('progressbar', { name: /image upload progress/i });
+    expect(bar.getAttribute('aria-valuenow')).toBe('42');
+    expect(screen.getByText(/42%/)).toBeTruthy();
+  });
+
+  it('surfaces an upload error from the parent', () => {
+    render(
+      <ImageDropzone
+        file={makeFile('cover.png', 'image/png', 2048)}
+        onFileChange={vi.fn()}
+        status="error"
+        uploadError="Server rejected the upload"
+      />,
+    );
+    expect(screen.getByRole('alert').textContent).toBe('Server rejected the upload');
+  });
+});

--- a/frontend/tests/lib/image-upload.test.ts
+++ b/frontend/tests/lib/image-upload.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  MAX_IMAGE_BYTES,
+  formatBytes,
+  validateImageFile,
+  uploadEventImage,
+  ImageUploadError,
+} from '@/lib/utils/image-upload';
+
+function makeFile(name: string, type: string, size: number): File {
+  const file = new File(['x'], name, { type });
+  Object.defineProperty(file, 'size', { value: size });
+  return file;
+}
+
+describe('validateImageFile', () => {
+  it('accepts a JPEG under the size limit', () => {
+    expect(validateImageFile(makeFile('cover.jpg', 'image/jpeg', 1024))).toEqual({ ok: true });
+  });
+
+  it('accepts a PNG under the size limit', () => {
+    expect(validateImageFile(makeFile('cover.png', 'image/png', 4_000_000))).toEqual({ ok: true });
+  });
+
+  it('rejects unsupported MIME types', () => {
+    const result = validateImageFile(makeFile('doc.pdf', 'application/pdf', 1024));
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toMatch(/JPEG or PNG/);
+  });
+
+  it('rejects a GIF even though it is an image', () => {
+    expect(validateImageFile(makeFile('anim.gif', 'image/gif', 1024)).ok).toBe(false);
+  });
+
+  it('falls back to the extension when the browser reports no MIME type', () => {
+    expect(validateImageFile(makeFile('cover.PNG', '', 1024))).toEqual({ ok: true });
+    expect(validateImageFile(makeFile('cover.bmp', '', 1024)).ok).toBe(false);
+  });
+
+  it('rejects files over 5 MB', () => {
+    const result = validateImageFile(makeFile('big.jpg', 'image/jpeg', MAX_IMAGE_BYTES + 1));
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toMatch(/maximum size is 5 MB/);
+  });
+
+  it('rejects empty files', () => {
+    expect(validateImageFile(makeFile('empty.jpg', 'image/jpeg', 0)).ok).toBe(false);
+  });
+});
+
+describe('formatBytes', () => {
+  it('formats bytes, kilobytes and megabytes', () => {
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(2048)).toBe('2 KB');
+    expect(formatBytes(MAX_IMAGE_BYTES)).toBe('5 MB');
+    expect(formatBytes(1_500_000)).toBe('1.4 MB');
+  });
+});
+
+// Minimal XMLHttpRequest double that lets each test drive the lifecycle.
+class MockXhr {
+  static instances: MockXhr[] = [];
+  upload = { onprogress: null as ((e: { lengthComputable: boolean; loaded: number; total: number }) => void) | null };
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onabort: (() => void) | null = null;
+  status = 200;
+  response = '';
+  responseType = '';
+  method = '';
+  url = '';
+  sentBody: FormData | null = null;
+
+  constructor() {
+    MockXhr.instances.push(this);
+  }
+
+  open(method: string, url: string) {
+    this.method = method;
+    this.url = url;
+  }
+
+  send(body: FormData) {
+    this.sentBody = body;
+  }
+
+  abort() {
+    this.onabort?.();
+  }
+}
+
+describe('uploadEventImage', () => {
+  beforeEach(() => {
+    MockXhr.instances = [];
+    vi.stubGlobal('XMLHttpRequest', MockXhr);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts multipart form data to the event image endpoint', async () => {
+    const file = makeFile('cover.png', 'image/png', 1024);
+    const promise = uploadEventImage({ eventId: 'evt-1', file });
+
+    const xhr = MockXhr.instances[0];
+    expect(xhr.method).toBe('POST');
+    expect(xhr.url).toBe('/api/proxy/events/evt-1/image');
+    expect(xhr.sentBody?.get('file')).toBeInstanceOf(File);
+
+    xhr.response = JSON.stringify({ imageUrl: '/uploads/cover.png' });
+    xhr.onload?.();
+
+    await expect(promise).resolves.toEqual({ imageUrl: '/uploads/cover.png' });
+  });
+
+  it('reports progress as bytes are flushed', async () => {
+    const onProgress = vi.fn();
+    const promise = uploadEventImage({
+      eventId: 'evt-1',
+      file: makeFile('cover.png', 'image/png', 1024),
+      onProgress,
+    });
+
+    const xhr = MockXhr.instances[0];
+    xhr.upload.onprogress?.({ lengthComputable: true, loaded: 256, total: 1024 });
+    xhr.upload.onprogress?.({ lengthComputable: true, loaded: 768, total: 1024 });
+    expect(onProgress).toHaveBeenNthCalledWith(1, 25);
+    expect(onProgress).toHaveBeenNthCalledWith(2, 75);
+
+    xhr.response = '{}';
+    xhr.onload?.();
+    await promise;
+    expect(onProgress).toHaveBeenLastCalledWith(100);
+  });
+
+  it('rejects with the server message on a non-2xx response', async () => {
+    const promise = uploadEventImage({
+      eventId: 'evt-1',
+      file: makeFile('cover.png', 'image/png', 1024),
+    });
+
+    const xhr = MockXhr.instances[0];
+    xhr.status = 413;
+    xhr.response = JSON.stringify({ message: 'File too large' });
+    xhr.onload?.();
+
+    await expect(promise).rejects.toMatchObject({ status: 413, message: 'File too large' });
+    await expect(promise).rejects.toBeInstanceOf(ImageUploadError);
+  });
+
+  it('rejects on a network error', async () => {
+    const promise = uploadEventImage({
+      eventId: 'evt-1',
+      file: makeFile('cover.png', 'image/png', 1024),
+    });
+    MockXhr.instances[0].onerror?.();
+    await expect(promise).rejects.toMatchObject({ status: 0 });
+  });
+
+  it('aborts when the supplied signal fires', async () => {
+    const controller = new AbortController();
+    const promise = uploadEventImage({
+      eventId: 'evt-1',
+      file: makeFile('cover.png', 'image/png', 1024),
+      signal: controller.signal,
+    });
+    controller.abort();
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('encodes the event id in the URL', () => {
+    void uploadEventImage({
+      eventId: 'evt/1 2',
+      file: makeFile('cover.png', 'image/png', 1024),
+    }).catch(() => undefined);
+    expect(MockXhr.instances[0].url).toBe('/api/proxy/events/evt%2F1%202/image');
+  });
+});


### PR DESCRIPTION
Closes #508

## Summary

The create-event form had no way to attach a cover image. This PR adds the full client-side UX for it: a reusable drag-and-drop zone, client-side validation, an instant preview, a real upload-progress bar, and the two-step submit flow the `POST /events/:id/image` endpoint requires.

## What changed

### `components/ImageDropzone.tsx` (new)

A self-contained, controlled dropzone component.

- **Drag-and-drop and click-to-browse.** The drop zone is a real `<button>` rather than a styled `<div>`, so it is focusable and activates on both **Enter** and **Space** natively — no synthetic key handling to keep in sync with browser behaviour. The `<input type="file">` is visually hidden (`sr-only`, `aria-hidden`, `tabIndex={-1}`) and triggered programmatically, so it never becomes a second tab stop.
- **Instant preview.** As soon as a file is accepted, an object URL is created and rendered. The URL is revoked in the effect cleanup, so switching files or unmounting does not leak blobs.
- **Remove / replace.** The preview carries a `Remove` button (`aria-label="Remove selected image"`) and a `Replace` button; both are disabled while an upload is in flight. Removing also clears the hidden input's value so re-picking the *same* file still fires `change`.
- **Progress.** While `status === \"uploading\"` it renders a `role=\"progressbar\"` with `aria-valuenow`/`min`/`max` plus a readable percentage.
- **Errors.** Validation errors render in a `role=\"alert\"` and are wired to the zone via `aria-describedby`.
- **Edit flows.** `initialPreviewUrl` lets the same component show an already-uploaded remote image, so it can be reused on the organizer edit page later.

### `lib/utils/image-upload.ts` (new)

- `validateImageFile(file)` enforces **JPEG/PNG** and the **5 MB** ceiling, and rejects empty files. Some browsers report an empty `type` for files dragged from unusual sources, so it falls back to the filename extension before rejecting rather than showing a spurious error.
- `uploadEventImage({ eventId, file, onProgress, signal })` POSTs multipart form data to `/events/:id/image`. It uses `XMLHttpRequest` rather than `fetch` deliberately: `fetch` still has no upload-progress event, so it cannot drive a real progress bar. Supports `AbortSignal`, maps non-2xx bodies to a typed `ImageUploadError` (unwrapping Nest's `message` string/array shape), and resolves with the parsed JSON body.
- Exported constants (`ACCEPTED_IMAGE_TYPES`, `MAX_IMAGE_BYTES`) keep the picker's `accept` attribute, the validation rule, and the copy shown to the user from drifting apart.

### `app/create/page.tsx`

Stages the file locally while the form is being filled in, then uploads **after** the event is created — the endpoint is keyed on the event id, so it cannot run earlier. If the upload fails, the event-created success message stays and the error explicitly says the event *was* created and the image can be added from the edit page, so a failed upload is never misread as a failed submit.

### `app/api/proxy/[...path]/route.ts`

The proxy read every outgoing body with `await request.text()`. That is correct for JSON but corrupts binary multipart payloads and is the reason an upload would have failed even with a working backend endpoint. Non-JSON content types are now forwarded as raw bytes via `arrayBuffer()`; JSON is unchanged. The incoming `Content-Type` (including the multipart boundary) was already being passed through.

## Acceptance criteria

- [x] Drag-and-drop and click-to-browse both work
- [x] Invalid file type shows error without submitting
- [x] Upload progress updates in real time
- [x] Preview shows immediately after selection (before upload)
- [x] Removing the image is possible from the preview
- [x] Drop zone is keyboard-accessible (focusable, Enter/Space)

## Testing

22 new tests, all passing:

- `tests/lib/image-upload.test.ts` — accepts JPEG/PNG, rejects PDF/GIF/oversized/empty files, extension fallback when MIME is blank, byte formatting, multipart body shape, progress reporting, 4xx error mapping, network error, abort, event-id URL encoding.
- `tests/components/ImageDropzone.test.tsx` — drop zone is a focusable button that opens the picker on activation, accepts valid drops, shows inline alerts for invalid type and oversized files, renders preview + remove, renders the accessible progress bar, surfaces parent upload errors.

\`\`\`
npx vitest run tests/lib/image-upload.test.ts tests/components/ImageDropzone.test.tsx
Test Files  2 passed (2)
     Tests  22 passed (22)
\`\`\`

`npx tsc --noEmit` reports no errors in any file touched by this PR. (The repo has pre-existing type errors in `lib/stellar*` and `tests/a11y`, and the root `package.json` is currently invalid JSON — a missing comma on line 9 — which makes the vitest runner exit non-zero even when every test passes. Both are untouched here to keep this PR focused.)

## Notes for reviewers

- This is the frontend half. It expects `POST /events/:id/image` to accept a multipart field named `file` and to return `{ imageUrl }`; the component degrades gracefully if the response body is empty.
- No backend or database changes, so no migration is needed.

